### PR TITLE
Refactor download decisions and cache metadata

### DIFF
--- a/syncmymoodle/config.py
+++ b/syncmymoodle/config.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import copy
+from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Any, Mapping
+from typing import Any, TypeAlias
+
+PatternConfig: TypeAlias = dict[str, list[str]]
 
 # Default module toggle tree used when the config file does not define one.
 DEFAULT_USED_MODULES: dict[str, Any] = {
@@ -11,6 +14,27 @@ DEFAULT_USED_MODULES: dict[str, Any] = {
     "url": {"youtube": True, "opencast": True, "sciebo": True, "quiz": False},
     "folder": True,
 }
+
+
+def as_string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        values = value
+    else:
+        values = [value]
+    return [str(item) for item in values if item is not None]
+
+
+def normalize_pattern_config(value: Any) -> PatternConfig:
+    if isinstance(value, Mapping):
+        return {
+            str(key): patterns
+            for key, raw_patterns in value.items()
+            if (patterns := as_string_list(raw_patterns))
+        }
+    patterns = as_string_list(value)
+    return {"*": patterns} if patterns else {}
 
 
 @dataclass
@@ -39,18 +63,16 @@ class Config:
     update_files_conflict: str = "rename"
 
     # Course/semester selection
-    selected_courses: list[Any] = field(default_factory=list)
-    skip_courses: list[Any] = field(default_factory=list)
-    only_sync_semester: list[Any] = field(default_factory=list)
+    selected_courses: list[str] = field(default_factory=list)
+    skip_courses: list[str] = field(default_factory=list)
+    only_sync_semester: list[str] = field(default_factory=list)
 
-    # Exclusions. exclude_links/sections/modules and allowed_domains may be
-    # either a flat list or a per-course dict ({"*": [...], "<id>": [...]}).
-    exclude_filetypes: list[Any] = field(default_factory=list)
-    exclude_files: list[Any] = field(default_factory=list)
-    exclude_links: Any = field(default_factory=list)
-    allowed_domains: Any = field(default_factory=list)
-    exclude_sections: Any = field(default_factory=list)
-    exclude_modules: Any = field(default_factory=list)
+    exclude_filetypes: list[str] = field(default_factory=list)
+    exclude_files: list[str] = field(default_factory=list)
+    exclude_links: PatternConfig = field(default_factory=dict)
+    allowed_domains: PatternConfig = field(default_factory=dict)
+    exclude_sections: PatternConfig = field(default_factory=dict)
+    exclude_modules: PatternConfig = field(default_factory=dict)
 
     # Module toggle tree (see DEFAULT_USED_MODULES).
     used_modules: dict[str, Any] = field(default_factory=dict)
@@ -77,17 +99,19 @@ class Config:
             nolinks=bool(raw.get("nolinks", raw.get("no_links", False))),
             updatefiles=bool(raw.get("updatefiles", raw.get("update_files", False))),
             update_files_conflict=raw.get("update_files_conflict") or "rename",
-            selected_courses=raw.get("selected_courses") or [],
-            skip_courses=raw.get("skip_courses") or [],
-            only_sync_semester=raw.get("only_sync_semester") or [],
-            exclude_filetypes=raw.get("exclude_filetypes") or [],
-            exclude_files=raw.get("exclude_files") or [],
-            exclude_links=raw.get("exclude_links") or [],
-            allowed_domains=raw.get("allowed_domains") or [],
-            exclude_sections=raw.get("exclude_sections", raw.get("skip_sections", []))
-            or [],
-            exclude_modules=raw.get("exclude_modules", raw.get("skip_modules", []))
-            or [],
+            selected_courses=as_string_list(raw.get("selected_courses")),
+            skip_courses=as_string_list(raw.get("skip_courses")),
+            only_sync_semester=as_string_list(raw.get("only_sync_semester")),
+            exclude_filetypes=as_string_list(raw.get("exclude_filetypes")),
+            exclude_files=as_string_list(raw.get("exclude_files")),
+            exclude_links=normalize_pattern_config(raw.get("exclude_links")),
+            allowed_domains=normalize_pattern_config(raw.get("allowed_domains")),
+            exclude_sections=normalize_pattern_config(
+                raw.get("exclude_sections", raw.get("skip_sections"))
+            ),
+            exclude_modules=normalize_pattern_config(
+                raw.get("exclude_modules", raw.get("skip_modules"))
+            ),
             used_modules=used_modules,
         )
 

--- a/syncmymoodle/constants.py
+++ b/syncmymoodle/constants.py
@@ -4,6 +4,10 @@ import re
 INVALID_CHARS = '~"#%&*:<>?/\\{|}'
 
 YOUTUBE_ID_LENGTH = 11
+HASH_ALGOS_BY_LENGTH = {32: "md5", 40: "sha1", 64: "sha256"}
+CHECKSUM_LENGTHS_BY_ALGO = {
+    algo: length for length, algo in HASH_ALGOS_BY_LENGTH.items()
+}
 YOUTUBE_LINK_RE = re.compile(
     r"(https?://(www\.)?(youtube\.com/(watch\?[a-zA-Z0-9_=&-]*v=|embed/)|youtu.be/).{11})"
 )

--- a/syncmymoodle/context.py
+++ b/syncmymoodle/context.py
@@ -28,7 +28,7 @@ class SyncContext:
     sciebo_link_cache: dict[str, Node] = field(default_factory=dict)
     opencast_episode_auth_cache: set[tuple[Any, str]] = field(default_factory=set)
     opencast_track_cache: dict[str, OpencastTrack] = field(default_factory=dict)
-    downloaded_paths: set[Path] | None = None
+    downloaded_paths: set[Path] = field(default_factory=set)
 
     def require_session(self) -> requests.Session:
         """Return the active session, or raise if login() has not run yet."""

--- a/syncmymoodle/course_cache.py
+++ b/syncmymoodle/course_cache.py
@@ -88,6 +88,10 @@ def node_to_cache_data(
 
 
 def node_from_cache_data(data: dict[str, Any], parent: Node | None = None) -> Node:
+    download_status = data.get("download_status")
+    legacy_is_downloaded = download_status is None and bool(
+        data.get("is_downloaded", False)
+    )
     node = Node(
         data.get("name", ""),
         data.get("id"),
@@ -99,7 +103,8 @@ def node_from_cache_data(data: dict[str, Any], parent: Node | None = None) -> No
         etag_kind=data.get("etag_kind"),
         content_hash=data.get("content_hash"),
         name_clash_id=data.get("name_clash_id", NAME_CLASH_ID_UNSET),
-        download_status=data.get("download_status"),
+        download_status=download_status,
+        is_downloaded=legacy_is_downloaded,
     )
     node.children = [
         node_from_cache_data(child, node)

--- a/syncmymoodle/course_cache.py
+++ b/syncmymoodle/course_cache.py
@@ -3,7 +3,11 @@ from pathlib import Path
 from typing import Any
 
 from syncmymoodle.context import SyncContext
-from syncmymoodle.node import NAME_CLASH_ID_UNSET, Node
+from syncmymoodle.node import (
+    NAME_CLASH_ID_UNSET,
+    DownloadStatus,
+    Node,
+)
 from syncmymoodle.pathing import get_sanitized_node_path
 from syncmymoodle.storage import read_private_gzip_json, write_private_gzip_json
 
@@ -42,12 +46,11 @@ def node_to_cache_data(
 ) -> dict[str, Any]:
     timemodified = node.timemodified
     etag = node.etag
+    etag_kind = node.etag_kind
     content_hash = getattr(node, "content_hash", None)
-    is_downloaded = node.is_downloaded
+    is_handled = node.is_handled
     node_path = _node_path(ctx, node)
-    downloaded_this_run = (
-        ctx.downloaded_paths is not None and node_path in ctx.downloaded_paths
-    )
+    downloaded_this_run = node_path in ctx.downloaded_paths
     # If this file was not actually downloaded this run but a previously
     # downloaded version is still on disk, keep the previously cached version
     # markers. The node may still be marked is_downloaded=True when download
@@ -56,13 +59,14 @@ def node_to_cache_data(
     if (
         not downloaded_this_run
         and old_node is not None
-        and getattr(old_node, "is_downloaded", False)
+        and old_node.is_handled
         and node_path.exists()
     ):
         timemodified = getattr(old_node, "timemodified", None)
         etag = getattr(old_node, "etag", None)
+        etag_kind = getattr(old_node, "etag_kind", None)
         content_hash = getattr(old_node, "content_hash", None)
-        is_downloaded = True
+        is_handled = True
     return {
         "name": node.name,
         "id": node.id,
@@ -70,9 +74,13 @@ def node_to_cache_data(
         "url": node.url,
         "timemodified": timemodified,
         "etag": etag,
+        "etag_kind": str(etag_kind) if etag_kind else None,
         "content_hash": content_hash,
         "name_clash_id": node.name_clash_id,
-        "is_downloaded": is_downloaded,
+        "download_status": str(
+            DownloadStatus.HANDLED if is_handled else DownloadStatus.PENDING
+        ),
+        "is_downloaded": is_handled,
         "children": [
             node_to_cache_data(ctx, child, match_old_cache_child(old_node, child))
             for child in node.children
@@ -89,8 +97,10 @@ def node_from_cache_data(data: dict[str, Any], parent: Node | None = None) -> No
         url=data.get("url"),
         timemodified=data.get("timemodified"),
         etag=data.get("etag"),
+        etag_kind=data.get("etag_kind"),
         content_hash=data.get("content_hash"),
         name_clash_id=data.get("name_clash_id", NAME_CLASH_ID_UNSET),
+        download_status=data.get("download_status"),
         is_downloaded=data.get("is_downloaded", False),
     )
     node.children = [
@@ -107,10 +117,17 @@ def ensure_timemodified_attribute(node: Node) -> None:
         node.timemodified = None
     if not hasattr(node, "etag"):
         node.etag = None
+    if not hasattr(node, "etag_kind"):
+        node.etag_kind = None
     if not hasattr(node, "content_hash"):
         node.content_hash = None
     if not hasattr(node, "name_clash_id"):
         node.name_clash_id = getattr(node, "id", None)
+    if "download_status" not in node.__dict__:
+        legacy_is_downloaded = bool(node.__dict__.pop("is_downloaded", False))
+        node.download_status = (
+            DownloadStatus.HANDLED if legacy_is_downloaded else DownloadStatus.PENDING
+        )
     for child in getattr(node, "children", []):
         ensure_timemodified_attribute(child)
 

--- a/syncmymoodle/course_cache.py
+++ b/syncmymoodle/course_cache.py
@@ -53,9 +53,9 @@ def node_to_cache_data(
     downloaded_this_run = node_path in ctx.downloaded_paths
     # If this file was not actually downloaded this run but a previously
     # downloaded version is still on disk, keep the previously cached version
-    # markers. The node may still be marked is_downloaded=True when download
-    # traversal skipped an unchanged existing file; downloaded_paths tells us
-    # whether bytes were really replaced in this run.
+    # markers. The node may still be marked as handled when download traversal
+    # skipped an unchanged existing file; downloaded_paths tells us whether
+    # bytes were really replaced in this run.
     if (
         not downloaded_this_run
         and old_node is not None
@@ -80,7 +80,6 @@ def node_to_cache_data(
         "download_status": str(
             DownloadStatus.HANDLED if is_handled else DownloadStatus.PENDING
         ),
-        "is_downloaded": is_handled,
         "children": [
             node_to_cache_data(ctx, child, match_old_cache_child(old_node, child))
             for child in node.children
@@ -101,7 +100,6 @@ def node_from_cache_data(data: dict[str, Any], parent: Node | None = None) -> No
         content_hash=data.get("content_hash"),
         name_clash_id=data.get("name_clash_id", NAME_CLASH_ID_UNSET),
         download_status=data.get("download_status"),
-        is_downloaded=data.get("is_downloaded", False),
     )
     node.children = [
         node_from_cache_data(child, node)
@@ -123,11 +121,6 @@ def ensure_timemodified_attribute(node: Node) -> None:
         node.content_hash = None
     if not hasattr(node, "name_clash_id"):
         node.name_clash_id = getattr(node, "id", None)
-    if "download_status" not in node.__dict__:
-        legacy_is_downloaded = bool(node.__dict__.pop("is_downloaded", False))
-        node.download_status = (
-            DownloadStatus.HANDLED if legacy_is_downloaded else DownloadStatus.PENDING
-        )
     for child in getattr(node, "children", []):
         ensure_timemodified_attribute(child)
 

--- a/syncmymoodle/downloader.py
+++ b/syncmymoodle/downloader.py
@@ -4,6 +4,8 @@ import os
 import re
 import urllib.parse
 from contextlib import closing
+from dataclasses import dataclass
+from enum import Enum
 from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import Any
@@ -19,34 +21,46 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_BLOCK_SIZE = 1024
 
+_HASH_ALGOS_BY_LENGTH = {32: "md5", 40: "sha1", 64: "sha256"}
 
-def local_file_matches_etag(path: Path, etag: str) -> bool:
-    """Return True if the local file content matches the given ETag hash.
 
-    We currently support strong ETags that contain a plain hex digest for MD5
-    (32 chars), SHA1 (40 chars) or SHA256 (64 chars). Other formats are
-    ignored and treated as non-matching.
+class FileMatch(Enum):
+    """Comparison result for a local file and a remote version marker."""
+
+    MATCH = "match"
+    DIFFER = "differ"
+    UNKNOWN = "unknown"
+
+
+class LocalCopyState(Enum):
+    """State of the existing local file when the remote may have changed."""
+
+    UP_TO_DATE = "up_to_date"
+    CLEAN = "clean"
+    MODIFIED = "modified"
+
+
+def classify_local_file(path: Path, marker: str | None) -> FileMatch:
+    """Compare a local file against a remote ``marker``.
+
+    Only strong markers carrying a plain MD5/SHA1/SHA256 hex digest can verify
+    content. Opaque, missing, or unreadable markers are UNKNOWN.
     """
-    # Extract a plausible hex digest from the ETag value, ignoring weak
-    # prefixes (W/) and surrounding quotes or algorithm markers.
-    match = re.search(r"([0-9a-fA-F]{32,64})", etag)
+    if not marker:
+        return FileMatch.UNKNOWN
+    match = re.search(r"([0-9a-fA-F]{32,64})", str(marker))
     if not match:
-        return False
+        return FileMatch.UNKNOWN
     hex_str = match.group(1).lower()
-
-    algo = None
-    if len(hex_str) == 32:
-        algo = "md5"
-    elif len(hex_str) == 40:
-        algo = "sha1"
-    elif len(hex_str) == 64:
-        algo = "sha256"
-    else:
-        return False
-
-    with path.open("rb") as f:
-        digest = hashlib.file_digest(f, algo)
-        return digest.hexdigest() == hex_str
+    algo = _HASH_ALGOS_BY_LENGTH.get(len(hex_str))
+    if algo is None:
+        return FileMatch.UNKNOWN
+    try:
+        with path.open("rb") as f:
+            digest = hashlib.file_digest(f, algo).hexdigest()
+    except OSError:
+        return FileMatch.UNKNOWN
+    return FileMatch.MATCH if digest == hex_str else FileMatch.DIFFER
 
 
 def content_type_without_parameters(response: Any) -> str:
@@ -138,10 +152,122 @@ def conditional_get_confirms_unchanged(
                 node.etag = response_etag
                 return True
     except Exception as exc:
-        # A routine transient (timeout, reset) shouldn't spam a stack trace; we
-        # simply fall back to a normal download below.
         log.warning("Failed to validate cached ETag for %s: %s", node.url, exc)
     return False
+
+
+@dataclass
+class DownloadDecision:
+    """Outcome of the change-detection step for a single file."""
+
+    skip: bool
+    conflict: bool = False
+
+
+def remote_unchanged(
+    ctx: SyncContext,
+    node: Any,
+    old_node: Any,
+    cached_timemodified: Any,
+    log: logging.Logger = logger,
+) -> bool:
+    """Whether the remote file is provably unchanged since our last download."""
+    old_etag = getattr(old_node, "etag", None)
+    node_etag = getattr(node, "etag", None)
+
+    if cached_timemodified is not None:
+        return bool(node.timemodified == cached_timemodified)
+
+    if old_etag and node_etag == old_etag:
+        return True
+    if (
+        old_etag
+        and node_etag is None
+        and conditional_get_confirms_unchanged(ctx, node, old_etag, log)
+    ):
+        return True
+    return False
+
+
+def assess_local_copy(
+    ctx: SyncContext,
+    node: Any,
+    downloadpath: Path,
+    old_node: Any,
+    cached_timemodified: Any,
+    log: logging.Logger = logger,
+) -> LocalCopyState:
+    """Classify the on-disk file when the remote may have changed."""
+    old_etag = getattr(old_node, "etag", None) if old_node is not None else None
+    old_content_hash = (
+        getattr(old_node, "content_hash", None) if old_node is not None else None
+    )
+    verdict = classify_local_file(downloadpath, old_content_hash or old_etag)
+    if verdict is FileMatch.MATCH:
+        return LocalCopyState.CLEAN
+    if verdict is FileMatch.DIFFER:
+        return LocalCopyState.MODIFIED
+
+    if cached_timemodified is not None:
+        try:
+            if int(downloadpath.stat().st_mtime) != int(cached_timemodified):
+                return LocalCopyState.MODIFIED
+            return LocalCopyState.CLEAN
+        except (OSError, ValueError):
+            return LocalCopyState.MODIFIED
+
+    remote_etag = getattr(node, "etag", None)
+    if remote_etag is None and node.url:
+        try:
+            head_resp = ctx.require_session().head(node.url, allow_redirects=True)
+            remote_etag = head_resp.headers.get("ETag")
+        except Exception:
+            remote_etag = None
+
+    if classify_local_file(downloadpath, remote_etag) is FileMatch.MATCH:
+        node.etag = remote_etag
+        if getattr(node, "timemodified", None) is not None:
+            try:
+                ts = int(node.timemodified)
+                os.utime(downloadpath, (ts, ts))
+            except (OSError, OverflowError, ValueError):
+                pass
+        return LocalCopyState.UP_TO_DATE
+    return LocalCopyState.MODIFIED
+
+
+def decide_download(
+    ctx: SyncContext,
+    node: Any,
+    downloadpath: Path,
+    log: logging.Logger = logger,
+) -> DownloadDecision:
+    """Decide whether ``node`` must be (re)downloaded and whether the local copy
+    is user-modified.
+    """
+    if not downloadpath.exists():
+        return DownloadDecision(skip=False)
+    if not ctx.config.updatefiles:
+        return DownloadDecision(skip=True)
+
+    old_node = course_cache.get_old_node_for(ctx, node, log)
+    if old_node is not None and not getattr(old_node, "is_downloaded", False):
+        old_node = None
+    cached_timemodified = (
+        getattr(old_node, "timemodified", None) if old_node is not None else None
+    )
+
+    if old_node is not None and remote_unchanged(
+        ctx, node, old_node, cached_timemodified, log
+    ):
+        return DownloadDecision(skip=True)
+
+    verdict = assess_local_copy(
+        ctx, node, downloadpath, old_node, cached_timemodified, log
+    )
+    if verdict is LocalCopyState.UP_TO_DATE:
+        return DownloadDecision(skip=True)
+    return DownloadDecision(skip=False, conflict=verdict is LocalCopyState.MODIFIED)
 
 
 def download_file(
@@ -155,167 +281,36 @@ def download_file(
     if filters.should_skip_url(ctx.config, node.url, f"{node.type} file", log):
         return True
 
-    # Respect filetype/name exclusions up front so that excluded files never
-    # trigger conflict handling, displace local files, or create temp files.
+    # Exclusions must not trigger conflict handling or temp-file writes.
     if node.name.split(".")[-1] in ctx.config.exclude_filetypes:
         return True
     if any(fnmatchcase(node.name, pattern) for pattern in ctx.config.exclude_files):
         return True
 
-    # If we already downloaded this path during the current run, skip any
-    # further processing. This avoids duplicate downloads and spurious
-    # conflicts when the same remote file appears multiple times in the node
-    # tree (e.g. Sciebo links reused in a course).
     if ctx.downloaded_paths is None:
-        # Initialise on first use to keep __init__ simple.
         ctx.downloaded_paths = set()
     elif downloadpath in ctx.downloaded_paths:
         return True
 
-    # Decide whether we need to (re-)download the file at all
-    cached_timemodified = None
-    old_node = None
+    decision = decide_download(ctx, node, downloadpath, log)
+    if decision.skip:
+        return True
+
     conflict_rename_pending = False
-    if downloadpath.exists():
-        if not ctx.config.updatefiles:
-            return True
-
-        # Try to find a cached node for this file from the per-course cache.
-        old_node = course_cache.get_old_node_for(ctx, node, log)
-        # Only trust the cached version markers when the previous run actually
-        # downloaded the file. Otherwise an update that failed last time (e.g.
-        # an expired session) gets cached with Moodle's new timemodified and
-        # would be skipped forever, leaving a stale file. Treat a
-        # non-downloaded cache entry as if there were no cache at all.
-        if old_node is not None and not getattr(old_node, "is_downloaded", False):
-            old_node = None
-        if old_node is not None:
-            cached_timemodified = getattr(old_node, "timemodified", None)
-            old_etag = getattr(old_node, "etag", None)
-            # If Moodle did not change the file, skip re-download. Only when
-            # timemodified is meaningful: Sciebo files have no timemodified
-            # (always None), so this must fall through to the etag check below
-            # instead of treating None == None as "unchanged".
-            if cached_timemodified is not None and (
-                node.timemodified == cached_timemodified
-            ):
-                return True
-            # For Sciebo, we use the etag from the previous run as the remote
-            # version marker. If it matches the current etag from the PROPFIND
-            # response, the remote file has not changed.
-            if (
-                cached_timemodified is None
-                and old_etag
-                and getattr(node, "etag", None) == old_etag
-            ):
-                # The remote revision marker is unchanged since our last run, so
-                # there is nothing new to install: skip. We deliberately do NOT
-                # gate this on re-hashing the local file, because Sciebo/WebDAV
-                # ETags are opaque revision tokens (not content hashes). Gating
-                # here made every checksum-less Sciebo file re-download and its
-                # identical local copy get moved aside as a spurious conflict on
-                # every run.
-                return True
-            if (
-                cached_timemodified is None
-                and old_etag
-                and getattr(node, "etag", None) is None
-                and conditional_get_confirms_unchanged(ctx, node, old_etag, log)
-            ):
-                return True
-
-        # At this point, either there is no cache for this course/path, or
-        # Moodle reports a different modification time. This means the remote
-        # file might have changed.
-
-        # Check for potential local modifications since the last sync to avoid
-        # silently overwriting user changes.
+    if decision.conflict:
         conflict_mode = ctx.config.update_files_conflict
         if conflict_mode not in {"rename", "keep", "none", "overwrite"}:
             conflict_mode = "rename"
-
-        local_conflict = False
-        old_etag = getattr(old_node, "etag", None) if old_node is not None else None
-        old_content_hash = (
-            getattr(old_node, "content_hash", None) if old_node is not None else None
-        )
-        # Prefer a content hash we computed ourselves at download time: a Sciebo
-        # ETag is an opaque revision token, so hashing the local file against it
-        # can never match and would flag every file as a conflict. Fall back to
-        # the ETag only when we have no stored content hash (e.g. a Moodle file
-        # whose ETag is a real content hash, or a pre-upgrade cache entry).
-        verify_hash = old_content_hash or old_etag
-        etag_check_failed = False
-        if verify_hash:
-            try:
-                if not local_file_matches_etag(downloadpath, verify_hash):
-                    local_conflict = True
-            except Exception:
-                # A faulty/unusable hash cache is treated as if we had none:
-                # fall back to the timestamp/HEAD heuristic below to decide
-                # whether this is a conflict.
-                etag_check_failed = True
-
-        if not verify_hash or etag_check_failed:
-            if cached_timemodified is not None:
-                # Fallback: compare local mtime with the previous Moodle timestamp.
-                try:
-                    local_mtime = int(downloadpath.stat().st_mtime)
-                    if local_mtime != int(cached_timemodified):
-                        local_conflict = True
-                except (OSError, ValueError):
-                    local_conflict = True
-            else:
-                # No previous etag and no previous timemodified: this usually
-                # means the file existed before we ever cached it. Before we
-                # treat this as a conflict, try to see if the local file already
-                # matches the *current* remote content using the ETag from
-                # either the Sciebo PROPFIND or a Moodle HEAD request.
-                remote_etag = getattr(node, "etag", None)
-                if remote_etag is None and node.url:
-                    try:
-                        head_resp = ctx.require_session().head(
-                            node.url, allow_redirects=True
-                        )
-                        remote_etag = head_resp.headers.get("ETag")
-                    except Exception:
-                        remote_etag = None
-
-                if remote_etag and local_file_matches_etag(downloadpath, remote_etag):
-                    # Local file already equals the current remote content, so
-                    # there is no conflict and no need to download again.
-                    node.etag = remote_etag
-                    if getattr(node, "timemodified", None) is not None:
-                        try:
-                            ts = int(node.timemodified)
-                            os.utime(downloadpath, (ts, ts))
-                        except (OSError, OverflowError, ValueError):
-                            pass
-                    return True
-
-                # At this point we know the local file differs from the current
-                # remote version (or we couldn't verify), and we have no prior
-                # cached state. Treat this as a potential conflict to avoid
-                # silently overwriting user changes.
-                local_conflict = True
-
-        if local_conflict:
-            if conflict_mode in {"keep", "none"}:
-                # Keep the locally modified file and skip updating from Moodle
-                log.info(
-                    "Detected local changes for %s, skipping Moodle update "
-                    "due to update_files_conflict=%s",
-                    downloadpath,
-                    conflict_mode,
-                )
-                return True
-            if conflict_mode == "rename":
-                # Defer moving the locally modified file aside until the
-                # replacement has been fully downloaded, so an aborted or failed
-                # download (e.g. an expired session returning an HTML error
-                # page) never leaves the canonical path empty.
-                conflict_rename_pending = True
-            # conflict_mode == "overwrite": fall through and overwrite
+        if conflict_mode in {"keep", "none"}:
+            log.info(
+                "Detected local changes for %s, skipping Moodle update "
+                "due to update_files_conflict=%s",
+                downloadpath,
+                conflict_mode,
+            )
+            return True
+        if conflict_mode == "rename":
+            conflict_rename_pending = True
 
     # Hidden, namespaced temp/sidecar names so we never resume from or
     # overwrite a file the user happens to own. The sidecar records the ETag a

--- a/syncmymoodle/downloader.py
+++ b/syncmymoodle/downloader.py
@@ -14,14 +14,12 @@ import yt_dlp
 from tqdm import tqdm
 
 from syncmymoodle import course_cache, filters, pathing
-from syncmymoodle.constants import YOUTUBE_ID_LENGTH
+from syncmymoodle.constants import HASH_ALGOS_BY_LENGTH, YOUTUBE_ID_LENGTH
 from syncmymoodle.context import SyncContext
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_BLOCK_SIZE = 1024
-
-_HASH_ALGOS_BY_LENGTH = {32: "md5", 40: "sha1", 64: "sha256"}
 
 
 class FileMatch(Enum):
@@ -52,7 +50,7 @@ def classify_local_file(path: Path, marker: str | None) -> FileMatch:
     if not match:
         return FileMatch.UNKNOWN
     hex_str = match.group(1).lower()
-    algo = _HASH_ALGOS_BY_LENGTH.get(len(hex_str))
+    algo = HASH_ALGOS_BY_LENGTH.get(len(hex_str))
     if algo is None:
         return FileMatch.UNKNOWN
     try:

--- a/syncmymoodle/downloader.py
+++ b/syncmymoodle/downloader.py
@@ -16,6 +16,7 @@ from tqdm import tqdm
 from syncmymoodle import course_cache, filters, pathing
 from syncmymoodle.constants import HASH_ALGOS_BY_LENGTH, YOUTUBE_ID_LENGTH
 from syncmymoodle.context import SyncContext
+from syncmymoodle.node import Node, RemoteMarkerKind
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +37,27 @@ class LocalCopyState(Enum):
     UP_TO_DATE = "up_to_date"
     CLEAN = "clean"
     MODIFIED = "modified"
+
+
+class ConflictAction(Enum):
+    DOWNLOAD = "download"
+    RENAME_LOCAL = "rename_local"
+    SKIP = "skip"
+
+
+@dataclass
+class TransferPlan:
+    tmp_path: Path
+    etag_sidecar: Path
+    headers: dict[str, str]
+    resume_size: int = 0
+    partial_etag: str | None = None
+
+    def discard_partial(self) -> None:
+        self.resume_size = 0
+        self.partial_etag = None
+        self.tmp_path.unlink(missing_ok=True)
+        self.etag_sidecar.unlink(missing_ok=True)
 
 
 def classify_local_file(path: Path, marker: str | None) -> FileMatch:
@@ -120,7 +142,7 @@ def download_response_is_usable(
 
 def conditional_get_confirms_unchanged(
     ctx: SyncContext,
-    node: Any,
+    node: Node,
     old_etag: str,
     log: logging.Logger = logger,
 ) -> bool:
@@ -135,8 +157,8 @@ def conditional_get_confirms_unchanged(
         return False
 
     headers: dict[str, str] = {"If-None-Match": old_etag}
-    if node.type.lower() == "sciebo file" and isinstance(node.additional_info, dict):
-        headers = {**headers, **node.additional_info}
+    if node.download_headers:
+        headers = {**headers, **node.download_headers}
 
     try:
         with closing(
@@ -145,9 +167,11 @@ def conditional_get_confirms_unchanged(
             response_etag = response.headers.get("ETag")
             if response.status_code == 304:
                 node.etag = old_etag
+                node.etag_kind = RemoteMarkerKind.OPAQUE
                 return True
             if 200 <= response.status_code < 300 and response_etag == old_etag:
                 node.etag = response_etag
+                node.etag_kind = RemoteMarkerKind.OPAQUE
                 return True
     except Exception as exc:
         log.warning("Failed to validate cached ETag for %s: %s", node.url, exc)
@@ -164,8 +188,8 @@ class DownloadDecision:
 
 def remote_unchanged(
     ctx: SyncContext,
-    node: Any,
-    old_node: Any,
+    node: Node,
+    old_node: Node,
     cached_timemodified: Any,
     log: logging.Logger = logger,
 ) -> bool:
@@ -187,20 +211,26 @@ def remote_unchanged(
     return False
 
 
+def local_verification_marker(old_node: Node | None) -> str | None:
+    if old_node is None:
+        return None
+    if old_node.content_hash:
+        return old_node.content_hash
+    if old_node.etag and old_node.etag_kind in (None, RemoteMarkerKind.CONTENT_HASH):
+        return old_node.etag
+    return None
+
+
 def assess_local_copy(
     ctx: SyncContext,
-    node: Any,
+    node: Node,
     downloadpath: Path,
-    old_node: Any,
+    old_node: Node | None,
     cached_timemodified: Any,
     log: logging.Logger = logger,
 ) -> LocalCopyState:
     """Classify the on-disk file when the remote may have changed."""
-    old_etag = getattr(old_node, "etag", None) if old_node is not None else None
-    old_content_hash = (
-        getattr(old_node, "content_hash", None) if old_node is not None else None
-    )
-    verdict = classify_local_file(downloadpath, old_content_hash or old_etag)
+    verdict = classify_local_file(downloadpath, local_verification_marker(old_node))
     if verdict is FileMatch.MATCH:
         return LocalCopyState.CLEAN
     if verdict is FileMatch.DIFFER:
@@ -215,15 +245,21 @@ def assess_local_copy(
             return LocalCopyState.MODIFIED
 
     remote_etag = getattr(node, "etag", None)
+    remote_etag_kind = node.etag_kind
     if remote_etag is None and node.url:
         try:
             head_resp = ctx.require_session().head(node.url, allow_redirects=True)
             remote_etag = head_resp.headers.get("ETag")
+            remote_etag_kind = RemoteMarkerKind.OPAQUE if remote_etag else None
         except Exception:
             remote_etag = None
 
-    if classify_local_file(downloadpath, remote_etag) is FileMatch.MATCH:
+    if (
+        remote_etag_kind == RemoteMarkerKind.CONTENT_HASH
+        and classify_local_file(downloadpath, remote_etag) is FileMatch.MATCH
+    ):
         node.etag = remote_etag
+        node.etag_kind = remote_etag_kind
         if getattr(node, "timemodified", None) is not None:
             try:
                 ts = int(node.timemodified)
@@ -236,7 +272,7 @@ def assess_local_copy(
 
 def decide_download(
     ctx: SyncContext,
-    node: Any,
+    node: Node,
     downloadpath: Path,
     log: logging.Logger = logger,
 ) -> DownloadDecision:
@@ -249,7 +285,7 @@ def decide_download(
         return DownloadDecision(skip=True)
 
     old_node = course_cache.get_old_node_for(ctx, node, log)
-    if old_node is not None and not getattr(old_node, "is_downloaded", False):
+    if old_node is not None and not old_node.is_handled:
         old_node = None
     cached_timemodified = (
         getattr(old_node, "timemodified", None) if old_node is not None else None
@@ -268,201 +304,240 @@ def decide_download(
     return DownloadDecision(skip=False, conflict=verdict is LocalCopyState.MODIFIED)
 
 
-def download_file(
-    ctx: SyncContext,
-    node: Any,
-    log: logging.Logger = logger,
+def should_skip_before_decision(
+    ctx: SyncContext, node: Node, downloadpath: Path, log: logging.Logger = logger
 ) -> bool:
-    """Download file with progress bar if it isn't already downloaded."""
-    downloadpath = pathing.get_sanitized_node_path(node, Path(ctx.config.basedir))
-
     if filters.should_skip_url(ctx.config, node.url, f"{node.type} file", log):
         return True
-
-    # Exclusions must not trigger conflict handling or temp-file writes.
     if node.name.split(".")[-1] in ctx.config.exclude_filetypes:
         return True
     if any(fnmatchcase(node.name, pattern) for pattern in ctx.config.exclude_files):
         return True
+    return downloadpath in ctx.downloaded_paths
 
-    if ctx.downloaded_paths is None:
-        ctx.downloaded_paths = set()
-    elif downloadpath in ctx.downloaded_paths:
-        return True
 
-    decision = decide_download(ctx, node, downloadpath, log)
-    if decision.skip:
-        return True
+def conflict_action(
+    ctx: SyncContext,
+    decision: DownloadDecision,
+    downloadpath: Path,
+    log: logging.Logger = logger,
+) -> ConflictAction:
+    if not decision.conflict:
+        return ConflictAction.DOWNLOAD
 
-    conflict_rename_pending = False
-    if decision.conflict:
-        conflict_mode = ctx.config.update_files_conflict
-        if conflict_mode not in {"rename", "keep", "none", "overwrite"}:
-            conflict_mode = "rename"
-        if conflict_mode in {"keep", "none"}:
-            log.info(
-                "Detected local changes for %s, skipping Moodle update "
-                "due to update_files_conflict=%s",
-                downloadpath,
-                conflict_mode,
-            )
-            return True
-        if conflict_mode == "rename":
-            conflict_rename_pending = True
+    conflict_mode = ctx.config.update_files_conflict
+    if conflict_mode not in {"rename", "keep", "none", "overwrite"}:
+        conflict_mode = "rename"
+    if conflict_mode in {"keep", "none"}:
+        log.info(
+            "Detected local changes for %s, skipping Moodle update "
+            "due to update_files_conflict=%s",
+            downloadpath,
+            conflict_mode,
+        )
+        return ConflictAction.SKIP
+    if conflict_mode == "rename":
+        return ConflictAction.RENAME_LOCAL
+    return ConflictAction.DOWNLOAD
 
-    # Hidden, namespaced temp/sidecar names so we never resume from or
-    # overwrite a file the user happens to own. The sidecar records the ETag a
-    # partial download was fetched against.
-    tmp_downloadpath = downloadpath.parent / f".{downloadpath.name}.smmpart"
-    etag_sidecar = tmp_downloadpath.with_name(tmp_downloadpath.name + ".etag")
 
-    # Only resume a previous partial when we recorded the ETag it was fetched
-    # against, so we can ask the server (via If-Range) to confirm the remote
-    # content is unchanged. Without that proof a blind range request could
-    # splice bytes from a newer version onto an older partial and silently
-    # corrupt the file.
-    resume_size = 0
-    partial_etag: str | None = None
-    header = dict()
-    if tmp_downloadpath.exists():
+def prepare_transfer_plan(node: Node, downloadpath: Path) -> TransferPlan:
+    tmp_path = downloadpath.parent / f".{downloadpath.name}.smmpart"
+    etag_sidecar = tmp_path.with_name(tmp_path.name + ".etag")
+    plan = TransferPlan(tmp_path=tmp_path, etag_sidecar=etag_sidecar, headers={})
+
+    if tmp_path.exists():
         if etag_sidecar.exists():
             try:
-                partial_etag = etag_sidecar.read_text(encoding="utf-8").strip()
+                plan.partial_etag = etag_sidecar.read_text(encoding="utf-8").strip()
             except OSError:
-                partial_etag = None
-        if partial_etag:
-            resume_size = tmp_downloadpath.stat().st_size
-            header = {"Range": f"bytes={resume_size}-", "If-Range": partial_etag}
+                plan.partial_etag = None
+        if plan.partial_etag:
+            plan.resume_size = tmp_path.stat().st_size
+            plan.headers = {
+                "Range": f"bytes={plan.resume_size}-",
+                "If-Range": plan.partial_etag,
+            }
         else:
-            # Cannot validate the partial; discard it and start fresh.
-            tmp_downloadpath.unlink(missing_ok=True)
-            etag_sidecar.unlink(missing_ok=True)
-    if node.type.lower() == "sciebo file":
-        header = {**header, **node.additional_info}
+            plan.discard_partial()
 
-    with closing(
-        ctx.require_session().get(node.url, headers=header, stream=True)
-    ) as response:
-        etag_header = response.headers.get("ETag")
+    if node.download_headers:
+        plan.headers = {**plan.headers, **node.download_headers}
+    return plan
 
-        if resume_size:
-            # The remote content differs from our partial when the server
-            # ignores the range (any non-206) or cannot prove that the returned
-            # tail belongs to the same ETag as the saved partial.
-            valid_resume = response.status_code == 206 and etag_header == partial_etag
-            version_changed = not valid_resume
-            if version_changed:
-                resume_size = 0
-                tmp_downloadpath.unlink(missing_ok=True)
-                etag_sidecar.unlink(missing_ok=True)
-                if response.status_code == 206:
-                    # This 206 body is only a tail, and without an exact ETag
-                    # match it cannot be safely appended. Restart fresh on the
-                    # next run.
-                    return False
 
-        if not download_response_is_usable(node, response, downloadpath, log):
-            return False
+def validate_resume_response(response: Any, transfer: TransferPlan) -> bool:
+    if not transfer.resume_size:
+        return True
 
-        content = response.iter_content(DEFAULT_BLOCK_SIZE)
-        first_chunk = next((chunk for chunk in content if chunk), b"")
-        if (
-            first_chunk
-            and chunk_looks_like_html(first_chunk)
-            and not node_allows_html_download(node)
-        ):
-            log.warning(
-                "Skipping download of %s from %s because the response body "
-                "starts with HTML instead of the expected file. This usually "
-                "means the link requires a separate login or points to an "
-                "error page.",
-                downloadpath,
-                node.url,
-            )
-            return False
+    etag_header = response.headers.get("ETag")
+    valid_resume = response.status_code == 206 and etag_header == transfer.partial_etag
+    if valid_resume:
+        return True
 
-        print(f"Downloading {downloadpath} [{node.type}]")
-        total_size_in_bytes = int(response.headers.get("content-length", 0)) + max(
-            resume_size, 0
-        )
-        progress_bar = tqdm(total=total_size_in_bytes, unit="iB", unit_scale=True)
-        if resume_size:
-            progress_bar.update(resume_size)
+    was_partial_response = response.status_code == 206
+    transfer.discard_partial()
+    return not was_partial_response
+
+
+def response_body_is_usable(
+    node: Node,
+    first_chunk: bytes,
+    downloadpath: Path,
+    log: logging.Logger = logger,
+) -> bool:
+    if not first_chunk:
+        return True
+    if not chunk_looks_like_html(first_chunk):
+        return True
+    if node_allows_html_download(node):
+        return True
+
+    log.warning(
+        "Skipping download of %s from %s because the response body starts "
+        "with HTML instead of the expected file. This usually means the link "
+        "requires a separate login or points to an error page.",
+        downloadpath,
+        node.url,
+    )
+    return False
+
+
+def write_response_body(
+    node: Node,
+    response: Any,
+    transfer: TransferPlan,
+    downloadpath: Path,
+    content: Any,
+    first_chunk: bytes,
+) -> None:
+    print(f"Downloading {downloadpath} [{node.type}]")
+    total_size_in_bytes = int(response.headers.get("content-length", 0)) + max(
+        transfer.resume_size, 0
+    )
+    progress_bar = tqdm(total=total_size_in_bytes, unit="iB", unit_scale=True)
+    try:
+        if transfer.resume_size:
+            progress_bar.update(transfer.resume_size)
         downloadpath.parent.mkdir(parents=True, exist_ok=True)
-        # Record the ETag this partial is being fetched against so an
-        # interrupted download can be safely resumed next time.
+
+        etag_header = response.headers.get("ETag")
         if etag_header:
             try:
-                etag_sidecar.write_text(etag_header, encoding="utf-8")
+                transfer.etag_sidecar.write_text(etag_header, encoding="utf-8")
             except OSError:
                 pass
-        mode = "ab" if resume_size else "wb"
-        with tmp_downloadpath.open(mode) as file:
+
+        mode = "ab" if transfer.resume_size else "wb"
+        with transfer.tmp_path.open(mode) as file:
             if first_chunk:
                 progress_bar.update(len(first_chunk))
                 file.write(first_chunk)
             for data in content:
                 progress_bar.update(len(data))
                 file.write(data)
+    finally:
         progress_bar.close()
 
-        # The replacement is now fully on disk. Only at this point do we move a
-        # conflicting local file aside, so a failure above never empties the
-        # canonical path.
-        if conflict_rename_pending:
-            conflict_path = pathing.make_conflict_path(downloadpath)
-            try:
-                downloadpath.rename(conflict_path)
-                log.warning(
-                    "Detected local changes for %s, moved to %s before "
-                    "installing the updated file from Moodle",
-                    downloadpath,
-                    conflict_path,
-                )
-            except OSError:
-                log.exception(
-                    "Failed to move locally modified file %s to %s; keeping "
-                    "it and discarding the downloaded update to avoid data loss",
-                    downloadpath,
-                    conflict_path,
-                )
-                tmp_downloadpath.unlink(missing_ok=True)
-                etag_sidecar.unlink(missing_ok=True)
-                return True
 
-        os.replace(tmp_downloadpath, downloadpath)
-        etag_sidecar.unlink(missing_ok=True)
-        # Record a content hash of exactly the bytes we just downloaded, so the
-        # next run can detect genuine local modifications even when the remote
-        # only offers an opaque ETag (e.g. Sciebo/WebDAV). We hash the file we
-        # just wrote (untouched by the user at this point), never a pre-existing
-        # file, so a later user edit is never mistaken for our own download.
+def install_downloaded_file(
+    downloadpath: Path,
+    transfer: TransferPlan,
+    action: ConflictAction,
+    log: logging.Logger = logger,
+) -> bool:
+    if action == ConflictAction.RENAME_LOCAL:
+        conflict_path = pathing.make_conflict_path(downloadpath)
         try:
-            with downloadpath.open("rb") as fh:
-                node.content_hash = hashlib.file_digest(fh, "sha256").hexdigest()
+            downloadpath.rename(conflict_path)
+            log.warning(
+                "Detected local changes for %s, moved to %s before installing "
+                "the updated file from Moodle",
+                downloadpath,
+                conflict_path,
+            )
         except OSError:
+            log.exception(
+                "Failed to move locally modified file %s to %s; keeping it "
+                "and discarding the downloaded update to avoid data loss",
+                downloadpath,
+                conflict_path,
+            )
+            transfer.discard_partial()
+            return False
+
+    os.replace(transfer.tmp_path, downloadpath)
+    transfer.etag_sidecar.unlink(missing_ok=True)
+    return True
+
+
+def record_download_metadata(
+    node: Node,
+    downloadpath: Path,
+    etag_header: str | None,
+) -> None:
+    try:
+        with downloadpath.open("rb") as fh:
+            node.content_hash = hashlib.file_digest(fh, "sha256").hexdigest()
+    except OSError:
+        pass
+
+    if node.timemodified is not None:
+        try:
+            ts = int(node.timemodified)
+            os.utime(downloadpath, (ts, ts))
+        except (OSError, OverflowError, ValueError):
             pass
-        # Align the local mtime with Moodle's timemodified to detect local
-        # changes on subsequent runs.
-        if getattr(node, "timemodified", None) is not None:
-            try:
-                ts = int(node.timemodified)
-                os.utime(downloadpath, (ts, ts))
-            except (OSError, OverflowError, ValueError):
-                # If updating timestamps fails, fall back to the current time.
-                pass
-        # Persist a response ETag only when discovery did not already provide a
-        # remote version marker. Sciebo/WebDAV can expose one marker through
-        # PROPFIND and a different ETag on GET; the next scan compares against
-        # the PROPFIND marker, so replacing it here would force re-downloads on
-        # every run.
-        if etag_header is not None and getattr(node, "etag", None) is None:
-            try:
-                node.etag = etag_header
-            except Exception:
-                # If for some reason we cannot set it, just ignore.
-                pass
-        # Remember that we downloaded this path during the current run.
+
+    if etag_header is not None and node.etag is None:
+        node.etag = etag_header
+        node.etag_kind = RemoteMarkerKind.OPAQUE
+
+
+def download_file(
+    ctx: SyncContext,
+    node: Node,
+    log: logging.Logger = logger,
+) -> bool:
+    """Download file with progress bar if it isn't already downloaded."""
+    downloadpath = pathing.get_sanitized_node_path(node, Path(ctx.config.basedir))
+
+    if not node.url:
+        return False
+
+    if should_skip_before_decision(ctx, node, downloadpath, log):
+        return True
+
+    decision = decide_download(ctx, node, downloadpath, log)
+    if decision.skip:
+        return True
+
+    action = conflict_action(ctx, decision, downloadpath, log)
+    if action == ConflictAction.SKIP:
+        return True
+
+    transfer = prepare_transfer_plan(node, downloadpath)
+    with closing(
+        ctx.require_session().get(node.url, headers=transfer.headers, stream=True)
+    ) as response:
+        etag_header = response.headers.get("ETag")
+
+        if not validate_resume_response(response, transfer):
+            return False
+        if not download_response_is_usable(node, response, downloadpath, log):
+            return False
+
+        content = response.iter_content(DEFAULT_BLOCK_SIZE)
+        first_chunk = next((chunk for chunk in content if chunk), b"")
+        if not response_body_is_usable(node, first_chunk, downloadpath, log):
+            return False
+
+        write_response_body(
+            node, response, transfer, downloadpath, content, first_chunk
+        )
+        if not install_downloaded_file(downloadpath, transfer, action, log):
+            return True
+        record_download_metadata(node, downloadpath, etag_header)
         ctx.downloaded_paths.add(downloadpath)
         return True
 
@@ -485,15 +560,15 @@ def download_all_files(
 
 def download_node_tree(
     ctx: SyncContext,
-    cur_node: Any,
+    cur_node: Node,
     log: logging.Logger = logger,
 ) -> None:
     if len(cur_node.children) == 0:
-        if cur_node.url and not cur_node.is_downloaded:
+        if cur_node.url and not cur_node.is_handled:
             if cur_node.type == "Youtube":
                 try:
                     scan_and_download_youtube(ctx, cur_node, log)
-                    cur_node.is_downloaded = True
+                    cur_node.mark_handled()
                 except Exception:
                     log.exception(f"Failed to download the module {cur_node}")
                     log.error(
@@ -508,7 +583,7 @@ def download_node_tree(
                         else:
                             cur_node.name = cur_node.url.split("/")[-1]
                     if download_file(ctx, cur_node, log):
-                        cur_node.is_downloaded = True
+                        cur_node.mark_handled()
                 except Exception:
                     log.exception(f"Failed to download the module {cur_node}")
             elif cur_node.type == "Quiz":
@@ -520,7 +595,7 @@ def download_node_tree(
             else:
                 try:
                     if download_file(ctx, cur_node, log):
-                        cur_node.is_downloaded = True
+                        cur_node.mark_handled()
                 except Exception:
                     log.exception(f"Failed to download the module {cur_node}")
         return
@@ -531,10 +606,12 @@ def download_node_tree(
 
 def scan_and_download_youtube(
     ctx: SyncContext,
-    node: Any,
+    node: Node,
     log: logging.Logger = logger,
 ) -> bool:
     """Download Youtube-Videos using yt_dlp."""
+    if node.parent is None or node.url is None:
+        return False
     path = pathing.get_sanitized_node_path(node.parent, Path(ctx.config.basedir))
     link = node.url
     if filters.should_skip_url(ctx.config, link, "YouTube link", log):

--- a/syncmymoodle/downloader.py
+++ b/syncmymoodle/downloader.py
@@ -222,12 +222,10 @@ def local_verification_marker(old_node: Node | None) -> str | None:
 
 
 def assess_local_copy(
-    ctx: SyncContext,
     node: Node,
     downloadpath: Path,
     old_node: Node | None,
     cached_timemodified: Any,
-    log: logging.Logger = logger,
 ) -> LocalCopyState:
     """Classify the on-disk file when the remote may have changed."""
     verdict = classify_local_file(downloadpath, local_verification_marker(old_node))
@@ -246,14 +244,6 @@ def assess_local_copy(
 
     remote_etag = getattr(node, "etag", None)
     remote_etag_kind = node.etag_kind
-    if remote_etag is None and node.url:
-        try:
-            head_resp = ctx.require_session().head(node.url, allow_redirects=True)
-            remote_etag = head_resp.headers.get("ETag")
-            remote_etag_kind = RemoteMarkerKind.OPAQUE if remote_etag else None
-        except Exception:
-            remote_etag = None
-
     if (
         remote_etag_kind == RemoteMarkerKind.CONTENT_HASH
         and classify_local_file(downloadpath, remote_etag) is FileMatch.MATCH
@@ -296,9 +286,7 @@ def decide_download(
     ):
         return DownloadDecision(skip=True)
 
-    verdict = assess_local_copy(
-        ctx, node, downloadpath, old_node, cached_timemodified, log
-    )
+    verdict = assess_local_copy(node, downloadpath, old_node, cached_timemodified)
     if verdict is LocalCopyState.UP_TO_DATE:
         return DownloadDecision(skip=True)
     return DownloadDecision(skip=False, conflict=verdict is LocalCopyState.MODIFIED)

--- a/syncmymoodle/filters.py
+++ b/syncmymoodle/filters.py
@@ -3,7 +3,7 @@ import urllib.parse
 from fnmatch import fnmatchcase
 from typing import Any
 
-from syncmymoodle.config import Config
+from syncmymoodle.config import Config, PatternConfig
 from syncmymoodle.constants import (
     COURSE_PREFIX_HANDLING_OPTIONS,
     COURSE_PREFIX_RE,
@@ -13,15 +13,7 @@ from syncmymoodle.constants import (
 logger = logging.getLogger(__name__)
 
 
-def as_list(value: Any) -> list[Any]:
-    if value is None:
-        return []
-    if isinstance(value, list):
-        return value
-    return [value]
-
-
-def course_id_in_filter(course_id: Any, entries: Any) -> bool:
+def course_id_in_filter(course_id: Any, entries: list[str]) -> bool:
     """Return True if ``course_id`` is referenced by a configured entry.
 
     Entries are course URLs (``.../course/view.php?id=NNN``). The ``id``
@@ -29,8 +21,7 @@ def course_id_in_filter(course_id: Any, entries: Any) -> bool:
     match courses ``1`` or ``2``. A bare numeric id entry is also accepted.
     """
     course_id = str(course_id)
-    for entry in entries or []:
-        entry = str(entry)
+    for entry in entries:
         parsed = urllib.parse.urlparse(entry)
         if course_id in urllib.parse.parse_qs(parsed.query).get("id", []):
             return True
@@ -39,20 +30,11 @@ def course_id_in_filter(course_id: Any, entries: Any) -> bool:
     return False
 
 
-def pattern_list(value: Any, course_id: Any = None) -> list[str]:
-    """Flatten a config exclusion value into a list of glob patterns.
-
-    ``value`` may be a flat list, or a per-course dict of the form
-    ``{"*": [...], "<course_id>": [...]}``.
-    """
-    patterns = []
-    if isinstance(value, dict):
-        patterns.extend(as_list(value.get("*")))
-        if course_id is not None:
-            patterns.extend(as_list(value.get(str(course_id))))
-    else:
-        patterns.extend(as_list(value))
-    return [str(pattern) for pattern in patterns if pattern is not None]
+def pattern_list(value: PatternConfig, course_id: Any = None) -> list[str]:
+    patterns = list(value.get("*", []))
+    if course_id is not None:
+        patterns.extend(value.get(str(course_id), []))
+    return patterns
 
 
 def format_course_name(

--- a/syncmymoodle/links.py
+++ b/syncmymoodle/links.py
@@ -10,7 +10,7 @@ from syncmymoodle import opencast as opencast_api
 from syncmymoodle import sciebo as sciebo_api
 from syncmymoodle.constants import OPENCAST_LINK_RE, YOUTUBE_LINK_RE
 from syncmymoodle.context import SyncContext
-from syncmymoodle.node import Node
+from syncmymoodle.node import Node, RemoteMarkerKind
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +83,11 @@ def scan_for_links(
                     f'Linked file [{response.headers["Content-Type"]}]',
                     url=text,
                     etag=response.headers.get("ETag"),
+                    etag_kind=(
+                        RemoteMarkerKind.OPAQUE
+                        if response.headers.get("ETag")
+                        else None
+                    ),
                 )
                 # instantly return as it was a direct link
                 return
@@ -141,8 +146,8 @@ def scan_for_links(
                 vid_id,
                 "Opencast",
                 url=track.url,
-                additional_info=course_id,
                 etag=track.remote_marker,
+                etag_kind=track.remote_marker_kind,
             )
 
     # https://rwth-aachen.sciebo.de/s/XXX

--- a/syncmymoodle/node.py
+++ b/syncmymoodle/node.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 import hashlib
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 NAME_CLASH_ID_UNSET = object()
 
@@ -136,73 +136,79 @@ class Node:
             hashlib.md5(str(key).encode("utf-8")).hexdigest().encode("utf-8")
         ).decode()[:10]
 
-    def remove_children_nameclashes(self) -> None:
-        # Check for duplicate filenames
+    def _stable_clash_name(self) -> str:
+        filename = Path(self.name)
+        return filename.stem + "_" + self._clash_suffix() + filename.suffix
 
-        unclashed_children = []
-        # work on copy since deleting from the iterated list breaks stuff
-        copy_children = self.children.copy()
-        for child in copy_children:
-            if child not in self.children:
+    def _opencast_clash_name(self) -> str:
+        return f"{Path(self.name).name}_{str(self.url).split('/')[-1]}"
+
+    @staticmethod
+    def _general_name_clash(left: Node, right: Node) -> bool:
+        if left.name != right.name:
+            return False
+        if left.url != right.url:
+            return True
+        return (
+            left.type == "Course"
+            and right.type == "Course"
+            and left.name_clash_id != right.name_clash_id
+        )
+
+    @staticmethod
+    def _apply_opencast_name_clashes(children: list[Node]) -> list[Node]:
+        remaining = children.copy()
+        renamed: list[Node] = []
+
+        while remaining:
+            child = remaining.pop(0)
+            renamed.append(child)
+            if child.type != "Opencast":
                 continue
-            self.children.remove(child)
-            unclashed_children.append(child)
-            if child.type == "Opencast":
-                siblings = [
-                    c
-                    for c in self.children
-                    if c.name == child.name and c.url != child.url
-                ]
-                if len(siblings) > 0:
-                    # if an Opencast filename is duplicate in its directory, we append the filename as it was uploaded
-                    tmp_name = Path(child.name).name
-                    child.name = f"{tmp_name}_{cast(str, child.url).split('/')[-1]}"
-                    for s in siblings:
-                        tmp_name = Path(s.name).name
-                        s.name = f"{s.name}_{cast(str, s.url).split('/')[-1]}"
-                        self.children.remove(s)
-                    unclashed_children.extend(siblings)
 
-        self.children = unclashed_children
-
-        unclashed_children = []
-        copy_children = self.children.copy()
-        for child in copy_children:
-            if child not in self.children:
-                continue
-            self.children.remove(child)
-            unclashed_children.append(child)
             siblings = [
-                c
-                for c in self.children
-                if c.name == child.name
-                and (
-                    c.url != child.url
-                    # Course prefix handling may create duplicate URL-less course
-                    # folders. Other URL-less nodes, such as duplicate Moodle
-                    # sections, keep the legacy behavior and merge silently.
-                    or (
-                        child.type == "Course"
-                        and c.type == "Course"
-                        and c.name_clash_id != child.name_clash_id
-                    )
-                )
+                sibling
+                for sibling in remaining
+                if sibling.name == child.name and sibling.url != child.url
             ]
-            if len(siblings) > 0:
-                # if a filename is still duplicate in its directory, we rename
-                # it by appending a stable per-node key (works for ids and urls).
-                filename = Path(child.name)
-                child.name = (
-                    filename.stem + "_" + child._clash_suffix() + filename.suffix
-                )
-                for s in siblings:
-                    filename = Path(s.name)
-                    s.name = filename.stem + "_" + s._clash_suffix() + filename.suffix
-                    self.children.remove(s)
-                unclashed_children.extend(siblings)
+            if not siblings:
+                continue
 
-        self.children = unclashed_children
+            child.name = child._opencast_clash_name()
+            for sibling in siblings:
+                sibling.name = sibling._opencast_clash_name()
+                remaining.remove(sibling)
+                renamed.append(sibling)
+
+        return renamed
+
+    @classmethod
+    def _apply_general_name_clashes(cls, children: list[Node]) -> list[Node]:
+        remaining = children.copy()
+        renamed: list[Node] = []
+
+        while remaining:
+            child = remaining.pop(0)
+            renamed.append(child)
+            siblings = [
+                sibling
+                for sibling in remaining
+                if cls._general_name_clash(child, sibling)
+            ]
+            if not siblings:
+                continue
+
+            child.name = child._stable_clash_name()
+            for sibling in siblings:
+                sibling.name = sibling._stable_clash_name()
+                remaining.remove(sibling)
+                renamed.append(sibling)
+
+        return renamed
+
+    def remove_children_nameclashes(self) -> None:
+        self.children = self._apply_opencast_name_clashes(self.children)
+        self.children = self._apply_general_name_clashes(self.children)
 
         for child in self.children:
-            # recurse whole tree
             child.remove_children_nameclashes()

--- a/syncmymoodle/node.py
+++ b/syncmymoodle/node.py
@@ -2,10 +2,41 @@ from __future__ import annotations
 
 import base64
 import hashlib
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
 NAME_CLASH_ID_UNSET = object()
+
+
+class RemoteMarkerKind(StrEnum):
+    CONTENT_HASH = "content_hash"
+    OPAQUE = "opaque"
+
+
+class DownloadStatus(StrEnum):
+    PENDING = "pending"
+    HANDLED = "handled"
+
+
+def _remote_marker_kind(
+    value: RemoteMarkerKind | str | None,
+) -> RemoteMarkerKind | None:
+    if value is None:
+        return None
+    try:
+        return RemoteMarkerKind(value)
+    except ValueError:
+        return None
+
+
+def _download_status(value: DownloadStatus | str | None) -> DownloadStatus | None:
+    if value is None:
+        return None
+    try:
+        return DownloadStatus(value)
+    except ValueError:
+        return None
 
 
 class Node:
@@ -16,11 +47,13 @@ class Node:
         type: str,  # noqa: A003 - keep original name for compatibility
         parent: Node | None,
         url: str | None = None,
-        additional_info: Any = None,
+        download_headers: dict[str, str] | None = None,
         timemodified: Any = None,
         etag: str | None = None,
+        etag_kind: RemoteMarkerKind | str | None = None,
         content_hash: str | None = None,
         name_clash_id: Any = NAME_CLASH_ID_UNSET,
+        download_status: DownloadStatus | str | None = None,
         is_downloaded: bool = False,
     ) -> None:
         self.name = name
@@ -29,11 +62,10 @@ class Node:
         self.type = type
         self.parent = parent
         self.children: list[Node] = []
-        # Currently only used for course_id in opencast, auth header in sciebo,
-        # and may be extended for other module-specific data.
-        self.additional_info = additional_info
+        self.download_headers = dict(download_headers) if download_headers else None
         self.timemodified = timemodified
         self.etag = etag
+        self.etag_kind = _remote_marker_kind(etag_kind)
         # A content hash (sha256 hex) we compute from the bytes we downloaded.
         # Unlike etag, which for Sciebo/WebDAV is an opaque revision token, this
         # is a real hash of our copy, used to detect local user modifications.
@@ -41,12 +73,29 @@ class Node:
         self.name_clash_id = (
             id if name_clash_id is NAME_CLASH_ID_UNSET else name_clash_id
         )
-        self.is_downloaded = (
-            is_downloaded  # Can also be used to exclude files from being downloaded
+        self.download_status = _download_status(download_status) or (
+            DownloadStatus.HANDLED if is_downloaded else DownloadStatus.PENDING
         )
 
     def __repr__(self) -> str:
         return f"Node(name={self.name}, id={self.id}, url={self.url}, type={self.type})"
+
+    @property
+    def is_handled(self) -> bool:
+        return self.download_status == DownloadStatus.HANDLED
+
+    def mark_handled(self) -> None:
+        self.download_status = DownloadStatus.HANDLED
+
+    @property
+    def is_downloaded(self) -> bool:
+        return self.is_handled
+
+    @is_downloaded.setter
+    def is_downloaded(self, value: bool) -> None:
+        self.download_status = (
+            DownloadStatus.HANDLED if value else DownloadStatus.PENDING
+        )
 
     def add_child(
         self,
@@ -54,9 +103,10 @@ class Node:
         id: Any,
         type: str,  # noqa: A003 - keep original name for compatibility
         url: str | None = None,
-        additional_info: Any = None,
+        download_headers: dict[str, str] | None = None,
         timemodified: Any = None,
         etag: str | None = None,
+        etag_kind: RemoteMarkerKind | str | None = None,
         name_clash_id: Any = NAME_CLASH_ID_UNSET,
     ) -> Node | None:
         if url:
@@ -75,9 +125,10 @@ class Node:
             type,
             self,
             url=url,
-            additional_info=additional_info,
+            download_headers=download_headers,
             timemodified=timemodified,
             etag=etag,
+            etag_kind=etag_kind,
             name_clash_id=name_clash_id,
         )
         self.children.append(temp)
@@ -90,12 +141,13 @@ class Node:
             self.type,
             parent,
             url=self.url,
-            additional_info=self.additional_info,
+            download_headers=self.download_headers,
             timemodified=self.timemodified,
             etag=self.etag,
+            etag_kind=self.etag_kind,
             content_hash=self.content_hash,
             name_clash_id=self.name_clash_id,
-            is_downloaded=self.is_downloaded,
+            download_status=self.download_status,
         )
         clone.children = [child.clone(clone) for child in self.children]
         return clone

--- a/syncmymoodle/opencast.py
+++ b/syncmymoodle/opencast.py
@@ -7,14 +7,17 @@ from typing import Any, cast
 
 from bs4 import BeautifulSoup as bs
 
-from syncmymoodle.constants import MOODLE_URL, RWTH_MOODLE_STATUS_URL
+from syncmymoodle.constants import (
+    CHECKSUM_LENGTHS_BY_ALGO,
+    MOODLE_URL,
+    RWTH_MOODLE_STATUS_URL,
+)
 from syncmymoodle.context import SyncContext
 
 logger = logging.getLogger(__name__)
 
 OPENCAST_LTI_URL = "https://engage.streaming.rwth-aachen.de/lti"
 OPENCAST_SEARCH_URL = "https://engage.streaming.rwth-aachen.de/search/episode.json"
-SUPPORTED_CHECKSUM_LENGTHS = {"md5": 32, "sha1": 40, "sha256": 64}
 
 
 @dataclass(frozen=True)
@@ -280,7 +283,7 @@ def optional_int(value: Any) -> int | None:
 
 
 def infer_checksum_type(checksum: str) -> str | None:
-    for checksum_type, expected_length in SUPPORTED_CHECKSUM_LENGTHS.items():
+    for checksum_type, expected_length in CHECKSUM_LENGTHS_BY_ALGO.items():
         if len(checksum) == expected_length:
             return checksum_type
     return None
@@ -309,7 +312,7 @@ def extract_checksum(track: dict[str, Any]) -> tuple[str | None, str | None]:
     checksum = checksum_value.lower()
     checksum_type = checksum_type or infer_checksum_type(checksum)
     expected_length = (
-        SUPPORTED_CHECKSUM_LENGTHS.get(checksum_type) if checksum_type else None
+        CHECKSUM_LENGTHS_BY_ALGO.get(checksum_type) if checksum_type else None
     )
     if expected_length is None:
         return None, None

--- a/syncmymoodle/opencast.py
+++ b/syncmymoodle/opencast.py
@@ -13,6 +13,7 @@ from syncmymoodle.constants import (
     RWTH_MOODLE_STATUS_URL,
 )
 from syncmymoodle.context import SyncContext
+from syncmymoodle.node import RemoteMarkerKind
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,10 @@ class OpencastTrack:
         # selected mp4 track, which is a better skip marker than a later GET
         # response ETag.
         return self.checksum
+
+    @property
+    def remote_marker_kind(self) -> RemoteMarkerKind | None:
+        return RemoteMarkerKind.CONTENT_HASH if self.checksum else None
 
 
 def log_backend_issue(
@@ -383,6 +388,6 @@ def resolve_track_from_episode(
         return None
 
     # Prefer the highest resolution plain HTTPS mp4 track.
-    selected_track = sorted(tracks, key=lambda track: track[0])[-1][1]
+    selected_track = max(tracks, key=lambda track: track[0])[1]
     ctx.opencast_track_cache[episode_id] = selected_track
     return selected_track

--- a/syncmymoodle/sciebo.py
+++ b/syncmymoodle/sciebo.py
@@ -7,7 +7,7 @@ from bs4 import BeautifulSoup as bs
 from syncmymoodle import filters
 from syncmymoodle.constants import SCIEBO_LINK_RE
 from syncmymoodle.context import SyncContext
-from syncmymoodle.node import Node
+from syncmymoodle.node import Node, RemoteMarkerKind
 
 logger = logging.getLogger(__name__)
 
@@ -171,7 +171,9 @@ def _add_sciebo_files(
             )
             continue
 
-        etag_value = _extract_stable_etag(resp)
+        remote_marker = _extract_remote_marker(resp)
+        etag_value = remote_marker[0] if remote_marker else None
+        etag_kind = remote_marker[1] if remote_marker else None
 
         log.info(f"Sciebo response href: {new_href}")
         # get the displayname of the response
@@ -188,7 +190,11 @@ def _add_sciebo_files(
         if new_href.endswith("/"):
             # create a new node for the folder
             folder_node = parent_node.add_child(
-                displayname, None, "Sciebo Folder", etag=etag_value
+                displayname,
+                None,
+                "Sciebo Folder",
+                etag=etag_value,
+                etag_kind=etag_kind,
             )
             if folder_node is None:
                 continue
@@ -203,14 +209,15 @@ def _add_sciebo_files(
                 None,
                 "Sciebo File",
                 url=SCIEBO_URL + new_href,
-                additional_info=auth_header,
+                download_headers=auth_header,
                 etag=etag_value,
+                etag_kind=etag_kind,
             )
 
 
-def _extract_stable_etag(response_tag: Any) -> str | None:
-    # Extract a stable content hash for this item. Prefer the SHA1 checksum
-    # from oc:checksums if available; fall back to the raw ETag otherwise.
+def _extract_remote_marker(response_tag: Any) -> tuple[str, RemoteMarkerKind] | None:
+    # Prefer a stable content hash from oc:checksums; fall back to the raw ETag
+    # as an opaque remote-version marker.
     prop = response_tag.find("d:prop")
     if prop is None:
         return None
@@ -220,10 +227,10 @@ def _extract_stable_etag(response_tag: Any) -> str | None:
         for cs in checksums_tag.find_all("oc:checksum"):
             text = (cs.text or "").strip()
             if text.upper().startswith("SHA1:"):
-                return text.split(":", 1)[1]
+                return text.split(":", 1)[1], RemoteMarkerKind.CONTENT_HASH
 
     etag_tag = prop.find("d:getetag")
     if etag_tag and etag_tag.text:
-        return str(etag_tag.text).strip()
+        return str(etag_tag.text).strip(), RemoteMarkerKind.OPAQUE
 
     return None

--- a/syncmymoodle/sync_handlers.py
+++ b/syncmymoodle/sync_handlers.py
@@ -248,8 +248,8 @@ def handle_embedded_link_module(
                             vid_id,
                             "Opencast",
                             url=track.url,
-                            additional_info=course_id,
                             etag=track.remote_marker,
+                            etag_kind=track.remote_marker_kind,
                         )
 
                 if scan_page_links:
@@ -389,8 +389,8 @@ def handle_opencast_lti_module(
                 episode_id,
                 "Opencast",
                 url=track.url,
-                additional_info=module["id"],
                 etag=track.remote_marker,
+                etag_kind=track.remote_marker_kind,
             )
     else:
         if not engage_single_id:
@@ -413,8 +413,8 @@ def handle_opencast_lti_module(
                 engage_single_id,
                 "Opencast",
                 url=track.url,
-                additional_info=module["id"],
                 etag=track.remote_marker,
+                etag_kind=track.remote_marker_kind,
             )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,7 +14,7 @@ def test_defaults_applied_for_empty_config():
     assert cfg.nolinks is False
     assert cfg.updatefiles is False
     assert cfg.selected_courses == []
-    assert cfg.exclude_links == []
+    assert cfg.exclude_links == {}
     # A default module tree is provided when none is configured.
     assert cfg.module_enabled("assign")
     assert cfg.module_enabled("folder")
@@ -32,8 +32,8 @@ def test_legacy_key_aliases_are_resolved():
     )
     assert cfg.nolinks is True
     assert cfg.updatefiles is True
-    assert cfg.exclude_sections == ["Hidden*"]
-    assert cfg.exclude_modules == ["Skip Module"]
+    assert cfg.exclude_sections == {"*": ["Hidden*"]}
+    assert cfg.exclude_modules == {"*": ["Skip Module"]}
 
 
 def test_canonical_keys_win_over_aliases():
@@ -83,6 +83,24 @@ def test_module_helpers_reflect_toggles():
 def test_from_dict_accepts_none():
     cfg = Config.from_dict(None)
     assert cfg.basedir == "./"
+
+
+def test_filter_values_are_normalized():
+    cfg = Config.from_dict(
+        {
+            "selected_courses": 12,
+            "exclude_links": "*calendar*",
+            "allowed_domains": "moodle.rwth-aachen.de",
+            "exclude_sections": {"*": "General", 42: ["Hidden", None]},
+            "exclude_modules": {"42": "Quiz*"},
+        }
+    )
+
+    assert cfg.selected_courses == ["12"]
+    assert cfg.exclude_links == {"*": ["*calendar*"]}
+    assert cfg.allowed_domains == {"*": ["moodle.rwth-aachen.de"]}
+    assert cfg.exclude_sections == {"*": ["General"], "42": ["Hidden"]}
+    assert cfg.exclude_modules == {"42": ["Quiz*"]}
 
 
 def test_cli_preserves_canonical_config_keys(tmp_path, monkeypatch):

--- a/tests/test_course_prefix_handling.py
+++ b/tests/test_course_prefix_handling.py
@@ -147,3 +147,27 @@ def test_clashing_files_without_name_clash_id_use_url_for_distinct_names():
     assert len(names) == 2
     assert len(set(names)) == 2
     assert "slides.pdf" not in names
+
+
+def test_opencast_name_clashes_use_uploaded_filename_suffix():
+    root = Node("", -1, "Root", None)
+    section = root.add_child("General", None, "Section")
+    section.add_child(
+        "Recording",
+        "episode-a",
+        "Opencast",
+        url="https://video.example.test/opencast/high.mp4",
+    )
+    section.add_child(
+        "Recording",
+        "episode-b",
+        "Opencast",
+        url="https://video.example.test/opencast/low.mp4",
+    )
+
+    root.remove_children_nameclashes()
+
+    assert [child.name for child in section.children] == [
+        "Recording_high.mp4",
+        "Recording_low.mp4",
+    ]

--- a/tests/test_download_behavior.py
+++ b/tests/test_download_behavior.py
@@ -1,7 +1,7 @@
 import hashlib
 import os
 
-from syncmymoodle import course_cache
+from syncmymoodle import course_cache, downloader
 from syncmymoodle.node import Node
 
 from .helpers import (
@@ -32,6 +32,23 @@ def sha1(data: bytes) -> str:
 
 def sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
+
+
+def test_classify_local_file_is_tristate(tmp_path):
+    from syncmymoodle.downloader import FileMatch, classify_local_file
+
+    f = tmp_path / "f.bin"
+    f.write_bytes(b"hello world\n")
+
+    assert classify_local_file(f, sha1(b"hello world\n")) is FileMatch.MATCH
+    assert classify_local_file(f, sha256(b"hello world\n")) is FileMatch.MATCH
+    assert classify_local_file(f, f'"{sha1(b"hello world\n")}"') is FileMatch.MATCH
+    assert classify_local_file(f, sha1(b"other")) is FileMatch.DIFFER
+
+    assert classify_local_file(f, '"66a1b2c3d4e5"') is FileMatch.UNKNOWN
+    assert classify_local_file(f, None) is FileMatch.UNKNOWN
+    assert classify_local_file(f, "") is FileMatch.UNKNOWN
+    assert classify_local_file(tmp_path / "nope", sha1(b"x")) is FileMatch.UNKNOWN
 
 
 def seed_course_cache(config, *, timemodified, etag, is_downloaded=True):
@@ -445,10 +462,10 @@ def test_etag_failure_falls_back_to_timestamp_heuristic_conflict(tmp_path, monke
     )
     new_body = _add_new_remote(syncer)
 
-    def boom(path, etag):
-        raise OSError("cannot read file for hashing")
+    def unverifiable(path, marker):
+        return downloader.FileMatch.UNKNOWN
 
-    monkeypatch.setattr("syncmymoodle.downloader.local_file_matches_etag", boom)
+    monkeypatch.setattr("syncmymoodle.downloader.classify_local_file", unverifiable)
 
     assert download_file(syncer, file_node) is True
     assert download_path.read_bytes() == new_body
@@ -469,10 +486,10 @@ def test_etag_failure_falls_back_to_timestamp_heuristic_no_conflict(
     os.utime(download_path, (1710000300, 1710000300))
     new_body = _add_new_remote(syncer)
 
-    def boom(path, etag):
-        raise OSError("cannot read file for hashing")
+    def unverifiable(path, marker):
+        return downloader.FileMatch.UNKNOWN
 
-    monkeypatch.setattr("syncmymoodle.downloader.local_file_matches_etag", boom)
+    monkeypatch.setattr("syncmymoodle.downloader.classify_local_file", unverifiable)
 
     assert download_file(syncer, file_node) is True
     assert download_path.read_bytes() == new_body

--- a/tests/test_download_behavior.py
+++ b/tests/test_download_behavior.py
@@ -3,6 +3,7 @@ import os
 
 from syncmymoodle import course_cache, downloader
 from syncmymoodle.node import Node, RemoteMarkerKind
+from syncmymoodle.storage import write_private_gzip_json
 
 from .helpers import (
     FakeResponse,
@@ -941,6 +942,56 @@ def test_cache_preserves_markers_for_failed_download_over_existing_file(tmp_path
     assert cached_file.timemodified == 100
     assert cached_file.etag == sha1(v1)
     assert cached_file.is_downloaded is True
+
+
+def test_legacy_is_downloaded_cache_key_is_read_as_handled(tmp_path):
+    config = {"basedir": str(tmp_path), "updatefiles": True}
+    content = b"legacy cached file"
+    root, cached_file = build_single_file_tree(
+        "slides.pdf", URL, timemodified=100, etag=sha1(content)
+    )
+    course_node = root.children[0].children[0]
+    course_path = node_path(make_context(config), course_node)
+    course_path.mkdir(parents=True, exist_ok=True)
+    write_private_gzip_json(
+        course_path / ".syncmymoodle_cache",
+        {
+            "format": "syncmymoodle.course-cache.v1",
+            "course": {
+                "name": course_node.name,
+                "id": course_node.id,
+                "type": course_node.type,
+                "children": [
+                    {
+                        "name": cached_file.parent.name,
+                        "id": cached_file.parent.id,
+                        "type": cached_file.parent.type,
+                        "children": [
+                            {
+                                "name": cached_file.name,
+                                "id": cached_file.id,
+                                "type": cached_file.type,
+                                "url": cached_file.url,
+                                "timemodified": cached_file.timemodified,
+                                "etag": cached_file.etag,
+                                "is_downloaded": True,
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+    )
+
+    syncer, current_file = make_run_syncer(config, timemodified=100)
+    download_path = node_path(syncer, current_file)
+    download_path.parent.mkdir(parents=True, exist_ok=True)
+    download_path.write_bytes(content)
+
+    assert download_file(syncer, current_file) is True
+    assert syncer.session.calls == []
+    assert download_path.read_bytes() == content
+    assert course_cache.get_old_node_for(syncer, current_file).is_handled is True
 
 
 def test_cache_preserves_content_hash_for_skipped_existing_file(tmp_path):

--- a/tests/test_download_behavior.py
+++ b/tests/test_download_behavior.py
@@ -2,7 +2,7 @@ import hashlib
 import os
 
 from syncmymoodle import course_cache, downloader
-from syncmymoodle.node import Node
+from syncmymoodle.node import Node, RemoteMarkerKind
 
 from .helpers import (
     FakeResponse,
@@ -147,7 +147,7 @@ def test_download_is_skipped_for_excluded_filetypes(tmp_path):
 
 def test_download_path_is_deduplicated_within_a_run(tmp_path):
     # Two distinct nodes that resolve to the same on-disk path must download
-    # only once, exercising the lazy-initialised ``_downloaded_paths`` guard.
+    # only once, exercising the per-run downloaded path guard.
     config = {"basedir": str(tmp_path)}
     syncer = make_context(config)
     syncer.session = FakeSession()
@@ -682,7 +682,7 @@ def test_unrecognized_partial_without_sidecar_is_not_resumed(tmp_path):
 SCIEBO_URL = "https://rwth-aachen.sciebo.de/public.php/webdav/notes.pdf"
 
 
-def _sciebo_tree(etag, is_downloaded=False, content_hash=None):
+def _sciebo_tree(etag, is_downloaded=False, content_hash=None, etag_kind=None):
     root = Node("", -1, "Root", None)
     semester = root.add_child("26ss", None, "Semester")
     course = semester.add_child("Download Course", 301, "Course")
@@ -692,17 +692,23 @@ def _sciebo_tree(etag, is_downloaded=False, content_hash=None):
         None,
         "Sciebo File",
         url=SCIEBO_URL,
-        additional_info={"Authorization": "Basic x"},
+        download_headers={"Authorization": "Basic x"},
         etag=etag,
+        etag_kind=etag_kind,
     )
     file_node.is_downloaded = is_downloaded
     file_node.content_hash = content_hash
     return root, file_node
 
 
-def _seed_sciebo_cache(config, etag, content, content_hash=None):
+def _seed_sciebo_cache(config, etag, content, content_hash=None, etag_kind=None):
     cache_syncer = make_context(config)
-    root, file_node = _sciebo_tree(etag, is_downloaded=True, content_hash=content_hash)
+    root, file_node = _sciebo_tree(
+        etag,
+        is_downloaded=True,
+        content_hash=content_hash,
+        etag_kind=etag_kind,
+    )
     cache_syncer.root_node = root
     course_cache.cache_root_node(cache_syncer)
     download_path = node_path(make_context(config), file_node)
@@ -869,6 +875,34 @@ def test_sciebo_changed_getetag_with_local_edit_preserves_conflict(tmp_path):
     assert conflicts[0].read_bytes() == edited
 
 
+def test_opaque_etag_is_not_treated_as_local_content_hash(tmp_path):
+    config = {"basedir": str(tmp_path), "updatefiles": True}
+    original = b"etag-looking marker is not a content proof"
+    old_marker = sha1(original)
+    download_path = _seed_sciebo_cache(
+        config,
+        old_marker,
+        original,
+        etag_kind=RemoteMarkerKind.OPAQUE,
+    )
+
+    syncer = make_context(config)
+    syncer.session = FakeSession()
+    new = b"remote v2"
+    syncer.session.add(
+        "GET",
+        SCIEBO_URL,
+        FakeResponse(headers={"Content-Type": "application/pdf"}, chunks=[new]),
+    )
+    _, current = _sciebo_tree(GETETAG_V2, etag_kind=RemoteMarkerKind.OPAQUE)
+
+    assert download_file(syncer, current) is True
+    assert download_path.read_bytes() == new
+    conflicts = list(download_path.parent.glob("*.syncconflict.*"))
+    assert len(conflicts) == 1
+    assert conflicts[0].read_bytes() == original
+
+
 # --------------------------------------------------------------------------
 # Cache reflects on-disk state, not optimistic Moodle markers (refinement)
 # --------------------------------------------------------------------------
@@ -933,7 +967,6 @@ def test_cache_preserves_content_hash_for_skipped_existing_file(tmp_path):
         "slides.pdf", URL, timemodified=100, etag='"v1"'
     )
     file_node.is_downloaded = True
-    syncer.downloaded_paths = set()
     syncer.root_node = root
     course_cache.cache_root_node(syncer)
 

--- a/tests/test_download_behavior.py
+++ b/tests/test_download_behavior.py
@@ -40,10 +40,11 @@ def test_classify_local_file_is_tristate(tmp_path):
 
     f = tmp_path / "f.bin"
     f.write_bytes(b"hello world\n")
+    hello_world_sha1 = sha1(b"hello world\n")
 
-    assert classify_local_file(f, sha1(b"hello world\n")) is FileMatch.MATCH
+    assert classify_local_file(f, hello_world_sha1) is FileMatch.MATCH
     assert classify_local_file(f, sha256(b"hello world\n")) is FileMatch.MATCH
-    assert classify_local_file(f, f'"{sha1(b"hello world\n")}"') is FileMatch.MATCH
+    assert classify_local_file(f, f'"{hello_world_sha1}"') is FileMatch.MATCH
     assert classify_local_file(f, sha1(b"other")) is FileMatch.DIFFER
 
     assert classify_local_file(f, '"66a1b2c3d4e5"') is FileMatch.UNKNOWN


### PR DESCRIPTION
Refactors sync download handling around explicit download states, typed cache metadata, and clearer tri-state decisions for skipping, updating, or conflict-preserving files.

Also cleans up config filter handling, name-clash logic, shared hash constants, stale download marker paths, and preserves compatibility with legacy caches that only stored `is_downloaded`.
