### PR TITLE
Fix crash when no config file secified

### DIFF
--- a/syncMyMoodle.py
+++ b/syncMyMoodle.py
@@ -706,6 +706,8 @@ if __name__ == '__main__':
 	parser.add_argument('--verbose', action='store_true', help="Verbose output for debugging.")
 	args = parser.parse_args()
 
+	config = {}
+
 	if os.path.exists(args.config):
 		config = json.load(open(args.config))
 


### PR DESCRIPTION
If no config file was specified, the config variable doesn't exist.
This commits defined a default empty dictionary when no config file is
available.