### PR TITLE
Make package ready for PyPi publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,142 @@
-__pycache__
 config.json
 downloaded_modules.json
 session
-.idea
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
 .venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ to store your password securely if your system supports it - if you're on Linux,
 
 ## Configuration
 
-Copy `config.json.example` to `config.json` and adjust the settings:
+Copy `config.json.example` or the following text (minus the comments) to `config.json` in your current directory
+or alternatively to `~/.config/syncmymoodle/config.json` for configuring `syncmymoodle` user-wide.
+Afterwards you can adjust the settings:
 
 ```js
 {

--- a/README.md
+++ b/README.md
@@ -11,46 +11,45 @@ Downloads the following materials:
 * Quizzes (**Disabled by default**)
 * Pages and Labels: Embedded Opencast and Youtube Videos
 
-## Setup
+## Installation
 
 This software requires **Python version >= 3.6**.
 
-First obtain the source using `git` or by downloading the zip.
-Use the following exemplary commands from the `syncMyMoodle` directory.
+### Installation using `pip` (recommended)
 
-syncMyMoodle requires further dependencies which can be installed using `pip` or your distro's package manager (`apt`, `dnf`, `pacman`, etc.).
-The recommended method is to first create and activate a virtual environment.
-If you are unfamiliar, you can use the following commands
-([more info](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment)):
+The simples way to setup this app is to install it using pip.
+To isolate dependencies it is advised to use a virtual environment.
+For more information take a look at
+[the guide from the Python website](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment):
 
 ```bash
 python3 -m venv .venv
-source moodle-venv/bin/activate # bash/zsh
+source .venv/bin/activate  # bash/zsh, for other shells view the docs
+pip3 install syncmymoodle
 ```
 
-<details>
-    <summary>commands for shells other than bash</summary>
+### Manual installation
 
-(taken from [here](https://docs.python.org/3/library/venv.html))
+If you like living on the bleeding edge you can also clone or download the source directly
+and setup everything manually.
+syncMyMoodle requires some dependencies which can be installed using `pip`
+or your distro's package manager (`apt`, `dnf`, `pacman`, etc.).
 
-| Platform | Shell           | Command to activate virtual environment |
-| -------- | --------------- | --------------------------------------- |
-| POSIX    | bash/zsh        | `source <venv>/bin/activate`            |
-|          | fish            | `source <venv>/bin/activate.fish`       |
-|          | csh/tcsh        | `source <venv>/bin/activate.csh`        |
-|          | PowerShell Core | `<venv>/bin/Activate.ps1`               |
-| Windows  | cmd.exe         | `<venv>\Scripts\activate.bat`           |
-|          | PowerShell      | `<venv>\Scripts\Activate.ps1`           |
-
-</details>
-
-Then install the requirements using pip:
+To install the requirements using pip execute the following command from the repository root.
 
 ```bash
-pip3 install -r requirements.txt
+# It is best to run this in a virtual environment.
+# For more information see the section above.
+pip3 install .
 ```
 
-It is recommended to also install and use the optional [FreeDesktop.org Secret Service integration](#freedesktoporg-secret-service-integration) to store your password securely if your system supports it - if you're on Linux, it probably does!
+### Optional steps
+
+It is recommended to also install and use the optional
+[FreeDesktop.org Secret Service integration](#freedesktoporg-secret-service-integration)
+to store your password securely if your system supports it - if you're on Linux, it probably does!
+
+## Configuration
 
 Copy `config.json.example` to `config.json` and adjust the settings:
 
@@ -85,12 +84,12 @@ Your cookies will be stored in a session file.
 
 ## CLI usage
 
-Run
+Run:
 
 ```bash
-source moodle-venv/bin/activate # if you installed using virtual environment
-./syncMyMoodle.py
-deactivate # leave virtual environment
+source .venv/bin/activate  # if you installed using virtual environment
+python3 -m syncmymoodle
+deactivate  # leave virtual environment
 ```
 
 You can override the fields in the config file by using command line arguments:
@@ -122,12 +121,16 @@ optional arguments:
 
 ## FreeDesktop.org Secret Service integration
 
-If you have a FreeDesktop.org Secret Service integration compatible keyring installed, you can save your RWTH SSO credentials in it.
-You need to have the python package `secretstorage` installed:
+If you have a FreeDesktop.org Secret Service integration compatible keyring installed,
+you can save your RWTH SSO credentials in it.
+You need to install syncMyMoodle with the `keyring` extra installed:
 
 ```bash
-pip3 install secretstorage
+pip3 install syncmymoodle[keyring]  # when installing from PyPi
+# or
+pip3 install .[keyring]  # when installing manually
 ```
 
-After you removed your password from the config file (delete the whole line in config.json), you will be prompted for your password when syncing for the first time.
+After you removed your password from the config file (delete the whole line in config.json),
+you will be prompted for your password when syncing for the first time.
 In subsequent runs, the credentials will be obtained automatically.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=46.4.0",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-requests
-beautifulsoup4
-youtube_dl
-tqdm
-pdfkit

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,30 @@
+[metadata]
+name = syncMyMoodle
+version = 0.0.2
+author = Nils Kattenbeck
+author_email = nilskemail+pypi@gmail.com
+description = Synchronization client for RWTH Moodle
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/Romern/syncMyMoodle
+project_urls =
+    Bug Tracker = https://github.com/Romern/syncMyMoodle/issues
+classifiers =
+    Programming Language :: Python :: 3
+    License :: OSI Approved :: GNU General Public License v3 (GPLv3)
+    Operating System :: OS Independent
+    Development Status :: 5 - Production/Stable
+
+[options]
+packages = find:
+python_requires = >=3.6
+install_requires =
+    requests>=2.0.0
+    beautifulsoup4>=4.0.0
+    youtube-dl>=2021.6.0
+    pdfkit>=0.6.0
+    tqdm>=4.0.0
+
+[options.extras_require]
+keyring =
+    secretstorage>=3.1.0

--- a/syncmymoodle/__main__.py
+++ b/syncmymoodle/__main__.py
@@ -693,8 +693,7 @@ if __name__ == '__main__':
 		has_secretstorage = False
 
 	parser = ArgumentParser(
-		# workaround for invoking as `python3 -m ...`
-		prog=None if not globals().get('__spec__') else 'python3 -m {}'.format(__spec__.name.partition('.')[0]),
+		prog="python3 -m syncmymoodle",
 		description="Synchronization client for RWTH Moodle. All optional arguments override those in config.json."
 	)
 	if has_secretstorage:
@@ -712,25 +711,26 @@ if __name__ == '__main__':
 	parser.add_argument('--verbose', action='store_true', help="Verbose output for debugging.")
 	args = parser.parse_args()
 
-	config = {}
-
-	global_config = Path(os.environ.get(
-		"XDG_CONFIG_HOME",
-		Path("~/.config").expanduser()
-	)) / "syncmymoodle" / "config.json"
-	if global_config.is_file():
-		with global_config.open() as f:
-			config.update(json.load(f))
-
-	local_config = Path("config.json")
-	if local_config.is_file():
-		with local_config.open() as f:
-			config.update(json.load(f))
 
 	if args.config:
 		overwrite_config = Path(args.config)
 		if overwrite_config.is_file():
 			with overwrite_config.open() as f:
+				config = json.load(f)
+	else:
+		config = {}
+
+		global_config = Path(os.environ.get(
+			"XDG_CONFIG_HOME",
+			Path("~/.config").expanduser()
+		)) / "syncmymoodle" / "config.json"
+		if global_config.is_file():
+			with global_config.open() as f:
+				config.update(json.load(f))
+
+		local_config = Path("config.json")
+		if local_config.is_file():
+			with local_config.open() as f:
 				config.update(json.load(f))
 
 	config["user"] = args.user or config.get("user")


### PR DESCRIPTION
This PR contains multiple changes:

* Updated .gitignore to cover e.g. dist directory and egg files
* Updated README.md to contain the new setup instructions
* The required files for publishing (`pyproject.toml`, `setup.cfg`)
* The `requirements.txt` file was removed in favour of `setup.cfg`
* The script was moved into the `syncmymoodle` package as the main entrypoint
* Respect xdg-specification for config files (now tried in the order `${XDG_CONFIG_HOME:-~/.config}/syncmymoodle/config.json` > `$PWD/config.json` > `--config`). I thought about dropping the implicit PWD one, what do you think?

TODO:

* [x] Swap author information in `setup.cfg`? I just added myself as I did not want to upload on your behalf @Romern. Are you fine with that? Otherwise we can also swap that and e.g. add myself as a maintainer.
* [x] Document xdg-specification compliance for the config in the docs. Currently it still instructs to use the current working directory.
* [ ] Potentially set up a Github Action for publishing in the long run
* [ ] Add @Romern as a owner/maintainer on PyPi if he wants to