### PR TITLE
Scan assignment intros for Opencast links

### DIFF
--- a/syncmymoodle/__main__.py
+++ b/syncmymoodle/__main__.py
@@ -925,6 +925,15 @@ class SyncMyMoodle:
                                 assignment_name, assignment_id, "Assignment"
                             )
 
+                            assignment_intro = ass.get("intro")
+                            if assignment_intro:
+                                self.scanForLinks(
+                                    assignment_intro,
+                                    assignment_node,
+                                    course_id,
+                                    module_title=assignment_name,
+                                )
+
                             ass = ass[
                                 "introattachments"
                             ] + self.get_assignment_submission_files(assignment_id)


### PR DESCRIPTION
- Scan assignment intro HTML for embedded links.
- Detect Opencast `engage.streaming.rwth-aachen.de/play/...` URLs in assignment intro iframes.
- Attach discovered Opencast videos below the assignment node.

Closes #91.