### PR TITLE
Add file name exclusion using UNIX filename pattern matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Afterwards you can adjust the settings:
         "folder": true, //Folders
     },
     "exclude_filetypes": [] //Exclude specific filetypes, e.g. ["mp4","mkv"] do disable downloading most videos
+    "exlcude_files": [] // Exclude specific files using UNIX filename pattern matching (e.g. "Lecture{video,zoom}*.{mp4,mkv}")
 }
 ```
 

--- a/config.json.example
+++ b/config.json.example
@@ -19,5 +19,6 @@
         },
         "folder": true
     },
-    "exclude_filetypes": []
+    "exclude_filetypes": [],
+    "exclude_files": []
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,6 @@ install_requires =
     youtube-dl>=2021.6.0
     pdfkit>=0.6.0
     tqdm>=4.0.0
-    braceexpand>=0.1.7
 
 [options.extras_require]
 keyring =

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires =
     youtube-dl>=2021.6.0
     pdfkit>=0.6.0
     tqdm>=4.0.0
+    braceexpand>=0.1.7
 
 [options.extras_require]
 keyring =

--- a/syncmymoodle/__main__.py
+++ b/syncmymoodle/__main__.py
@@ -11,15 +11,12 @@ import pickle
 import re
 import shutil
 import urllib.parse
-from fnmatch import fnmatchcase
-import functools
-import operator
 from argparse import ArgumentParser
 from contextlib import closing
+from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import List
 
-from braceexpand import braceexpand
 import pdfkit
 import requests
 import youtube_dl
@@ -197,12 +194,12 @@ class SyncMyMoodle:
             return
         soup = bs(resp.text, features="html.parser")
         if soup.find("input", {"name": "RelayState"}) is None:
-            csrf_token = soup.find("input",{"name": "csrf_token"})["value"]
+            csrf_token = soup.find("input", {"name": "csrf_token"})["value"]
             data = {
                 "j_username": self.config["user"],
                 "j_password": self.config["password"],
                 "_eventId_proceed": "",
-                'csrf_token': csrf_token
+                "csrf_token": csrf_token,
             }
             resp2 = self.session.post(resp.url, data=data)
             soup = bs(resp2.text, features="html.parser")
@@ -771,7 +768,10 @@ class SyncMyMoodle:
         ] in self.config.get("exclude_filetypes", []):
             return True
 
-        if any(map(lambda pattern: fnmatchcase(node.name, pattern), self.config.get("exclude_files"))):
+        if any(
+            fnmatchcase(node.name, pattern)
+            for pattern in self.config.get("exclude_files")
+        ):
             return True
 
         tmp_downloadpath = downloadpath.with_suffix(downloadpath.suffix + ".temp")
@@ -1131,8 +1131,7 @@ def main():
         else config.get("exclude_filetypes", [])
     )
 
-    exclude_files = config.get("exclude_files", [])
-    config["exclude_files"] = functools.reduce(operator.iconcat, map(braceexpand, exclude_files), [])
+    config["exclude_files"] = config.get("exclude_files", [])
 
     logging.basicConfig(level=args.loglevel)
 

--- a/syncmymoodle/__main__.py
+++ b/syncmymoodle/__main__.py
@@ -11,11 +11,15 @@ import pickle
 import re
 import shutil
 import urllib.parse
+from fnmatch import fnmatchcase
+import functools
+import operator
 from argparse import ArgumentParser
 from contextlib import closing
 from pathlib import Path
 from typing import List
 
+from braceexpand import braceexpand
 import pdfkit
 import requests
 import youtube_dl
@@ -767,6 +771,9 @@ class SyncMyMoodle:
         ] in self.config.get("exclude_filetypes", []):
             return True
 
+        if any(map(lambda pattern: fnmatchcase(node.name, pattern), self.config.get("exclude_files"))):
+            return True
+
         tmp_downloadpath = downloadpath.with_suffix(downloadpath.suffix + ".temp")
         if tmp_downloadpath.exists():
             resume_size = tmp_downloadpath.stat().st_size
@@ -1123,6 +1130,9 @@ def main():
         if args.excludefiletypes
         else config.get("exclude_filetypes", [])
     )
+
+    exclude_files = config.get("exclude_files", [])
+    config["exclude_files"] = functools.reduce(operator.iconcat, map(braceexpand, exclude_files), [])
 
     logging.basicConfig(level=args.loglevel)
 


### PR DESCRIPTION
Exclude files using a combination of fnmatch and braceexpand in order to give the full BASH filepattern matching experience.

For example it is now possible with the `exclude_files` parameter in the `config.json` to exclude all files like the following by simply using `Lecture Videos_{zoom,video}*.mp4`. Whcih makes sense in my case for example where lecture videos are uploaded with a semantic name in an extra folder called `Video Download` 
```
Lecture Videos_zoom_0_NWFjN2RlMD.mp4
Lecture Videos_video1680865997.mp4
Lecture Videos_video1119115261.mp4
Lecture Videos_video1230373776.mp4
Lecture Videos_video1599374246.mp4
```

In other words it is a more powerful version of the existing `exclude_filetypes` config parameter.

Current limitations are:
- [ ] it's not possible to supply `exclude_files` using the command line arguments
- [ ] You can only give a pattern for the filename, not the full path (i.e. exclusions of whole subfolders)
- [ ] added a new dependency `bracketexpand` in order to give the BASH file pattern matching experience 
  - UNIX file patterns alone don't define the `{a,b}` expansion
- [ ] `exclude_filetypes` still exists for compatibility reasons, even though it could be completely replaced by `exclude_files`
  - `exclude_filetypes` could be merged into `exclude_files` during the config loading phase, removing https://github.com/Romern/syncMyMoodle/blob/e928bab71223b4ec176fd0c3c9f0574056be23cd/syncmymoodle/__main__.py#L765-L768 