### PR TITLE
shorter filename declashification using hashing

### DIFF
--- a/syncMyMoodle.py
+++ b/syncMyMoodle.py
@@ -7,6 +7,7 @@ import re
 from contextlib import closing
 import json
 import base64
+import hashlib
 import youtube_dl
 import traceback
 import http.client
@@ -87,9 +88,11 @@ class Node:
 			if len(siblings) > 0:
 				# if a filename is still duplicate in its directory, we rename it by appending its id (urlsafe base64 so it also works for urls).
 				base, ext = os.path.splitext(child.name)
+				# child.name = base + "_" + base64.urlsafe_b64encode(hashlib.md5(str(child.id).encode("utf-8")).hexdigest().encode("utf-8")).decode()[:10] + ext
 				child.name = base + "_" + base64.urlsafe_b64encode(str(child.id).encode("utf-8")).decode() + ext
 				for s in siblings:
 					base, ext = os.path.splitext(s.name)
+					# s.name = base + "_" + base64.urlsafe_b64encode(hashlib.md5(str(s.id).encode("utf-8")).hexdigest().encode("utf-8")).decode()[:10] + ext
 					s.name = base + "_" + base64.urlsafe_b64encode(str(s.id).encode("utf-8")).decode() + ext
 					self.children.remove(s)
 				unclashed_children.extend(siblings)


### PR DESCRIPTION
depends on #58

---

during development I ran into

> `OSError: [Errno 36] File name too long`

since the complete base64 encoded URL can be quite long and the NTFS
limits are quite conservative. This hashes the URL, so the ability
to decode it is lost. base64 is still used to encode the hexdigest
before trimming it to 10 chars since base64 offers more bits per
character than the hex digest.

The resoning for hashing here is that (trivially) trimming the URL before or after
base64 isn't sufficient since name clashes will likely appear in the
first (around the domain) and last (filename) parts. However the middle
part is not necessarily well defined/formatted, thus it is easiest to
hash.

Theoretically it would be possible to compare the URLs of clashing files
and extract the differing parts to use only them in a non- or less lossy manner.