### PR TITLE
Add safe sciebo file updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Downloads the following materials:
 * Quizzes (**Disabled by default**)
 * Pages and Labels: Embedded Opencast and Youtube Videos
 
+On subsequent runs, *syncMyMoodle* can also update existing files when the
+content on Moodle or Sciebo (Nextcloud) changed, while optionally protecting
+local edits through configurable conflict handling.
+
 ## Installation
 
 This software requires **Python 3.11 or higher**.
@@ -32,6 +36,21 @@ If you just want to get the job done, just use the following commands:
 python3 -m venv .venv
 source .venv/bin/activate  # bash/zsh, for other shells view the docs
 pip3 install syncmymoodle
+```
+
+After installation you can run the CLI directly as:
+
+```bash
+syncmymoodle
+```
+
+You can also install it as an isolated tool, for example using
+[pipx](https://pipx.pypa.io) or [uv](https://github.com/astral-sh/uv):
+
+```bash
+pipx install syncmymoodle
+# or
+uv tool install syncmymoodle
 ```
 
 ### Manual installation
@@ -64,15 +83,15 @@ of simplicity.
 
 ### Command line arguments
 
-#### Using pip
+#### Using pip / tool install
 
-Use `python3 -m syncmymoodle` and use the command line arguments.
+Use `syncmymoodle` and pass the command line arguments directly.
 
 #### Manual installation
 
 ```bash
 source .venv/bin/activate  # if you installed using virtual environment
-python3 -m syncmymoodle
+syncmymoodle
 deactivate  # leave virtual environment
 ```
 
@@ -171,8 +190,8 @@ configuration does:
     },
     "exclude_filetypes": [], // Exclude specific filetypes (e.g. ["mp4", "mkv"]) to disable downloading most videos
     "exclude_files": [], // Exclude specific files using UNIX filename pattern matching (e.g. "Lecture{video,zoom}*.{mp4,mkv}")
-    "update_files": true, // If true, existing files are redownloaded only when Moodle reports that they were modified (requires a cached root node from a previous run).
-    "update_files_conflict": "rename" // How to handle locally modified files when Moodle has a newer version: "rename" (default, move to <name>.syncconflict.<hash>), "keep" (skip update), or "overwrite" (replace local file).
+    "update_files": true, // If true, existing files are redownloaded only when Moodle/Sciebo report that they were modified (based on timemodified and checksums).
+    "update_files_conflict": "rename" // How to handle locally modified files when a newer version is available on Moodle/Sciebo: "rename" (default, move to <name>.syncconflict.<hash>), "keep" (skip update), or "overwrite" (!!DANGEROUS!! replaces the local file, you may lose any files you edited/changed!).
 }
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ dependencies = [
   "requests>=2.0.0",
   "beautifulsoup4>=4.0.0",
   "yt-dlp>=2021.12.27",
-  "tqdm>=4.0.0"
+  "tqdm>=4.0.0",
+  "lxml>=5.0.0"
 ]
 
 [project.optional-dependencies]

--- a/syncmymoodle/__main__.py
+++ b/syncmymoodle/__main__.py
@@ -1457,7 +1457,9 @@ class SyncMyMoodle:
 
         # https://rwth-aachen.sciebo.de/s/XXX
         if self.config.get("used_modules", {}).get("url", {}).get("sciebo", {}):
-            sciebo_links = set(re.findall("https://rwth-aachen.sciebo.de/s/[a-zA-Z0-9-]+", text))
+            sciebo_links = set(
+                re.findall("https://rwth-aachen.sciebo.de/s/[a-zA-Z0-9-]+", text)
+            )
             sciebo_url = "https://rwth-aachen.sciebo.de"
             webdav_location = "/public.php/webdav/"
             for link in sciebo_links:

--- a/syncmymoodle/__main__.py
+++ b/syncmymoodle/__main__.py
@@ -1481,13 +1481,13 @@ class SyncMyMoodle:
 
                 # get baseauthentication secret
                 baseAuthSecret = base64.b64encode(
-                    (sharingToken + ":null").encode()
+                    f"{sharingToken}:null".encode()
                 ).decode()
                 logger.info(f"BaseAuthSecret: {baseAuthSecret}")
 
                 # get auth header
                 auth_header = {
-                    "Authorization": "Basic " + baseAuthSecret,
+                    "Authorization": f"Basic {baseAuthSecret}",
                     "requesttoken": requestToken,
                 }
 

--- a/syncmymoodle/__main__.py
+++ b/syncmymoodle/__main__.py
@@ -1457,9 +1457,7 @@ class SyncMyMoodle:
 
         # https://rwth-aachen.sciebo.de/s/XXX
         if self.config.get("used_modules", {}).get("url", {}).get("sciebo", {}):
-            sciebo_links = list(
-                set(re.findall("https://rwth-aachen.sciebo.de/s/[a-zA-Z0-9-]+", text))
-            )
+            sciebo_links = set(re.findall("https://rwth-aachen.sciebo.de/s/[a-zA-Z0-9-]+", text))
             sciebo_url = "https://rwth-aachen.sciebo.de"
             webdav_location = "/public.php/webdav/"
             for link in sciebo_links:

--- a/syncmymoodle/__main__.py
+++ b/syncmymoodle/__main__.py
@@ -80,9 +80,9 @@ class Node:
         self.type = type
         self.parent = parent
         self.children: List[Node] = []
-        self.additional_info = (
-            additional_info  # Currently only used for course_id in opencast
-        )
+        # Currently only used for course_id in opencast, auth header in sciebo,
+        # and may be extended for other module-specific data.
+        self.additional_info = additional_info
         self.timemodified = timemodified
         self.etag = etag
         self.is_downloaded = (
@@ -1207,6 +1207,8 @@ class SyncMyMoodle:
         else:
             resume_size = 0
             header = dict()
+        if node.type.lower() == "sciebo file":
+            header = {**header, **node.additional_info}
 
         with closing(
             self.session.get(node.url, headers=header, stream=True)
@@ -1455,18 +1457,103 @@ class SyncMyMoodle:
 
         # https://rwth-aachen.sciebo.de/s/XXX
         if self.config.get("used_modules", {}).get("url", {}).get("sciebo", {}):
-            sciebo_links = re.findall(
-                "https://rwth-aachen.sciebo.de/s/[a-zA-Z0-9-]+", text
+            sciebo_links = list(
+                set(re.findall("https://rwth-aachen.sciebo.de/s/[a-zA-Z0-9-]+", text))
             )
-            for vid in sciebo_links:
-                response = self.session.get(vid)
+            sciebo_url = "https://rwth-aachen.sciebo.de"
+            webdav_location = "/public.php/webdav/"
+            for link in sciebo_links:
+                logging.info(f"Found Sciebo Link: {link}")
+
+                # get the download page
+                response = self.session.get(link)
+
+                # parse html code
                 soup = bs(response.text, features="html.parser")
-                url = soup.find("input", {"name": "downloadURL"})
-                filename = soup.find("input", {"name": "filename"})
-                if url and filename:
-                    parent_node.add_child(
-                        filename["value"], url["value"], "Sciebo file", url=url["value"]
+
+                # get the requesttoken
+                requestToken = soup.head["data-requesttoken"]
+                logger.info(f"RequestToken: {requestToken}")
+
+                # print the property value of the input tag with the name sharingToken
+                sharingToken = soup.find("input", {"name": "sharingToken"})["value"]
+                logger.info(f"SharingToken: {sharingToken}")
+
+                # get baseauthentication secret
+                baseAuthSecret = base64.b64encode(
+                    (sharingToken + ":null").encode()
+                ).decode()
+                logger.info(f"BaseAuthSecret: {baseAuthSecret}")
+
+                # get auth header
+                auth_header = {
+                    "Authorization": "Basic " + baseAuthSecret,
+                    "requesttoken": requestToken,
+                }
+
+                parent_node = parent_node.add_child(
+                    f"sciebo-{sharingToken}", None, "Sciebo Folder"
+                )
+
+                # recursive function to get all files in the sciebo folder
+                def get_sciebo_files(
+                    href: str, parent_node: Node, sharingToken: str, auth_header: dict
+                ):
+
+                    # request the URL with the PROPFIND method and the header
+                    response = self.session.request(
+                        "PROPFIND", sciebo_url + href, headers=auth_header
                     )
+
+                    # parse the response
+                    soup = bs(response.text, features="xml")
+
+                    for response in soup.find_all("d:response"):
+                        # get the href of the response
+                        new_href = response.find("d:href").text
+
+                        if new_href == href:
+                            logger.info(
+                                f"Skipping {new_href} because it is the current folder"
+                            )
+                            continue
+
+                        logger.info(f"response: {response.find('d:href').text}")
+                        # get the displayname of the response
+                        displayname = (
+                            new_href.split("/")[-2]
+                            if new_href.endswith("/")
+                            else new_href.split("/")[-1]
+                        )
+                        displayname = (
+                            f"sciebo-{sharingToken}"
+                            if displayname == "webdav"
+                            else displayname
+                        )
+
+                        # check if the response is a folder
+                        if new_href.endswith("/"):
+                            # create a new node for the folder
+                            folder_node = parent_node.add_child(
+                                displayname, None, "Sciebo Folder"
+                            )
+                            # recursive call to get all files in the folder
+                            get_sciebo_files(
+                                new_href, folder_node, sharingToken, auth_header
+                            )
+                        else:
+                            # create a new node for the file
+                            parent_node.add_child(
+                                displayname,
+                                None,
+                                "Sciebo File",
+                                url=sciebo_url + new_href,
+                                additional_info=auth_header,
+                            )
+
+                get_sciebo_files(
+                    webdav_location, parent_node, sharingToken, auth_header
+                )
 
 
 def main():

--- a/syncmymoodle/__main__.py
+++ b/syncmymoodle/__main__.py
@@ -389,14 +389,9 @@ class SyncMyMoodle:
         self._opencast_error_count += 1
 
         if response_body:
-            logger.info(
-                f"Opencast response body (truncated): {response_body[:1000]}"
-            )
+            logger.info(f"Opencast response body (truncated): {response_body[:1000]}")
 
-        if (
-            self._opencast_error_count >= 5
-            and not self._opencast_status_hint_logged
-        ):
+        if self._opencast_error_count >= 5 and not self._opencast_status_hint_logged:
             logger.warning(
                 "Multiple Opencast backend errors occurred. Please check the RWTH "
                 "ITC status page before reporting an issue on GitHub: "
@@ -1374,9 +1369,7 @@ class SyncMyMoodle:
         try:
             episodejson = episode_response.json()
         except ValueError:
-            logger.error(
-                "Opencast: failed to decode JSON from %s", episode_url
-            )
+            logger.error("Opencast: failed to decode JSON from %s", episode_url)
             self._log_opencast_backend_issue(episode_response.text)
             return False
 
@@ -1571,7 +1564,9 @@ class SyncMyMoodle:
 
                 # get the requesttoken
                 requestToken = (
-                    soup.head.get("data-requesttoken") if soup.head is not None else None
+                    soup.head.get("data-requesttoken")
+                    if soup.head is not None
+                    else None
                 )
                 if not requestToken:
                     logger.warning(
@@ -1635,7 +1630,10 @@ class SyncMyMoodle:
                     }
                     try:
                         propfind_response = self.session.request(
-                            "PROPFIND", sciebo_url + href, headers=headers, data=propfind_body
+                            "PROPFIND",
+                            sciebo_url + href,
+                            headers=headers,
+                            data=propfind_body,
                         )
                     except Exception:
                         logger.exception(


### PR DESCRIPTION
This supersedes PR #117 

  - Sciebo shares are now traversed via WebDAV PROPFIND with an explicit request for oc:checksums, so each file gets a stable content hash (SHA1) in addition to getetag.
  - For each Sciebo item, we store the SHA1 checksum on the node as its etag and persist it in the per‑course .syncmymoodle_cache alongside the usual Moodle nodes.
  - During downloads, we use the cached Sciebo checksum to detect remote changes: if the SHA1 from the new PROPFIND matches the old cached one, we skip re‑downloading that file.
  - When the remote checksum changed, we hash the local file and compare it to the old checksum to detect local modifications; if they differ, we treat this as a sync conflict and apply the same
    update_files_conflict strategies (rename, keep, overwrite) as for Moodle files.
  - If there is no cache yet but a local file already exists, we compare its hash against the current Sciebo checksum from PROPFIND; if they match, we treat the file as up‑to‑date and skip both downloading and
    conflict handling.

This solves #110 
This PR (should) also fix #74 by checking the response header when resuming partially downloaded files 
And as far as I can tell, the current code should resolve #35 