### PR TITLE
Use yt_dlp instead of youtube_dl to bypass speed limit for now.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ warn_unreachable = true
 [[tool.mypy.overrides]]
 module = [
     "bs4",
-    "youtube_dl",
+    "yt_dlp",
     "tqdm",
     "pdfkit",
     "secretstorage",

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ python_requires = >=3.6
 install_requires =
     requests>=2.0.0
     beautifulsoup4>=4.0.0
-    youtube-dl>=2021.6.0
+    yt-dlp>=2021.12.27
     pdfkit>=0.6.0
     tqdm>=4.0.0
 

--- a/syncmymoodle/__main__.py
+++ b/syncmymoodle/__main__.py
@@ -18,7 +18,7 @@ from typing import List
 
 import pdfkit
 import requests
-import youtube_dl
+import yt_dlp
 from bs4 import BeautifulSoup as bs
 from tqdm import tqdm
 
@@ -716,7 +716,7 @@ class SyncMyMoodle:
                     except Exception:
                         logger.exception(f"Failed to download the module {cur_node}")
                         logger.error(
-                            "This could be caused by an out of date youtube-dl version. Try upgrading youtube-dl through pip or your package manager."
+                            "This could be caused by an out of date yt-dlp version. Try upgrading yt-dlp through pip or your package manager."
                         )
                 elif cur_node.type == "Opencast":
                     try:
@@ -858,7 +858,7 @@ class SyncMyMoodle:
         return self.download_file(node)
 
     def scanAndDownloadYouTube(self, node):
-        """Download Youtube-Videos using youtube_dl"""
+        """Download Youtube-Videos using yt_dlp"""
         path = self.get_sanitized_node_path(node.parent)
         link = node.url
         if path.exists():
@@ -871,7 +871,7 @@ class SyncMyMoodle:
             "retries": 15,
         }
         path.mkdir(parents=True, exist_ok=True)
-        with youtube_dl.YoutubeDL(ydl_opts) as ydl:
+        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             ydl.download([link])
         return True
 


### PR DESCRIPTION
Just noticed youtube videos downloading is really slow for me with youtube-dl (around 70 kb/s), switching to yt-dlp works better on my side at the moment. 