### PR TITLE
Fix Session token retrieval

### DIFF
--- a/syncmymoodle/__main__.py
+++ b/syncmymoodle/__main__.py
@@ -179,13 +179,16 @@ class SyncMyMoodle:
 
     def login(self):
         def get_session_key(soup):
-            try:
-                session_key = soup.find("input", {"name": "sesskey"})["value"]
-            except TypeError:
-                logger.critical("Can't retrieve session key")
-                logger.info(soup)
-                sys.exit(1)
-            return session_key
+            script = soup.find("script", string=lambda text: text and 'sesskey' in text)
+            js_text = script.text
+            match = re.search(r'"sesskey":"(.*?)"', js_text)
+            if match:
+                return match.group(1)
+            else:
+                logger.critical("Can't retrieve session key from JavaScript config")
+                exit(1)
+
+
 
         self.session = requests.Session()
         cookie_file = Path(self.config.get("cookie_file", "./session"))


### PR DESCRIPTION
It seems like RWTH Moodle changed how data is stored on the front end, resulting in the following error:

```
python -m syncmymoodle               
Logging in...
CRITICAL:__main__:Can't retrieve session key
```

The sessionkey is now stored in a javascript object, and beautiful soup can't find it:
`M.cfg = {"wwwroot":"https:\/\/moodle.rwth-aachen.de","homeurl":{},"sesskey":"*******","sessiontimeout":"50400","sessiontimeoutwarning":"1200","themerev":"1709792389","slasharguments":1,"theme":"boost_union_rwth","iconsystemmodule":"core\/icon_system_fontawesome","jsrev":"1709792177","admin":"admin","svgicons":true,"usertimezone":"Europa\/Berlin","language":"de","courseId":1,"courseContextId":2,"contextid":1,"contextInstanceId":0,"langrev":1709953813,"templaterev":"1709792177"};var yui1ConfigFn = function(me) {if(/-skin|reset|fonts|grids|base/.test(me.name)){me.type='css';me.path=me.path.replace(/\.js/,'.css');me.path=me.path.replace(/\/yui2-skin/,'/assets/skins/sam/yui2-skin')}};`

I've updated it to select the script and then regex the session key from it, fixing the error. Not sure if this is the best way to do it, alternatives welcome.

