### PR TITLE
Fix URL check in SyncMyMoodle login

### DIFF
--- a/syncmymoodle/__main__.py
+++ b/syncmymoodle/__main__.py
@@ -197,7 +197,7 @@ class SyncMyMoodle:
         resp = self.session.get(
             "https://moodle.rwth-aachen.de/auth/shibboleth/index.php"
         )
-        if resp.url == "https://moodle.rwth-aachen.de/my/":
+        if "https://moodle.rwth-aachen.de/" in resp.url:
             soup = bs(resp.text, features="html.parser")
             self.session_key = get_session_key(soup)
             with cookie_file.open("wb") as f:

--- a/syncmymoodle/__main__.py
+++ b/syncmymoodle/__main__.py
@@ -197,7 +197,7 @@ class SyncMyMoodle:
         resp = self.session.get(
             "https://moodle.rwth-aachen.de/auth/shibboleth/index.php"
         )
-        if "https://moodle.rwth-aachen.de/" in resp.url:
+        if resp.url.startswith("https://moodle.rwth-aachen.de/my/"):
             soup = bs(resp.text, features="html.parser")
             self.session_key = get_session_key(soup)
             with cookie_file.open("wb") as f:


### PR DESCRIPTION
The current check broke, because the url is slightly changed. A check if the page is the moodle page should be enough.

old link: https://moodle.rwth-aachen.de/my/

new link: https://moodle.rwth-aachen.de/my/courses.php