### PR TITLE
Remove unused root cache option

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ Command line arguments have a higher priority than configuration files.
 You can override any of the options that you have configured in the file
 using command line arguments.
 
+syncMyMoodle stores per-course metadata in a hidden `.syncmymoodle_cache` file
+inside each synced course directory. Delete that file to force a fresh metadata
+cache for a course.
+
 ### TOTP
 
 From the RWTH IDM service you will get a TOTP secret which will be used to

--- a/config.json.example
+++ b/config.json.example
@@ -8,7 +8,6 @@
     "totpsecret": "",
     "basedir": "./",
     "cookie_file": "./session",
-    "root_node_cache_file": "./cached_root_node",
     "use_secret_service": false,
     "secret_service_store_totp_secret": false,
     "no_links": false,

--- a/syncmymoodle/__main__.py
+++ b/syncmymoodle/__main__.py
@@ -2117,11 +2117,6 @@ def main():
         "--cookiefile", default=None, help="set the location of a cookie file"
     )
     parser.add_argument(
-        "--rootnodecachefile",
-        default=None,
-        help="set the location of a root node cache file",
-    )
-    parser.add_argument(
         "--courses",
         default=None,
         help="specify the courses that should be synced using comma-separated links. Defaults to all courses, if no additional restrictions e.g. semester are defined.",
@@ -2204,9 +2199,6 @@ def main():
     config["totp"] = args.totp or config.get("totp")
     config["totpsecret"] = args.totpsecret or config.get("totpsecret")
     config["cookie_file"] = args.cookiefile or config.get("cookie_file", "./session")
-    config["root_node_cache_file"] = args.rootnodecachefile or config.get(
-        "root_node_cache_file", "./cached_root_node"
-    )
     config["selected_courses"] = (
         args.courses.split(",") if args.courses else config.get("selected_courses", [])
     )


### PR DESCRIPTION
Drop the dead --rootnodecachefile CLI argument and config example entry. Document the actual per-course .syncmymoodle_cache behavior instead.