### PR TITLE
assert youtube link format before youtube_dl

### DIFF
--- a/syncMyMoodle.py
+++ b/syncMyMoodle.py
@@ -660,9 +660,9 @@ class SyncMyMoodle:
 		# Youtube videos
 		if self.config.get("used_modules",{}).get("url",{}).get("youtube",{}):
 			if single and "youtube.com" in text or "youtu.be" in text:
-				youtube_links = [text]
+				youtube_links = [u[0] for u in re.findall("(https?://(www\.)?(youtube\.com/(watch\?[a-zA-Z0-9=\&]*v=|embed/)|youtu.be/).{11})", text)]
 			else:
-				youtube_links = re.findall("https://www.youtube.com/embed/.{11}", text)
+				youtube_links = re.findall("https://www.youtube.com/embed/[a-zA-Z0-9]{11}", text)
 			for l in youtube_links:
 				parent_node.add_child(f"Youtube: {module_title or l}", l, "Youtube", url=l)
 


### PR DESCRIPTION
Fixes #47

I think this should work... I tested:

>
```
[u[0] for u in
re.findall("(https?://(www\.)?(youtube\.com/(watch\?[a-zA-Z0-9=\&]*v=|embed/)|youtu.be/)[a-zA-Z0-9]{11})",
'bit of trash text youtube.com/feed/subscriptions
https://www.youtube.com/watch?v=ch69W2l1Mak <iframe width="1869"
height="763" src="https://www.youtube.com/embed/ch69W2l1Mak"
title="YouTube video player" frameborder="0" allow="accelerometer;
autoplay; clipboard-write; encrypted-media; gyroscope;
picture-in-picture" allowfullscreen></iframe>
https://youtu.be/ch69W2l1Mak?t=10 https://www.youtube.com/watch?v=ch69W
http://youtube.com/watch?v=ch69W2l1Mak')]

['https://www.youtube.com/watch?v=ch69W2l1Mak', 'https://www.youtube.com/embed/ch69W2l1Mak', 'https://youtu.be/ch69W2l1Mak', 'http://youtube.com/watch?v=ch69W2l1Mak']
```

- trash text is ignored
- subscriptions etc ignored
- proper https desktop link matches
- random embed html ignored
- but proper embed link extracted
- youtu.be extracted, ignoring additional arguments
- broken link (too short ID) ignored
- match even without https and www

I also updated the other embed regex to improve the matching accuracy regarding broken IDs.

Feel free to edit if you disagree with any of these cases. E.g. the if else could be removed altogether, but I suppose using the embed only is more accurate. Or perhaps only the second if only embeds are needed?