### PR TITLE
Add shebang

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Copy ``config.json.example`` to ``config.json`` and adjust the settings, most no
 
 Now you just need to run
 ```
-python3 syncMyMoodle.py
+./syncMyMoodle.py
 ```
 
 And your courses will be synced into the ``basedir`` you specified (default is the current directory). Your cookies will be stored in a session file.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # syncMyMoodle
-Synchronization client for RWTH Moodle  
+Synchronization client for RWTH Moodle
 Downloads all lecture material including embedded YouTube and OpenCast videos, but not E-Tests or forum threads.
 
 # How to use
@@ -7,8 +7,8 @@ Intially you need to install the requirements (bs4, requests, tqdm and youtube-d
 ```
 pip3 install -r requirements.txt
 ```
-  
-Copy ``config.json.example`` to ``config.json`` and adjust the settings, most notably the ``user`` and ``password`` (the credentials you use in the RWTH SSO).  
+
+Copy ``config.json.example`` to ``config.json`` and adjust the settings, most notably the ``user`` and ``password`` (the credentials you use in the RWTH SSO).
 
 Now you just need to run
 ```

--- a/syncMyMoodle.py
+++ b/syncMyMoodle.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import requests, pickle
 from bs4 import BeautifulSoup as bs
 import os


### PR DESCRIPTION
The addition of a shebang line allows for easy execution by typing `./syncMyMoodle.py` instead of `python3 syncMyMoodle.py`.