### PR TITLE
Improve release workflow and packaging metadata

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,34 +6,42 @@ template: |
 name-template: "$RESOLVED_VERSION"
 tag-template: "$RESOLVED_VERSION"
 version-template: "$MAJOR.$MINOR.$PATCH"
-version-resolver:
-  major:
-    labels:
-      - "semver:major"
-  minor:
-    labels:
-      - "semver:minor"
-  patch:
-    labels:
-      - "semver:patch"
-  default: patch
 categories:
+  - type: pre-exclude
+    when:
+      label: skip-changelog
+  - type: version-resolver
+    semver-increment: major
+    when:
+      label: "semver:major"
+  - type: version-resolver
+    semver-increment: minor
+    when:
+      label: "semver:minor"
+  - type: version-resolver
+    semver-increment: patch
+    when:
+      label: "semver:patch"
+  - type: version-resolver
+    semver-increment: patch
   - title: "Features"
-    labels:
-      - feature
-      - enhancement
+    when:
+      labels:
+        - feature
+        - enhancement
   - title: "Bug Fixes"
-    labels:
-      - bug
-      - fix
+    when:
+      labels:
+        - bug
+        - fix
   - title: "Maintenance"
-    labels:
-      - chore
-      - maintenance
-      - refactor
-      - dependencies
-      - documentation
+    when:
+      labels:
+        - chore
+        - maintenance
+        - refactor
+        - dependencies
+        - documentation
 change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
+change-title-escapes: '\<*_&@#`'
 no-changes-template: "No user-facing changes."
-exclude-labels:
-  - skip-changelog

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,6 +17,6 @@ jobs:
       pull-requests: read
 
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,13 +5,27 @@ on:
     tags:
       - "*.*.*"
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish, for example 0.3.0"
+        required: true
+        type: string
 
 permissions:
   contents: read
-  id-token: write
+
+concurrency:
+  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
 
 env:
   PYTHON_VERSION: "3.12"
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  RELEASE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
 
 jobs:
   build:
@@ -19,27 +33,72 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
+          fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install build backend
+      - name: Validate release inputs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          git rev-parse --verify --quiet "${RELEASE_TAG}^{commit}" >/dev/null || {
+            echo "Release tag ${RELEASE_TAG} does not exist." >&2
+            exit 1
+          }
+
+          python - <<'PY'
+          import os
+          import sys
+          import tomllib
+          from pathlib import Path
+
+          release_tag = os.environ["RELEASE_TAG"]
+          version = tomllib.loads(Path("pyproject.toml").read_text())["project"]["version"]
+          if release_tag != version:
+              print(
+                  f"Release tag {release_tag!r} does not match pyproject.toml version {version!r}.",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          PY
+
+          draft_id=$(gh api "repos/${GH_REPO}/releases" \
+            --paginate \
+            --jq '.[] | select(.draft == true and (.name == env.RELEASE_TAG or .tag_name == env.RELEASE_TAG)) | .id' \
+            | head -n 1)
+
+          if [ -z "${draft_id}" ] && ! gh release view "${RELEASE_TAG}" --repo "${GH_REPO}" >/dev/null 2>&1; then
+            echo "No draft or published GitHub release found for ${RELEASE_TAG}. Make sure Release Drafter created a matching draft before publishing." >&2
+            exit 1
+          fi
+
+      - name: Install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install build
+          python -m pip install build twine
 
       - name: Build package
         run: python -m build
 
+      - name: Check package metadata
+        run: python -m twine check dist/*
+
       - name: Upload dist artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: syncmymoodle-dist
           path: dist/*
           if-no-files-found: error
+          retention-days: 7
 
   publish-testpypi:
     name: Publish to TestPyPI
@@ -52,7 +111,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: syncmymoodle-dist
           path: dist
@@ -75,7 +134,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: syncmymoodle-dist
           path: dist
@@ -92,7 +151,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: syncmymoodle-dist
           path: dist
@@ -101,26 +160,29 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          TAG_NAME: ${{ github.ref_name }}
-          TARGET_SHA: ${{ github.sha }}
+          TAG_NAME: ${{ env.RELEASE_TAG }}
         run: |
-          release_id=$(gh api repos/$GH_REPO/releases \
-            --paginate \
-            --jq '.[] | select(.draft == true and .name == env.TAG_NAME) | .id')
+          set -euo pipefail
 
-          if [ -z "$release_id" ]; then
+          release_id=$(gh api "repos/${GH_REPO}/releases" \
+            --paginate \
+            --jq '.[] | select(.draft == true and (.name == env.TAG_NAME or .tag_name == env.TAG_NAME)) | .id' \
+            | head -n 1)
+
+          if [ -n "${release_id}" ]; then
+            gh api "repos/${GH_REPO}/releases/${release_id}" \
+              --method PATCH \
+              -f draft=false \
+              -f tag_name="${TAG_NAME}"
+          elif gh release view "${TAG_NAME}" --repo "${GH_REPO}" >/dev/null 2>&1; then
+            echo "GitHub release ${TAG_NAME} is already published; uploading artifacts."
+          else
             echo "Draft release \"${TAG_NAME}\" not found. Make sure Release Drafter created it and the name matches the tag." >&2
             exit 1
           fi
-
-          gh api repos/$GH_REPO/releases/$release_id \
-            --method PATCH \
-            -f draft=false \
-            -f tag_name=$TAG_NAME \
-            -f target_commitish=$TARGET_SHA
 
       - name: Upload release artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-        run: gh release upload ${{ github.ref_name }} dist/* --clobber
+        run: gh release upload "${RELEASE_TAG}" dist/* --clobber

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -14,12 +17,13 @@ jobs:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
 
       - name: Install dependencies
         run: |

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,56 +1,118 @@
 # Releasing syncMyMoodle
 
-There are two GitHub Actions workflows that do publishing and prepare release notes.
+Releases are mostly automated through GitHub Actions. In practice, you usually only need to:
 
-## Release Drafter workflow
+1. merge the PRs you want in the release,
+2. bump the version in `pyproject.toml`,
+3. create and push a matching tag,
+4. check that the workflow finishes successfully.
 
-Every push to `master` has it's information go into `release-drafter.yml`, which updates the draft release on GitHub. Labels drive what happens:
+## Before releasing
 
-- `feature`, `bug`, `maintenance`, `dependencies`, `documentation`, etc. decide
-  which section a PR lands in.
-- `semver:major`, `semver:minor`, `semver:patch` hint at the next version bump.
-- `skip-changelog` hides a PR completely.
+Make sure merged PRs have useful titles and the right labels. These labels are used for the generated release notes.
 
-Before you tag a release, open the draft on GitHub and tweak the wording. Do it
-close to tagging so new merges don't overwrite your edits.
+Common labels are:
 
-## Publish Release workflow
+* `feature`
+* `bug`
+* `maintenance`
+* `dependencies`
+* `documentation`
 
-`release.yaml` runs on tags that look like our versions (`0.2.3`, `0.2.3.post1`,
-`0.3.0-rc.1`, ...) or when you trigger it manually. The job order:
+Version labels such as `semver:major`, `semver:minor`, and `semver:patch` help Release Drafter suggest the next version.
 
-1. Build sdist + wheel via `python -m build`.
-2. Push both archives to TestPyPI and PyPI using Trusted Publishing (OIDC).
-3. Flip the existing Release Drafter draft from "draft" to "published" (no body
-   changes) and then upload the freshly built artifacts to that release.
+Use `skip-changelog` for PRs that should not appear in the release notes.
 
-Since this uses Trusted Publishing you don't need API tokens, but PyPI/TestPyPI
-must trust the workflow.
+## Release notes
+
+The `release-drafter.yml` workflow updates a draft GitHub release whenever something is pushed to `master`.
+
+Before publishing a release, open the draft release on GitHub and clean up the wording if needed. Do this shortly before tagging, because new merges can update the draft again.
+
+## Publishing a release
+
+The release workflow is `.github/workflows/release.yaml`.
+
+It runs automatically when you push a version tag, for example:
+
+```bash
+git tag 0.2.4
+git push origin 0.2.4
+```
+
+Supported tag formats include:
+
+```text
+0.2.3
+0.2.3.post1
+0.3.0-rc.1
+```
+
+The tag must match the version in `pyproject.toml`.
+
+When the workflow runs, it will:
+
+1. check that the tag exists,
+2. check that the tag matches `pyproject.toml`,
+3. check that a matching GitHub release already exists,
+4. build the source distribution and wheel,
+5. run `twine check`,
+6. upload the package to TestPyPI and PyPI,
+7. publish the existing GitHub draft release,
+8. upload the built artifacts to the GitHub release.
+
+The workflow uses PyPI Trusted Publishing, so no API tokens are needed.
+
+## Release checklist
+
+1. Merge all PRs that should be included in the release.
+
+2. Check that PR labels and titles look good for the release notes.
+
+3. Bump the version in `pyproject.toml`.
+
+4. Commit the version bump.
+
+5. Create and push the tag:
+
+   ```bash
+   git tag X.Y.Z
+   git push origin X.Y.Z
+   ```
+
+6. Open the GitHub draft release and adjust the notes if needed.
+
+7. Watch the **Publish Release** workflow.
+
+8. Approve the Trusted Publishing request on PyPI/TestPyPI if GitHub or PyPI asks for it.
+
+9. Once the workflow is green, check that:
+
+   * the package is available on PyPI and TestPyPI,
+   * the GitHub release is published,
+   * the release contains the uploaded artifacts.
+
+## Re-running a release
+
+To re-run the workflow manually:
+
+1. Open the **Actions** tab.
+2. Select **Publish Release**.
+3. Click **Run workflow**.
+4. Enter the release tag you want to publish.
 
 ## Trusted Publishing setup
 
-(this is already done)
+This is already configured.
 
-1. On PyPI and TestPyPI open **Manage project -> Publishing**.
+For reference, the setup is:
+
+1. Open **Manage project -> Publishing** on PyPI and TestPyPI.
 2. Click **Add a trusted publisher -> GitHub Actions**.
-3. Point it at this repo, the workflow `.github/workflows/release.yaml`, and the
-   matching environment (`pypi` or `testpypi`).
-4. After the first workflow run, approve the pending publisher in the UI once.
+3. Select this repository.
+4. Use the workflow `.github/workflows/release.yaml`.
+5. Use the matching environment:
 
-## Release todos
-
-1. Merge PRs with the right labels and useful titles for the release note draft.
-2. Bump the version in `pyproject.toml`.
-3. Commit and tag using the version string (`X.Y.Z`, `X.Y.Z.postN`, etc.):
-   ```bash
-   git tag 0.2.4
-   git push origin 0.2.4
-   ```
-4. Double-check that there's a Release Drafter draft whose name matches your tag
-   (tweak the text now if needed), then watch the "Publish Release" workflow.
-   Approve the Trusted Publishing request on PyPI/TestPyPI if one pops up.
-5. Once it's green, PyPI/TestPyPI have the new files and GitHub shows your draft
-   as a published release with the same notes + the uploaded artifacts.
-
-To re-run the workflow, use the Actions
-tab -> **Publish Release -> Run workflow**.
+   * `pypi`
+   * `testpypi`
+6. After the first run, approve the pending publisher once in the PyPI/TestPyPI UI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61", "wheel"]
+requires = ["setuptools>=77.0.3", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,14 +8,14 @@ version = "0.3.0"
 description = "Synchronization client for RWTH Moodle"
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "GPL-3.0-only" }
+license = "GPL-3.0-only"
+license-files = ["LICENSE"]
 authors = [
   { name = "Nils Kattenbeck", email = "nilskemail+pypi@gmail.com" }
 ]
 keywords = ["moodle", "sync", "rwth", "cli"]
 classifiers = [
   "Programming Language :: Python :: 3",
-  "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
   "Operating System :: OS Independent",
   "Development Status :: 5 - Production/Stable"
 ]


### PR DESCRIPTION
- require manual release runs to provide an explicit tag and validate the tag, `pyproject.toml` version, and
  GitHub release draft before publishing
- build distributions once, run `twine check`, and reuse the checked artifacts for TestPyPI, PyPI, and GitHub
release uploads
- scope release workflow permissions per job and update GitHub Actions pins to current Node 24-compatible majors
- refresh Release Drafter configuration and document the release process
- update packaging license metadata to the current PEP 639 format
