### PR TITLE
Fix Sciebo share token extraction for newer Nextcloud

### DIFF
--- a/syncmymoodle/sciebo.py
+++ b/syncmymoodle/sciebo.py
@@ -13,6 +13,18 @@ logger = logging.getLogger(__name__)
 
 SCIEBO_URL = "https://rwth-aachen.sciebo.de"
 WEBDAV_LOCATION = "/public.php/webdav/"
+
+
+def sharing_token_from_link(link: str) -> str:
+    """Return the public-share token from a ``.../s/<token>`` Sciebo URL.
+
+    Nextcloud public shares use this final path segment as the WebDAV
+    username, so it is a reliable fallback when the share page no longer
+    exposes the token as a hidden ``<input name="sharingToken">``.
+    """
+    return link.split("?", 1)[0].rstrip("/").rsplit("/s/", 1)[-1]
+
+
 PROPFIND_BODY = """<?xml version="1.0" encoding="UTF-8"?>
 <d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
   <d:prop>
@@ -66,10 +78,17 @@ def scan_public_shares(
 
         # get the property value of the input tag with the name sharingToken
         sharing_input = soup.find("input", {"name": "sharingToken"})
-        if not sharing_input or not sharing_input.get("value"):
+        if sharing_input and sharing_input.get("value"):
+            sharingToken = cast(str, sharing_input["value"])
+        else:
+            # Newer Sciebo/Nextcloud share pages no longer render the token as a
+            # hidden input. It matches the /s/<token> segment of the share URL,
+            # which is what the public WebDAV endpoint expects, so fall back to
+            # deriving it from the link instead of skipping the share.
+            sharingToken = sharing_token_from_link(link)
+        if not sharingToken:
             log.warning("Sciebo: missing sharingToken for link %s, skipping", link)
             continue
-        sharingToken = cast(str, sharing_input["value"])
         log.info(f"Sciebo sharingToken: {sharingToken}")
 
         # get baseauthentication secret

--- a/tests/fixtures/sciebo/public_share_no_token.html
+++ b/tests/fixtures/sciebo/public_share_no_token.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <head data-requesttoken="fake-request-token"></head>
+  <body>
+    <!-- Newer Sciebo/Nextcloud share pages no longer expose the sharingToken input. -->
+  </body>
+</html>

--- a/tests/test_sync_fixtures.py
+++ b/tests/test_sync_fixtures.py
@@ -1,4 +1,4 @@
-from syncmymoodle import links, opencast, sync
+from syncmymoodle import links, opencast, sciebo, sync
 from syncmymoodle.node import Node
 
 from .helpers import (
@@ -150,6 +150,70 @@ def test_sciebo_public_share_is_cached_per_sync_run():
         "Sciebo Folder | First occurrence/sciebo-share-token-123/slides |  |  | "
         '"folder-slides"',
         "Sciebo File | First occurrence/sciebo-share-token-123/slides/deck.pdf | "
+        "https://rwth-aachen.sciebo.de/public.php/webdav/slides/deck.pdf |  | "
+        "2222222222222222222222222222222222222222",
+    ]
+
+
+def test_sharing_token_from_link_extracts_url_segment():
+    assert (
+        sciebo.sharing_token_from_link("https://rwth-aachen.sciebo.de/s/AbC123")
+        == "AbC123"
+    )
+    # Trailing slashes and query strings must not leak into the token.
+    assert (
+        sciebo.sharing_token_from_link("https://rwth-aachen.sciebo.de/s/AbC123/?x=1")
+        == "AbC123"
+    )
+
+
+def test_sciebo_share_without_token_input_uses_url_token():
+    # Newer share pages drop the <input name="sharingToken">; the token is then
+    # derived from the /s/<token> URL segment so the share still resolves.
+    link = "https://rwth-aachen.sciebo.de/s/share-token-123"
+    public_root = "https://rwth-aachen.sciebo.de/public.php/webdav/"
+    public_slides = "https://rwth-aachen.sciebo.de/public.php/webdav/slides/"
+    syncer = make_context(
+        {
+            "used_modules": {
+                "assign": False,
+                "resource": False,
+                "url": {"youtube": False, "opencast": False, "sciebo": True},
+                "folder": False,
+            }
+        }
+    )
+    session = FakeSession()
+    session.add(
+        "GET",
+        link,
+        FakeResponse(text=load_fixture("sciebo", "public_share_no_token.html")),
+    )
+    session.add(
+        "PROPFIND",
+        public_root,
+        FakeResponse(text=load_fixture("sciebo", "propfind_root.xml")),
+    )
+    session.add(
+        "PROPFIND",
+        public_slides,
+        FakeResponse(text=load_fixture("sciebo", "propfind_slides.xml")),
+    )
+    syncer.session = session
+
+    root = Node("", -1, "Root", None)
+    parent = root.add_child("Section", 1, "Section")
+    links.scan_for_links(syncer, link, parent, 101)
+
+    assert session.count("PROPFIND", public_root) == 1
+    assert node_rows(parent) == [
+        "Sciebo Folder | Section/sciebo-share-token-123 |  |  | ",
+        "Sciebo File | Section/sciebo-share-token-123/readme.pdf | "
+        "https://rwth-aachen.sciebo.de/public.php/webdav/readme.pdf |  | "
+        "1111111111111111111111111111111111111111",
+        "Sciebo Folder | Section/sciebo-share-token-123/slides |  |  | "
+        '"folder-slides"',
+        "Sciebo File | Section/sciebo-share-token-123/slides/deck.pdf | "
         "https://rwth-aachen.sciebo.de/public.php/webdav/slides/deck.pdf |  | "
         "2222222222222222222222222222222222222222",
     ]


### PR DESCRIPTION
Seems like the new sciebo broke our sharetoken parsing by removing the hidden input