### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,5 @@ You need to have the python package ``secretstorage`` installed:
 ```bash
 pip3 install secretstorage
 ```
-After you removed your password from the config file (delete the whole line in config.json), you need to specify your password once, either using ``--password``, or you will be promted.
+After you removed your password from the config file (delete the whole line in config.json), you will be prompted for your password when syncing for the first time.
 In subsequent runs, the credentials will be obtained automatically.


### PR DESCRIPTION
the secret service documentation did not match the code.

https://github.com/Romern/syncMyMoodle/blob/93528b25676a4ed49cefc756975142702c9e3447/syncMyMoodle.py#L608
means that subsequently
https://github.com/Romern/syncMyMoodle/blob/93528b25676a4ed49cefc756975142702c9e3447/syncMyMoodle.py#L633
is always hit when supplying a `--password` on cli and secretservice is enabled.

Arguably, you always want to use secret service if possible in order to avoid storing your password in plain text, which is likely to happen when using the cli arg (history). Perhaps you should go so far as recommending it if possible. It should even work on windows and headless linux (eg wsl), with slight tweaking.