### PR TITLE
Fix repeated downloads for unchanged files

### DIFF
--- a/syncmymoodle/context.py
+++ b/syncmymoodle/context.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import requests
 
 from syncmymoodle.config import Config
 from syncmymoodle.node import Node
+
+if TYPE_CHECKING:
+    from syncmymoodle.opencast import OpencastTrack
 
 
 @dataclass
@@ -24,7 +27,7 @@ class SyncContext:
     opencast_status_hint_logged: bool = False
     sciebo_link_cache: dict[str, Node] = field(default_factory=dict)
     opencast_episode_auth_cache: set[tuple[Any, str]] = field(default_factory=set)
-    opencast_track_cache: dict[str, str] = field(default_factory=dict)
+    opencast_track_cache: dict[str, OpencastTrack] = field(default_factory=dict)
     downloaded_paths: set[Path] | None = None
 
     def require_session(self) -> requests.Session:

--- a/syncmymoodle/course_cache.py
+++ b/syncmymoodle/course_cache.py
@@ -23,9 +23,15 @@ def match_old_cache_child(old_node: Node | None, child: Node) -> Node | None:
     ]
     if not candidates:
         return None
-    for candidate in candidates:
-        if candidate.url == child.url:
-            return candidate
+
+    for attr in ("url", "name_clash_id", "id"):
+        child_value = getattr(child, attr, None)
+        if child_value is None or child_value is NAME_CLASH_ID_UNSET:
+            continue
+        for candidate in candidates:
+            if getattr(candidate, attr, None) == child_value:
+                return candidate
+
     return candidates[0]
 
 
@@ -36,21 +42,26 @@ def node_to_cache_data(
 ) -> dict[str, Any]:
     timemodified = node.timemodified
     etag = node.etag
+    content_hash = getattr(node, "content_hash", None)
     is_downloaded = node.is_downloaded
-    # If this file was not (re)downloaded this run but a previously
+    node_path = _node_path(ctx, node)
+    downloaded_this_run = (
+        ctx.downloaded_paths is not None and node_path in ctx.downloaded_paths
+    )
+    # If this file was not actually downloaded this run but a previously
     # downloaded version is still on disk, keep the previously cached version
-    # markers. Otherwise the cache would record Moodle's new timemodified/etag
-    # for a file we never actually fetched, which either skips the file
-    # forever or moves the on-disk copy aside as a spurious conflict on the
-    # next run's retry.
+    # markers. The node may still be marked is_downloaded=True when download
+    # traversal skipped an unchanged existing file; downloaded_paths tells us
+    # whether bytes were really replaced in this run.
     if (
-        not node.is_downloaded
+        not downloaded_this_run
         and old_node is not None
         and getattr(old_node, "is_downloaded", False)
-        and _node_path(ctx, node).exists()
+        and node_path.exists()
     ):
         timemodified = getattr(old_node, "timemodified", None)
         etag = getattr(old_node, "etag", None)
+        content_hash = getattr(old_node, "content_hash", None)
         is_downloaded = True
     return {
         "name": node.name,
@@ -59,6 +70,7 @@ def node_to_cache_data(
         "url": node.url,
         "timemodified": timemodified,
         "etag": etag,
+        "content_hash": content_hash,
         "name_clash_id": node.name_clash_id,
         "is_downloaded": is_downloaded,
         "children": [
@@ -77,6 +89,7 @@ def node_from_cache_data(data: dict[str, Any], parent: Node | None = None) -> No
         url=data.get("url"),
         timemodified=data.get("timemodified"),
         etag=data.get("etag"),
+        content_hash=data.get("content_hash"),
         name_clash_id=data.get("name_clash_id", NAME_CLASH_ID_UNSET),
         is_downloaded=data.get("is_downloaded", False),
     )
@@ -94,6 +107,8 @@ def ensure_timemodified_attribute(node: Node) -> None:
         node.timemodified = None
     if not hasattr(node, "etag"):
         node.etag = None
+    if not hasattr(node, "content_hash"):
+        node.content_hash = None
     if not hasattr(node, "name_clash_id"):
         node.name_clash_id = getattr(node, "id", None)
     for child in getattr(node, "children", []):
@@ -156,17 +171,22 @@ def get_old_node_for(
     if cached_course_root is None:
         return None
 
-    full_path = node.get_path()
-    course_path = course_node.get_path()
-    # Compute the path segments beneath the course root
-    rel_segments = full_path[len(course_path) :]
-    if not rel_segments:
+    rel_nodes: list[Node] = []
+    cur = node
+    while cur is not course_node:
+        rel_nodes.insert(0, cur)
+        if cur.parent is None:
+            return None
+        cur = cur.parent
+    if not rel_nodes:
         return cached_course_root
 
-    try:
-        return cached_course_root.go_to_path(rel_segments)
-    except Exception:
-        return None
+    old_node: Node | None = cached_course_root
+    for rel_node in rel_nodes:
+        old_node = match_old_cache_child(old_node, rel_node)
+        if old_node is None:
+            return None
+    return old_node
 
 
 def cache_root_node(

--- a/syncmymoodle/downloader.py
+++ b/syncmymoodle/downloader.py
@@ -170,11 +170,14 @@ def download_file(
                 and old_etag
                 and getattr(node, "etag", None) == old_etag
             ):
-                # Additionally, on the first run with a cache, the local file
-                # may already match this etag (e.g. previously downloaded
-                # manually). If so, we can safely skip any download.
-                if local_file_matches_etag(downloadpath, old_etag):
-                    return True
+                # The remote revision marker is unchanged since our last run, so
+                # there is nothing new to install: skip. We deliberately do NOT
+                # gate this on re-hashing the local file, because Sciebo/WebDAV
+                # ETags are opaque revision tokens (not content hashes). Gating
+                # here made every checksum-less Sciebo file re-download and its
+                # identical local copy get moved aside as a spurious conflict on
+                # every run.
+                return True
 
         # At this point, either there is no cache for this course/path, or
         # Moodle reports a different modification time. This means the remote
@@ -188,20 +191,27 @@ def download_file(
 
         local_conflict = False
         old_etag = getattr(old_node, "etag", None) if old_node is not None else None
+        old_content_hash = (
+            getattr(old_node, "content_hash", None) if old_node is not None else None
+        )
+        # Prefer a content hash we computed ourselves at download time: a Sciebo
+        # ETag is an opaque revision token, so hashing the local file against it
+        # can never match and would flag every file as a conflict. Fall back to
+        # the ETag only when we have no stored content hash (e.g. a Moodle file
+        # whose ETag is a real content hash, or a pre-upgrade cache entry).
+        verify_hash = old_content_hash or old_etag
         etag_check_failed = False
-        if old_etag:
-            # Prefer using the old ETag (hash) to detect whether the local file
-            # still matches the previously downloaded version.
+        if verify_hash:
             try:
-                if not local_file_matches_etag(downloadpath, old_etag):
+                if not local_file_matches_etag(downloadpath, verify_hash):
                     local_conflict = True
             except Exception:
-                # A faulty/unusable ETag cache is treated as if we had no
-                # cached ETag at all: fall back to the timestamp/HEAD heuristic
-                # below to decide whether this is a conflict.
+                # A faulty/unusable hash cache is treated as if we had none:
+                # fall back to the timestamp/HEAD heuristic below to decide
+                # whether this is a conflict.
                 etag_check_failed = True
 
-        if not old_etag or etag_check_failed:
+        if not verify_hash or etag_check_failed:
             if cached_timemodified is not None:
                 # Fallback: compare local mtime with the previous Moodle timestamp.
                 try:
@@ -384,6 +394,16 @@ def download_file(
 
         os.replace(tmp_downloadpath, downloadpath)
         etag_sidecar.unlink(missing_ok=True)
+        # Record a content hash of exactly the bytes we just downloaded, so the
+        # next run can detect genuine local modifications even when the remote
+        # only offers an opaque ETag (e.g. Sciebo/WebDAV). We hash the file we
+        # just wrote (untouched by the user at this point), never a pre-existing
+        # file, so a later user edit is never mistaken for our own download.
+        try:
+            with downloadpath.open("rb") as fh:
+                node.content_hash = hashlib.file_digest(fh, "sha256").hexdigest()
+        except OSError:
+            pass
         # Align the local mtime with Moodle's timemodified to detect local
         # changes on subsequent runs.
         if getattr(node, "timemodified", None) is not None:
@@ -393,9 +413,12 @@ def download_file(
             except (OSError, OverflowError, ValueError):
                 # If updating timestamps fails, fall back to the current time.
                 pass
-        # Persist the ETag of the downloaded file on the node so it can be used
-        # on the next run to detect local modifications.
-        if etag_header is not None:
+        # Persist a response ETag only when discovery did not already provide a
+        # remote version marker. Sciebo/WebDAV can expose one marker through
+        # PROPFIND and a different ETag on GET; the next scan compares against
+        # the PROPFIND marker, so replacing it here would force re-downloads on
+        # every run.
+        if etag_header is not None and getattr(node, "etag", None) is None:
             try:
                 node.etag = etag_header
             except Exception:

--- a/syncmymoodle/downloader.py
+++ b/syncmymoodle/downloader.py
@@ -106,6 +106,44 @@ def download_response_is_usable(
     return True
 
 
+def conditional_get_confirms_unchanged(
+    ctx: SyncContext,
+    node: Any,
+    old_etag: str,
+    log: logging.Logger = logger,
+) -> bool:
+    """Return True when a cheap conditional GET proves the local file is current.
+
+    Some remote nodes, notably legacy Opencast and embedded video nodes, only
+    expose an ETag on the GET response. When the current scan cannot populate
+    ``node.etag``, ask the server whether the cached GET ETag is still current
+    before committing to a full re-download.
+    """
+    if not node.url:
+        return False
+
+    headers: dict[str, str] = {"If-None-Match": old_etag}
+    if node.type.lower() == "sciebo file" and isinstance(node.additional_info, dict):
+        headers = {**headers, **node.additional_info}
+
+    try:
+        with closing(
+            ctx.require_session().get(node.url, headers=headers, stream=True)
+        ) as response:
+            response_etag = response.headers.get("ETag")
+            if response.status_code == 304:
+                node.etag = old_etag
+                return True
+            if 200 <= response.status_code < 300 and response_etag == old_etag:
+                node.etag = response_etag
+                return True
+    except Exception as exc:
+        # A routine transient (timeout, reset) shouldn't spam a stack trace; we
+        # simply fall back to a normal download below.
+        log.warning("Failed to validate cached ETag for %s: %s", node.url, exc)
+    return False
+
+
 def download_file(
     ctx: SyncContext,
     node: Any,
@@ -177,6 +215,13 @@ def download_file(
                 # here made every checksum-less Sciebo file re-download and its
                 # identical local copy get moved aside as a spurious conflict on
                 # every run.
+                return True
+            if (
+                cached_timemodified is None
+                and old_etag
+                and getattr(node, "etag", None) is None
+                and conditional_get_confirms_unchanged(ctx, node, old_etag, log)
+            ):
                 return True
 
         # At this point, either there is no cache for this course/path, or

--- a/syncmymoodle/links.py
+++ b/syncmymoodle/links.py
@@ -82,6 +82,7 @@ def scan_for_links(
                     None,
                     f'Linked file [{response.headers["Content-Type"]}]',
                     url=text,
+                    etag=response.headers.get("ETag"),
                 )
                 # instantly return as it was a direct link
                 return

--- a/syncmymoodle/links.py
+++ b/syncmymoodle/links.py
@@ -128,18 +128,21 @@ def scan_for_links(
                 continue
             if not opencast_api.authenticate_episode(ctx, course_id, vid_id, log):
                 continue
-            vid = opencast_api.extract_track_from_episode(ctx, vid_id, log)
-            if not isinstance(vid, str) or not vid:
+            track = opencast_api.resolve_track_from_episode(ctx, vid_id, log)
+            if track is None:
                 continue
-            if filters.should_skip_url(ctx.config, vid, "Opencast video URL", log):
+            if filters.should_skip_url(
+                ctx.config, track.url, "Opencast video URL", log
+            ):
                 continue
 
             parent_node.add_child(
-                module_title or vid.split("/")[-1],
+                module_title or track.url.split("/")[-1],
                 vid_id,
                 "Opencast",
-                url=vid,
+                url=track.url,
                 additional_info=course_id,
+                etag=track.remote_marker,
             )
 
     # https://rwth-aachen.sciebo.de/s/XXX

--- a/syncmymoodle/node.py
+++ b/syncmymoodle/node.py
@@ -19,6 +19,7 @@ class Node:
         additional_info: Any = None,
         timemodified: Any = None,
         etag: str | None = None,
+        content_hash: str | None = None,
         name_clash_id: Any = NAME_CLASH_ID_UNSET,
         is_downloaded: bool = False,
     ) -> None:
@@ -33,6 +34,10 @@ class Node:
         self.additional_info = additional_info
         self.timemodified = timemodified
         self.etag = etag
+        # A content hash (sha256 hex) we compute from the bytes we downloaded.
+        # Unlike etag, which for Sciebo/WebDAV is an opaque revision token, this
+        # is a real hash of our copy, used to detect local user modifications.
+        self.content_hash = content_hash
         self.name_clash_id = (
             id if name_clash_id is NAME_CLASH_ID_UNSET else name_clash_id
         )
@@ -88,6 +93,7 @@ class Node:
             additional_info=self.additional_info,
             timemodified=self.timemodified,
             etag=self.etag,
+            content_hash=self.content_hash,
             name_clash_id=self.name_clash_id,
             is_downloaded=self.is_downloaded,
         )

--- a/syncmymoodle/opencast.py
+++ b/syncmymoodle/opencast.py
@@ -2,6 +2,7 @@ import json
 import logging
 import re
 import urllib.parse
+from dataclasses import dataclass
 from typing import Any, cast
 
 from bs4 import BeautifulSoup as bs
@@ -13,6 +14,24 @@ logger = logging.getLogger(__name__)
 
 OPENCAST_LTI_URL = "https://engage.streaming.rwth-aachen.de/lti"
 OPENCAST_SEARCH_URL = "https://engage.streaming.rwth-aachen.de/search/episode.json"
+SUPPORTED_CHECKSUM_LENGTHS = {"md5": 32, "sha1": 40, "sha256": 64}
+
+
+@dataclass(frozen=True)
+class OpencastTrack:
+    url: str
+    checksum_type: str | None = None
+    checksum: str | None = None
+    size: int | None = None
+    duration: int | None = None
+
+    @property
+    def remote_marker(self) -> str | None:
+        # The course cache stores remote version markers in Node.etag. For
+        # Opencast, the episode API exposes a real content checksum for the
+        # selected mp4 track, which is a better skip marker than a later GET
+        # response ETag.
+        return self.checksum
 
 
 def log_backend_issue(
@@ -251,20 +270,92 @@ def resolution_width(resolution: Any) -> int:
     return int(match.group(1))
 
 
-def extract_track_from_episode(
+def optional_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(float(str(value)))
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def infer_checksum_type(checksum: str) -> str | None:
+    for checksum_type, expected_length in SUPPORTED_CHECKSUM_LENGTHS.items():
+        if len(checksum) == expected_length:
+            return checksum_type
+    return None
+
+
+def extract_checksum(track: dict[str, Any]) -> tuple[str | None, str | None]:
+    checksum_data = track.get("checksum")
+    checksum_type: str | None = None
+    checksum_value: str | None = None
+
+    if isinstance(checksum_data, dict):
+        raw_type = checksum_data.get("type")
+        if isinstance(raw_type, str):
+            checksum_type = raw_type.strip().lower()
+        for key in ("$", "value", "#text"):
+            raw_value = checksum_data.get(key)
+            if isinstance(raw_value, str) and raw_value.strip():
+                checksum_value = raw_value.strip()
+                break
+    elif isinstance(checksum_data, str):
+        checksum_value = checksum_data.strip()
+
+    if not checksum_value:
+        return None, None
+
+    checksum = checksum_value.lower()
+    checksum_type = checksum_type or infer_checksum_type(checksum)
+    expected_length = (
+        SUPPORTED_CHECKSUM_LENGTHS.get(checksum_type) if checksum_type else None
+    )
+    if expected_length is None:
+        return None, None
+    if len(checksum) != expected_length:
+        return None, None
+    if not re.fullmatch(r"[0-9a-f]+", checksum):
+        return None, None
+    return checksum_type, checksum
+
+
+def opencast_track_from_api(track: dict[str, Any]) -> OpencastTrack | None:
+    video = track.get("video")
+    url = track.get("url")
+    if (
+        not isinstance(url, str)
+        or not url
+        or track.get("mimetype") != "video/mp4"
+        or "transport" in track
+        or not isinstance(video, dict)
+    ):
+        return None
+
+    checksum_type, checksum = extract_checksum(track)
+    return OpencastTrack(
+        url=url,
+        checksum_type=checksum_type,
+        checksum=checksum,
+        size=optional_int(track.get("size")),
+        duration=optional_int(track.get("duration")),
+    )
+
+
+def resolve_track_from_episode(
     ctx: SyncContext,
     episode_id: str,
     log: logging.Logger = logger,
-) -> str | bool:
+) -> OpencastTrack | None:
     if episode_id in ctx.opencast_track_cache:
         return ctx.opencast_track_cache[episode_id]
 
     episode_url = f"{OPENCAST_SEARCH_URL}?id={episode_id}"
     episodejson = fetch_json(ctx, episode_url, f"episode {episode_id}", log)
     if episodejson is None:
-        return False
+        return None
 
-    tracks: list[tuple[int, str]] = []
+    tracks: list[tuple[int, OpencastTrack]] = []
     for entry in get_result_list(ctx, episodejson, f"episode {episode_id}", log):
         if not isinstance(entry, dict):
             continue
@@ -278,21 +369,17 @@ def extract_track_from_episode(
         for track in track_data:
             if not isinstance(track, dict):
                 continue
-            video = track.get("video")
-            url = track.get("url")
-            if (
-                url
-                and track.get("mimetype") == "video/mp4"
-                and "transport" not in track
-                and isinstance(video, dict)
-            ):
-                tracks.append((resolution_width(video.get("resolution")), url))
+            opencast_track = opencast_track_from_api(track)
+            if opencast_track is None:
+                continue
+            video = cast(dict[str, Any], track["video"])
+            tracks.append((resolution_width(video.get("resolution")), opencast_track))
 
     if not tracks:
         log.warning("Opencast: no downloadable mp4 track found for %s", episode_id)
-        return False
+        return None
 
     # Prefer the highest resolution plain HTTPS mp4 track.
-    track_url = sorted(tracks, key=lambda track: track[0])[-1][1]
-    ctx.opencast_track_cache[episode_id] = track_url
-    return track_url
+    selected_track = sorted(tracks, key=lambda track: track[0])[-1][1]
+    ctx.opencast_track_cache[episode_id] = selected_track
+    return selected_track

--- a/syncmymoodle/sync_handlers.py
+++ b/syncmymoodle/sync_handlers.py
@@ -232,12 +232,14 @@ def handle_embedded_link_module(
                             ctx, course_id, vid_id, log
                         ):
                             continue
-                        vid = opencast_api.extract_track_from_episode(ctx, vid_id, log)
-                        if not isinstance(vid, str) or not vid:
+                        track = opencast_api.resolve_track_from_episode(
+                            ctx, vid_id, log
+                        )
+                        if track is None:
                             continue
 
                         if filters.should_skip_url(
-                            ctx.config, vid, "Opencast video URL"
+                            ctx.config, track.url, "Opencast video URL"
                         ):
                             continue
 
@@ -245,8 +247,9 @@ def handle_embedded_link_module(
                             module["name"],
                             vid_id,
                             "Opencast",
-                            url=vid,
+                            url=track.url,
                             additional_info=course_id,
+                            etag=track.remote_marker,
                         )
 
                 if scan_page_links:
@@ -376,17 +379,18 @@ def handle_opencast_lti_module(
                     series_id,
                 )
                 continue
-            vid = opencast_api.extract_track_from_episode(ctx, episode_id, log)
-            if not isinstance(vid, str) or not vid:
+            track = opencast_api.resolve_track_from_episode(ctx, episode_id, log)
+            if track is None:
                 continue
-            if filters.should_skip_url(ctx.config, vid, "Opencast video URL"):
+            if filters.should_skip_url(ctx.config, track.url, "Opencast video URL"):
                 continue
             series_node.add_child(
                 mediapackage.get("title") or episode_id,
                 episode_id,
                 "Opencast",
-                url=vid,
+                url=track.url,
                 additional_info=module["id"],
+                etag=track.remote_marker,
             )
     else:
         if not engage_single_id:
@@ -399,17 +403,18 @@ def handle_opencast_lti_module(
                 ctx, engage_data, f"LTI module {module['id']}", log
             ):
                 return
-            vid = opencast_api.extract_track_from_episode(ctx, engage_single_id, log)
-            if not isinstance(vid, str) or not vid:
+            track = opencast_api.resolve_track_from_episode(ctx, engage_single_id, log)
+            if track is None:
                 return
-            if filters.should_skip_url(ctx.config, vid, "Opencast video URL"):
+            if filters.should_skip_url(ctx.config, track.url, "Opencast video URL"):
                 return
             section_node.add_child(
                 name,
                 engage_single_id,
                 "Opencast",
-                url=vid,
+                url=track.url,
                 additional_info=module["id"],
+                etag=track.remote_marker,
             )
 
 

--- a/tests/fixtures/opencast/episode_series_a.json
+++ b/tests/fixtures/opencast/episode_series_a.json
@@ -6,6 +6,12 @@
           "track": {
             "mimetype": "video/mp4",
             "url": "https://video.example.test/opencast/series-a.mp4",
+            "checksum": {
+              "type": "md5",
+              "$": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            },
+            "size": 3000,
+            "duration": 180000,
             "video": {
               "resolution": "1280x720"
             }

--- a/tests/fixtures/opencast/episode_series_b.json
+++ b/tests/fixtures/opencast/episode_series_b.json
@@ -14,6 +14,12 @@
             {
               "mimetype": "video/mp4",
               "url": "https://video.example.test/opencast/series-b.mp4",
+              "checksum": {
+                "type": "md5",
+                "$": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+              },
+              "size": 4000,
+              "duration": 240000,
               "video": {
                 "resolution": "1920x1080"
               }

--- a/tests/fixtures/opencast/episode_single.json
+++ b/tests/fixtures/opencast/episode_single.json
@@ -7,6 +7,12 @@
             {
               "mimetype": "video/mp4",
               "url": "https://video.example.test/opencast/single-low.mp4",
+              "checksum": {
+                "type": "md5",
+                "$": "11111111111111111111111111111111"
+              },
+              "size": 1000,
+              "duration": 120000,
               "video": {
                 "resolution": "640x360"
               }
@@ -14,6 +20,12 @@
             {
               "mimetype": "video/mp4",
               "url": "https://video.example.test/opencast/single-high.mp4",
+              "checksum": {
+                "type": "md5",
+                "$": "22222222222222222222222222222222"
+              },
+              "size": 2000,
+              "duration": 120000,
               "video": {
                 "resolution": "1920x1080"
               }

--- a/tests/snapshots/assignment_opencast_tree.txt
+++ b/tests/snapshots/assignment_opencast_tree.txt
@@ -2,4 +2,4 @@ Semester | 26ss |  |  |
 Course | 26ss/(UE) Software Quality |  |  | 
 Section | 26ss/(UE) Software Quality/Assignments |  |  | 
 Assignment | 26ss/(UE) Software Quality/Assignments/Video reflection |  |  | 
-Opencast | 26ss/(UE) Software Quality/Assignments/Video reflection/Video reflection | https://video.example.test/11111111-2222-4333-8444-555555555555/presentation.mp4 |  | 
+Opencast | 26ss/(UE) Software Quality/Assignments/Video reflection/Video reflection | https://video.example.test/11111111-2222-4333-8444-555555555555/presentation.mp4 |  | 11111111111111111111111111111111

--- a/tests/snapshots/mixed_course_tree.txt
+++ b/tests/snapshots/mixed_course_tree.txt
@@ -13,7 +13,7 @@ Folder | 26ss/Comprehensive Sync/Materials/Essay upload/Feedback |  |  |
 Assignment File | 26ss/Comprehensive Sync/Materials/Essay upload/Feedback/feedback.txt | https://moodle.rwth-aachen.de/pluginfile.php/104/mod_assign/feedback/feedback.txt | 1710000106 | 
 Linked file [application/pdf] | 26ss/Comprehensive Sync/Materials/direct.pdf | https://files.example.test/direct.pdf |  | "direct-file-v1"
 Youtube | 26ss/Comprehensive Sync/Materials/Youtube: External HTML page | https://www.youtube.com/watch?v=directvid01 |  | 
-Opencast | 26ss/Comprehensive Sync/Materials/Page module | https://video.example.test/33333333-4444-4555-8666-777777777777/presentation.mp4 |  | 
+Opencast | 26ss/Comprehensive Sync/Materials/Page module | https://video.example.test/33333333-4444-4555-8666-777777777777/presentation.mp4 |  | 33333333333333333333333333333333
 Embedded videojs | 26ss/Comprehensive Sync/Materials/page-video.mp4 | https://moodle.rwth-aachen.de/pluginfile.php/104/mod_page/content/315/page-video.mp4 |  | 
 Youtube | 26ss/Comprehensive Sync/Materials/Youtube: Page module | https://www.youtube.com/watch?v=pagevideo01 |  | 
 Youtube | 26ss/Comprehensive Sync/Materials/Youtube: Label module | https://youtu.be/labelvid001 |  | 

--- a/tests/snapshots/mixed_course_tree.txt
+++ b/tests/snapshots/mixed_course_tree.txt
@@ -11,7 +11,7 @@ Assignment | 26ss/Comprehensive Sync/Materials/Essay upload |  |  |
 Assignment File | 26ss/Comprehensive Sync/Materials/Essay upload/essay-template.docx | https://moodle.rwth-aachen.de/pluginfile.php/104/mod_assign/introattachment/essay-template.docx | 1710000105 | 
 Folder | 26ss/Comprehensive Sync/Materials/Essay upload/Feedback |  |  | 
 Assignment File | 26ss/Comprehensive Sync/Materials/Essay upload/Feedback/feedback.txt | https://moodle.rwth-aachen.de/pluginfile.php/104/mod_assign/feedback/feedback.txt | 1710000106 | 
-Linked file [application/pdf] | 26ss/Comprehensive Sync/Materials/direct.pdf | https://files.example.test/direct.pdf |  | 
+Linked file [application/pdf] | 26ss/Comprehensive Sync/Materials/direct.pdf | https://files.example.test/direct.pdf |  | "direct-file-v1"
 Youtube | 26ss/Comprehensive Sync/Materials/Youtube: External HTML page | https://www.youtube.com/watch?v=directvid01 |  | 
 Opencast | 26ss/Comprehensive Sync/Materials/Page module | https://video.example.test/33333333-4444-4555-8666-777777777777/presentation.mp4 |  | 
 Embedded videojs | 26ss/Comprehensive Sync/Materials/page-video.mp4 | https://moodle.rwth-aachen.de/pluginfile.php/104/mod_page/content/315/page-video.mp4 |  | 

--- a/tests/snapshots/opencast_lti_tree.txt
+++ b/tests/snapshots/opencast_lti_tree.txt
@@ -1,7 +1,7 @@
 Semester | 26ss |  |  | 
 Course | 26ss/(VO) Data Science |  |  | 
 Section | 26ss/(VO) Data Science/Opencast |  |  | 
-Opencast | 26ss/(VO) Data Science/Opencast/Single recording | https://video.example.test/opencast/single-high.mp4 |  | 
+Opencast | 26ss/(VO) Data Science/Opencast/Single recording | https://video.example.test/opencast/single-high.mp4 |  | 22222222222222222222222222222222
 Section | 26ss/(VO) Data Science/Series recordings |  |  | 
-Opencast | 26ss/(VO) Data Science/Series recordings/Series episode A | https://video.example.test/opencast/series-a.mp4 |  | 
-Opencast | 26ss/(VO) Data Science/Series recordings/Series episode B | https://video.example.test/opencast/series-b.mp4 |  | 
+Opencast | 26ss/(VO) Data Science/Series recordings/Series episode A | https://video.example.test/opencast/series-a.mp4 |  | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+Opencast | 26ss/(VO) Data Science/Series recordings/Series episode B | https://video.example.test/opencast/series-b.mp4 |  | bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb

--- a/tests/test_download_behavior.py
+++ b/tests/test_download_behavior.py
@@ -16,10 +16,22 @@ from .helpers import (
 URL = (
     "https://moodle.rwth-aachen.de/pluginfile.php/301/mod_resource/content/1/slides.pdf"
 )
+DUPLICATE_SECTION_URL_A = (
+    "https://moodle.rwth-aachen.de/pluginfile.php/501/mod_resource/content/1/"
+    "Case%20Study%20Sezen.pdf"
+)
+DUPLICATE_SECTION_URL_B = (
+    "https://moodle.rwth-aachen.de/pluginfile.php/502/mod_resource/content/1/"
+    "Case%20Study%20Sezen.pdf"
+)
 
 
 def sha1(data: bytes) -> str:
     return hashlib.sha1(data).hexdigest()
+
+
+def sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
 
 
 def seed_course_cache(config, *, timemodified, etag, is_downloaded=True):
@@ -38,12 +50,39 @@ def seed_course_cache(config, *, timemodified, etag, is_downloaded=True):
     course_cache.cache_root_node(cache_syncer)
 
 
-def make_run_syncer(config, *, timemodified):
+def make_run_syncer(config, *, timemodified, etag=None):
     """Return a syncer plus the leaf node for the current (changed) sync run."""
     syncer = make_context(config)
     syncer.session = FakeSession()
-    _, file_node = build_single_file_tree("slides.pdf", URL, timemodified=timemodified)
+    _, file_node = build_single_file_tree(
+        "slides.pdf", URL, timemodified=timemodified, etag=etag
+    )
     return syncer, file_node
+
+
+def build_duplicate_section_file_tree():
+    root = Node("", -1, "Root", None)
+    semester = root.add_child("26ss", None, "Semester")
+    course = semester.add_child("Duplicate Section Course", 301, "Course")
+    first_section = course.add_child("Case Study", 501, "Section")
+    first_file = first_section.add_child(
+        "Case Study Sezen.pdf",
+        DUPLICATE_SECTION_URL_A,
+        "Linked file [application/pdf]",
+        url=DUPLICATE_SECTION_URL_A,
+        timemodified=100,
+        name_clash_id=None,
+    )
+    second_section = course.add_child("Case Study", 502, "Section")
+    second_file = second_section.add_child(
+        "Case Study Sezen.pdf",
+        DUPLICATE_SECTION_URL_B,
+        "Linked file [application/pdf]",
+        url=DUPLICATE_SECTION_URL_B,
+        timemodified=200,
+        name_clash_id=None,
+    )
+    return root, first_file, second_file
 
 
 # --------------------------------------------------------------------------
@@ -258,6 +297,58 @@ def test_successful_previous_download_with_same_timemodified_is_skipped(tmp_path
 
     assert download_file(syncer, file_node) is True
     assert syncer.session.calls == []
+
+
+def test_unchanged_linked_file_etag_skips_download(tmp_path):
+    # Direct linked files do not have Moodle timemodified metadata. The HEAD
+    # ETag discovered while scanning is their remote version marker, so an
+    # unchanged ETag must suppress the GET on later runs.
+    config = {"basedir": str(tmp_path), "updatefiles": True}
+    etag = '"linked-file-v1"'
+    content = b"already downloaded linked file"
+    seed_course_cache(config, timemodified=None, etag=etag, is_downloaded=True)
+    syncer, file_node = make_run_syncer(config, timemodified=None, etag=etag)
+    download_path = node_path(syncer, file_node)
+    download_path.parent.mkdir(parents=True, exist_ok=True)
+    download_path.write_bytes(content)
+
+    assert download_file(syncer, file_node) is True
+    assert syncer.session.calls == []
+    assert download_path.read_bytes() == content
+
+
+def test_unchanged_duplicate_section_file_uses_matching_cache_node(tmp_path):
+    # Some Moodle courses contain duplicate same-named sections that collapse
+    # onto the same local directory. Cache lookup must still match the section
+    # by its stable id, otherwise the second section can inherit timestamps from
+    # the first and re-download unchanged files as false conflicts.
+    config = {"basedir": str(tmp_path), "updatefiles": True}
+    content = b"same case study pdf bytes"
+
+    cached_root, cached_first, cached_second = build_duplicate_section_file_tree()
+    cached_first.is_downloaded = True
+    cached_second.is_downloaded = True
+    cached_second.content_hash = sha256(content)
+    cache_syncer = make_context(config)
+    cache_syncer.root_node = cached_root
+    course_cache.cache_root_node(cache_syncer)
+
+    syncer = make_context(config)
+    syncer.session = FakeSession()
+    _, _, current_second = build_duplicate_section_file_tree()
+    download_path = node_path(syncer, current_second)
+    download_path.parent.mkdir(parents=True, exist_ok=True)
+    download_path.write_bytes(content)
+    os.utime(download_path, (200, 200))
+
+    old_node = course_cache.get_old_node_for(syncer, current_second)
+    assert old_node is not None
+    assert old_node.url == DUPLICATE_SECTION_URL_B
+
+    assert download_file(syncer, current_second) is True
+    assert syncer.session.calls == []
+    assert list(download_path.parent.glob("*.syncconflict.*")) == []
+    assert download_path.read_bytes() == content
 
 
 def test_etag_failure_falls_back_to_timestamp_heuristic_conflict(tmp_path, monkeypatch):
@@ -489,7 +580,7 @@ def test_unrecognized_partial_without_sidecar_is_not_resumed(tmp_path):
 SCIEBO_URL = "https://rwth-aachen.sciebo.de/public.php/webdav/notes.pdf"
 
 
-def _sciebo_tree(etag, is_downloaded=False):
+def _sciebo_tree(etag, is_downloaded=False, content_hash=None):
     root = Node("", -1, "Root", None)
     semester = root.add_child("26ss", None, "Semester")
     course = semester.add_child("Download Course", 301, "Course")
@@ -503,18 +594,26 @@ def _sciebo_tree(etag, is_downloaded=False):
         etag=etag,
     )
     file_node.is_downloaded = is_downloaded
+    file_node.content_hash = content_hash
     return root, file_node
 
 
-def _seed_sciebo_cache(config, etag, content):
+def _seed_sciebo_cache(config, etag, content, content_hash=None):
     cache_syncer = make_context(config)
-    root, file_node = _sciebo_tree(etag, is_downloaded=True)
+    root, file_node = _sciebo_tree(etag, is_downloaded=True, content_hash=content_hash)
     cache_syncer.root_node = root
     course_cache.cache_root_node(cache_syncer)
     download_path = node_path(make_context(config), file_node)
     download_path.parent.mkdir(parents=True, exist_ok=True)
     download_path.write_bytes(content)
     return download_path
+
+
+# An opaque Nextcloud/WebDAV revision token (what Sciebo returns for files that
+# have no oc:checksums entry). It is NOT a content hash, so it cannot be used to
+# verify local file contents.
+GETETAG_V1 = '"665f1a2b3c4d5"'
+GETETAG_V2 = '"67a09e8d7c6b5"'
 
 
 def test_sciebo_changed_etag_triggers_redownload(tmp_path):
@@ -549,6 +648,123 @@ def test_sciebo_unchanged_etag_skips_download(tmp_path):
     assert download_file(syncer, current) is True
     assert syncer.session.calls == []
     assert download_path.read_bytes() == content
+
+
+def test_sciebo_unchanged_opaque_getetag_skips_without_conflict(tmp_path):
+    # Regression: files without oc:checksums fall back to an opaque getetag,
+    # which is not a content hash. An unchanged getetag must skip cleanly rather
+    # than re-download and move the identical local copy aside as a conflict on
+    # every run.
+    config = {"basedir": str(tmp_path), "updatefiles": True}
+    content = b"post-quantum notes"
+    download_path = _seed_sciebo_cache(config, GETETAG_V1, content)
+    syncer = make_context(config)
+    syncer.session = FakeSession()
+    _, current = _sciebo_tree(GETETAG_V1)  # same opaque getetag
+
+    assert download_file(syncer, current) is True
+    assert syncer.session.calls == []
+    assert download_path.read_bytes() == content
+    assert list(download_path.parent.glob("*.syncconflict.*")) == []
+
+
+def test_sciebo_download_records_content_hash(tmp_path):
+    # A fresh download stores a sha256 of exactly the bytes we wrote, so later
+    # runs can detect local edits even though the ETag is opaque.
+    config = {"basedir": str(tmp_path), "updatefiles": True}
+    download_path = _seed_sciebo_cache(config, GETETAG_V1, b"old")
+    syncer = make_context(config)
+    syncer.session = FakeSession()
+    new = b"new content"
+    syncer.session.add(
+        "GET",
+        SCIEBO_URL,
+        FakeResponse(headers={"Content-Type": "application/pdf"}, chunks=[new]),
+    )
+    _, current = _sciebo_tree(GETETAG_V2)  # remote changed (opaque etag differs)
+
+    assert download_file(syncer, current) is True
+    assert download_path.read_bytes() == new
+    assert current.content_hash == sha256(new)
+
+
+def test_sciebo_download_keeps_propfind_etag_when_get_etag_differs(tmp_path):
+    # The next sync discovers Sciebo files through PROPFIND again, so the
+    # cached version marker must stay comparable to the PROPFIND value. Some
+    # WebDAV downloads return a different GET ETag for the same file.
+    config = {"basedir": str(tmp_path), "updatefiles": True}
+    download_path = _seed_sciebo_cache(config, GETETAG_V1, b"old")
+    syncer = make_context(config)
+    syncer.session = FakeSession()
+    new = b"new content"
+    syncer.session.add(
+        "GET",
+        SCIEBO_URL,
+        FakeResponse(
+            headers={
+                "Content-Type": "application/pdf",
+                "ETag": '"different-get-etag"',
+            },
+            chunks=[new],
+        ),
+    )
+    _, current = _sciebo_tree(GETETAG_V2)
+
+    assert download_file(syncer, current) is True
+    assert download_path.read_bytes() == new
+    assert current.etag == GETETAG_V2
+    assert current.content_hash == sha256(new)
+
+
+def test_sciebo_changed_getetag_without_local_edit_overwrites_cleanly(tmp_path):
+    # Remote changed but the user did not touch the local file (it matches the
+    # stored content hash): overwrite without a spurious conflict copy.
+    config = {"basedir": str(tmp_path), "updatefiles": True}
+    original = b"our downloaded copy"
+    download_path = _seed_sciebo_cache(
+        config, GETETAG_V1, original, content_hash=sha256(original)
+    )
+    syncer = make_context(config)
+    syncer.session = FakeSession()
+    new = b"remote v2"
+    syncer.session.add(
+        "GET",
+        SCIEBO_URL,
+        FakeResponse(headers={"Content-Type": "application/pdf"}, chunks=[new]),
+    )
+    _, current = _sciebo_tree(GETETAG_V2)
+
+    assert download_file(syncer, current) is True
+    assert download_path.read_bytes() == new
+    assert list(download_path.parent.glob("*.syncconflict.*")) == []
+
+
+def test_sciebo_changed_getetag_with_local_edit_preserves_conflict(tmp_path):
+    # Remote changed AND the user edited the local file (it no longer matches the
+    # stored content hash): preserve the user's version as a conflict copy.
+    config = {"basedir": str(tmp_path), "updatefiles": True}
+    original = b"our downloaded copy"
+    download_path = _seed_sciebo_cache(
+        config, GETETAG_V1, original, content_hash=sha256(original)
+    )
+    edited = b"user edited this locally"
+    download_path.write_bytes(edited)
+
+    syncer = make_context(config)
+    syncer.session = FakeSession()
+    new = b"remote v2"
+    syncer.session.add(
+        "GET",
+        SCIEBO_URL,
+        FakeResponse(headers={"Content-Type": "application/pdf"}, chunks=[new]),
+    )
+    _, current = _sciebo_tree(GETETAG_V2)
+
+    assert download_file(syncer, current) is True
+    assert download_path.read_bytes() == new
+    conflicts = list(download_path.parent.glob("*.syncconflict.*"))
+    assert len(conflicts) == 1
+    assert conflicts[0].read_bytes() == edited
 
 
 # --------------------------------------------------------------------------
@@ -588,6 +804,41 @@ def test_cache_preserves_markers_for_failed_download_over_existing_file(tmp_path
     # The cache keeps the on-disk version's markers, not Moodle's new ones.
     assert cached_file.timemodified == 100
     assert cached_file.etag == sha1(v1)
+    assert cached_file.is_downloaded is True
+
+
+def test_cache_preserves_content_hash_for_skipped_existing_file(tmp_path):
+    config = {"basedir": str(tmp_path), "updatefiles": True}
+    v1 = b"version one"
+    v1_hash = sha256(v1)
+    cache_syncer = make_context(config)
+    cached_root, cached_file = build_single_file_tree(
+        "slides.pdf", URL, timemodified=100, etag='"v1"'
+    )
+    cached_file.is_downloaded = True
+    cached_file.content_hash = v1_hash
+    cache_syncer.root_node = cached_root
+    course_cache.cache_root_node(cache_syncer)
+    download_path = node_path(make_context(config), cached_file)
+    download_path.parent.mkdir(parents=True, exist_ok=True)
+    download_path.write_bytes(v1)
+
+    # The download walk marks an unchanged existing file as handled even though
+    # no bytes were replaced. Cache writing must keep the previous content hash
+    # so a later remote change can still detect local edits precisely.
+    syncer = make_context(config)
+    root, file_node = build_single_file_tree(
+        "slides.pdf", URL, timemodified=100, etag='"v1"'
+    )
+    file_node.is_downloaded = True
+    syncer.downloaded_paths = set()
+    syncer.root_node = root
+    course_cache.cache_root_node(syncer)
+
+    cached_file = _cached_file_node(config, root.children[0].children[0])
+    assert cached_file.timemodified == 100
+    assert cached_file.etag == '"v1"'
+    assert cached_file.content_hash == v1_hash
     assert cached_file.is_downloaded is True
 
 

--- a/tests/test_download_behavior.py
+++ b/tests/test_download_behavior.py
@@ -317,6 +317,91 @@ def test_unchanged_linked_file_etag_skips_download(tmp_path):
     assert download_path.read_bytes() == content
 
 
+def test_get_only_etag_304_skips_download(tmp_path):
+    # Legacy Opencast/embedded nodes may only have the ETag discovered during
+    # the previous GET. If the current scan cannot provide a marker, validate
+    # the cached ETag with If-None-Match before re-downloading.
+    config = {"basedir": str(tmp_path), "updatefiles": True}
+    etag = '"opencast-v1"'
+    content = b"already downloaded video"
+    seed_course_cache(config, timemodified=None, etag=etag, is_downloaded=True)
+    syncer, file_node = make_run_syncer(config, timemodified=None, etag=None)
+    download_path = node_path(syncer, file_node)
+    download_path.parent.mkdir(parents=True, exist_ok=True)
+    download_path.write_bytes(content)
+    seen_headers = []
+
+    def unchanged(url, kwargs):
+        del url
+        seen_headers.append(kwargs.get("headers", {}).copy())
+        return FakeResponse(status_code=304, headers={"ETag": etag})
+
+    syncer.session.add("GET", URL, unchanged)
+
+    assert download_file(syncer, file_node) is True
+    assert syncer.session.count("GET", URL) == 1
+    assert seen_headers == [{"If-None-Match": etag}]
+    assert file_node.etag == etag
+    assert download_path.read_bytes() == content
+
+
+def test_get_only_etag_same_200_skips_download(tmp_path):
+    # Some servers ignore If-None-Match but still return the same ETag on a 200
+    # response. Closing that streamed response without reading the body avoids
+    # a needless full re-download.
+    config = {"basedir": str(tmp_path), "updatefiles": True}
+    etag = '"video-v1"'
+    content = b"already downloaded video"
+    seed_course_cache(config, timemodified=None, etag=etag, is_downloaded=True)
+    syncer, file_node = make_run_syncer(config, timemodified=None, etag=None)
+    download_path = node_path(syncer, file_node)
+    download_path.parent.mkdir(parents=True, exist_ok=True)
+    download_path.write_bytes(content)
+    syncer.session.add(
+        "GET",
+        URL,
+        FakeResponse(
+            headers={"Content-Type": "video/mp4", "ETag": etag},
+            chunks=[b"same remote body that should not be read"],
+        ),
+    )
+
+    assert download_file(syncer, file_node) is True
+    assert syncer.session.count("GET", URL) == 1
+    assert file_node.etag == etag
+    assert download_path.read_bytes() == content
+
+
+def test_get_only_etag_changed_200_downloads_update(tmp_path):
+    config = {"basedir": str(tmp_path), "updatefiles": True}
+    original = b"already downloaded video"
+    old_etag = sha1(original)
+    new_etag = '"video-v2"'
+    seed_course_cache(config, timemodified=None, etag=old_etag, is_downloaded=True)
+    syncer, file_node = make_run_syncer(config, timemodified=None, etag=None)
+    download_path = node_path(syncer, file_node)
+    download_path.parent.mkdir(parents=True, exist_ok=True)
+    download_path.write_bytes(original)
+    responses = [
+        FakeResponse(headers={"Content-Type": "video/mp4", "ETag": new_etag}),
+        FakeResponse(
+            headers={"Content-Type": "video/mp4", "ETag": new_etag},
+            chunks=[b"new remote video"],
+        ),
+    ]
+
+    def changed(url, kwargs):
+        del url, kwargs
+        return responses.pop(0)
+
+    syncer.session.add("GET", URL, changed)
+
+    assert download_file(syncer, file_node) is True
+    assert syncer.session.count("GET", URL) == 2
+    assert file_node.etag == new_etag
+    assert download_path.read_bytes() == b"new remote video"
+
+
 def test_unchanged_duplicate_section_file_uses_matching_cache_node(tmp_path):
     # Some Moodle courses contain duplicate same-named sections that collapse
     # onto the same local directory. Cache lookup must still match the section

--- a/tests/test_sync_fixtures.py
+++ b/tests/test_sync_fixtures.py
@@ -248,7 +248,9 @@ def test_mixed_course_sync_tree_covers_common_module_surfaces(monkeypatch):
     session.add(
         "HEAD",
         direct_pdf,
-        FakeResponse(headers={"Content-Type": "application/pdf"}),
+        FakeResponse(
+            headers={"Content-Type": "application/pdf", "ETag": '"direct-file-v1"'}
+        ),
     )
     session.add(
         "HEAD",

--- a/tests/test_sync_fixtures.py
+++ b/tests/test_sync_fixtures.py
@@ -59,9 +59,13 @@ def test_assignment_intro_opencast_embed_is_added_to_assignment_node(monkeypatch
     )
     monkeypatch.setattr(
         opencast,
-        "extract_track_from_episode",
+        "resolve_track_from_episode",
         lambda ctx, episode_id, *a, **k: (
-            f"https://video.example.test/{episode_id}/presentation.mp4"
+            opencast.OpencastTrack(
+                f"https://video.example.test/{episode_id}/presentation.mp4",
+                checksum_type="md5",
+                checksum="11111111111111111111111111111111",
+            )
         ),
     )
 
@@ -283,9 +287,13 @@ def test_mixed_course_sync_tree_covers_common_module_surfaces(monkeypatch):
     )
     monkeypatch.setattr(
         opencast,
-        "extract_track_from_episode",
+        "resolve_track_from_episode",
         lambda ctx, episode_id, *a, **k: (
-            f"https://video.example.test/{episode_id}/presentation.mp4"
+            opencast.OpencastTrack(
+                f"https://video.example.test/{episode_id}/presentation.mp4",
+                checksum_type="md5",
+                checksum="33333333333333333333333333333333",
+            )
         ),
     )
 


### PR DESCRIPTION
Fixes repeated re-downloads and false local-conflict handling for unchanged files.

This improves cache/change detection for Moodle files, Sciebo files, linked files, Opencast videos, and embedded videojs nodes. It preserves valid cached markers for skipped files, avoids poisoning the cache after failed downloads, stores content hashes for downloaded bytes, handles duplicate same-named sections more reliably, uses Opencast checksums and conditional GET validation where available.

Adds regression tests for unchanged-file skips, failed-download retries, Sciebo marker handling, duplicate sections, and Opencast/videojs ETag fallback.