### PR TITLE
Harden CLI and Moodle API errors

### DIFF
--- a/syncmymoodle/cli.py
+++ b/syncmymoodle/cli.py
@@ -134,9 +134,12 @@ def main() -> None:
 
     if args.config:
         overwrite_config = Path(args.config)
-        if overwrite_config.is_file():
-            with overwrite_config.open() as f:
-                config = json.load(f)
+        if not overwrite_config.is_file():
+            # Silently continuing without the explicitly requested file would
+            # sync with unintended settings (or crash later); fail fast instead.
+            parser.error(f"config file not found: {args.config}")
+        with overwrite_config.open() as f:
+            config = json.load(f)
     else:
         config = {}
 
@@ -216,7 +219,7 @@ def main() -> None:
             sys.exit(1)
 
         if (
-            config.get("secretservicetotpsecret")
+            config.get("secret_service_store_totp_secret")
             and not args.totp
             and not config.get("totp")
         ):

--- a/syncmymoodle/moodle.py
+++ b/syncmymoodle/moodle.py
@@ -107,7 +107,30 @@ def get_moodle_wstoken(
     return token_parts[1]
 
 
-def get_all_courses(session: requests.Session, wstoken: str, user_id: Any) -> Any:
+def api_error_message(payload: Any) -> str | None:
+    """Return a description when ``payload`` is a Moodle error object.
+
+    Moodle webservice endpoints answer errors (expired token, missing
+    permission, hidden course, ...) with a JSON object carrying ``exception``/
+    ``errorcode`` instead of the expected data. Callers previously indexed
+    straight into the expected shape, turning such errors into KeyError
+    tracebacks.
+    """
+    if not isinstance(payload, dict):
+        return None
+    if not (payload.get("exception") or payload.get("errorcode")):
+        return None
+    message = payload.get("message") or payload.get("exception") or "unknown error"
+    errorcode = payload.get("errorcode")
+    return f"{message} (errorcode: {errorcode})" if errorcode else str(message)
+
+
+def get_all_courses(
+    session: requests.Session,
+    wstoken: str,
+    user_id: Any,
+    log: logging.Logger = logger,
+) -> Any:
     data = {
         "requests[0][function]": "core_enrol_get_users_courses",
         "requests[0][arguments]": json.dumps(
@@ -123,10 +146,35 @@ def get_all_courses(session: requests.Session, wstoken: str, user_id: Any) -> An
         "wsfunction": "tool_mobile_call_external_functions",
     }
     resp = session.post(MOODLE_REST_URL, params=params, data=data)
-    return json.loads(resp.json()["responses"][0]["data"])
+    payload = resp.json()
+
+    # Without the course list nothing can be synced, so API errors here are
+    # fatal. A clear message beats the KeyError traceback this used to raise.
+    error = api_error_message(payload)
+    if error is None:
+        responses = payload.get("responses") if isinstance(payload, dict) else None
+        first = responses[0] if responses else None
+        if first is None:
+            error = "unexpected response shape"
+        elif first.get("error"):
+            error = str(first.get("exception") or first.get("data"))
+        else:
+            return json.loads(first["data"])
+    log.critical(
+        "Failed to retrieve the course list from Moodle: %s. Your session "
+        "or webservice token may have expired; delete the cookie file and "
+        "try again.",
+        error,
+    )
+    sys.exit(1)
 
 
-def get_course(session: requests.Session, wstoken: str, course_id: Any) -> Any:
+def get_course(
+    session: requests.Session,
+    wstoken: str,
+    course_id: Any,
+    log: logging.Logger = logger,
+) -> Any:
     data = {
         "courseid": int(course_id),
         "moodlewssettingfilter": True,
@@ -139,7 +187,14 @@ def get_course(session: requests.Session, wstoken: str, course_id: Any) -> Any:
         "wsfunction": "core_course_get_contents",
     }
     resp = session.post(MOODLE_REST_URL, params=params, data=data)
-    return resp.json()
+    payload = resp.json()
+    # A course-specific error (hidden course, missing permission) should skip
+    # this course but not abort the whole sync.
+    error = api_error_message(payload)
+    if error is not None:
+        log.error("Skipping course %s: %s", course_id, error)
+        return []
+    return payload
 
 
 def get_userid(
@@ -159,7 +214,7 @@ def get_userid(
     }
     resp = session.post(MOODLE_REST_URL, params=params, data=data)
     payload = resp.json()
-    if not payload.get("userid") or not payload["userprivateaccesskey"]:
+    if not payload.get("userid") or not payload.get("userprivateaccesskey"):
         log.critical(
             f"Error while getting userid and access key: {json.dumps(payload, indent=4)}"
         )
@@ -167,7 +222,12 @@ def get_userid(
     return payload["userid"], payload["userprivateaccesskey"]
 
 
-def get_assignment(session: requests.Session, wstoken: str, course_id: Any) -> Any:
+def get_assignment(
+    session: requests.Session,
+    wstoken: str,
+    course_id: Any,
+    log: logging.Logger = logger,
+) -> Any:
     data = {
         "courseids[0]": int(course_id),
         "includenotenrolledcourses": 1,
@@ -181,7 +241,12 @@ def get_assignment(session: requests.Session, wstoken: str, course_id: Any) -> A
         "wsfunction": "mod_assign_get_assignments",
     }
     resp = session.post(MOODLE_REST_URL, params=params, data=data)
-    courses = resp.json()["courses"]
+    payload = resp.json()
+    error = api_error_message(payload)
+    if error is not None:
+        log.error("Skipping assignments for course %s: %s", course_id, error)
+        return None
+    courses = payload.get("courses") or []
     return courses[0] if courses else None
 
 
@@ -212,22 +277,29 @@ def get_assignment_submission_files(
     log.info(response.text)
 
     payload = response.json()
-    files = payload.get("lastattempt", {}).get("submission", {}).get("plugins", [])
-    files += payload.get("lastattempt", {}).get("teamsubmission", {}).get("plugins", [])
-    files += payload.get("feedback", {}).get("plugins", [])
+    # Per-assignment errors (e.g. no permission to view the submission) keep
+    # their historical behavior of contributing no files. The "or {}" also
+    # guards against JSON null values, which .get(key, {}) does not.
+    lastattempt = payload.get("lastattempt") or {}
+    files = (lastattempt.get("submission") or {}).get("plugins") or []
+    files += (lastattempt.get("teamsubmission") or {}).get("plugins") or []
+    files += (payload.get("feedback") or {}).get("plugins") or []
 
     files = [
         f.get("files", [])
         for p in files
         for f in p.get("fileareas", [])
-        if f["area"] in ["download", "submission_files", "feedback_files"]
+        if f.get("area") in ["download", "submission_files", "feedback_files"]
     ]
     files = [f for folder in files for f in folder]
     return files
 
 
 def get_folders_by_courses(
-    session: requests.Session, wstoken: str, course_id: Any
+    session: requests.Session,
+    wstoken: str,
+    course_id: Any,
+    log: logging.Logger = logger,
 ) -> Any:
     data = {
         "courseids[0]": str(course_id),
@@ -243,5 +315,9 @@ def get_folders_by_courses(
     }
 
     response = session.post(MOODLE_REST_URL, params=params, data=data)
-    folder = response.json()["folders"]
-    return folder
+    payload = response.json()
+    error = api_error_message(payload)
+    if error is not None:
+        log.error("Skipping folders for course %s: %s", course_id, error)
+        return []
+    return payload.get("folders") or []

--- a/syncmymoodle/moodle_files.py
+++ b/syncmymoodle/moodle_files.py
@@ -65,9 +65,15 @@ def add_moodle_content_file_node(
         return None
 
     mimetype = content.get("mimetype") or "unknown"
-    filename = urllib.parse.urlsplit(file_url).path.split("/")[-1]
-    if not filename:
-        filename = content.get("filename")
+    # A fileurl whose path ends in "/" yields an empty segment, and the payload
+    # may lack a filename too; a None node name would crash path sanitization
+    # at download time, so fall back to a placeholder (name-clash resolution
+    # disambiguates duplicates by URL).
+    filename = (
+        urllib.parse.urlsplit(file_url).path.split("/")[-1]
+        or content.get("filename")
+        or "file"
+    )
     return add_moodle_file_node(
         parent_node,
         "/",

--- a/syncmymoodle/totp.py
+++ b/syncmymoodle/totp.py
@@ -11,6 +11,9 @@ https://github.com/susam/mintotp
 
 
 def hotp(key: str, counter: int, digits: int = 6, digest: str = "sha1") -> str:
+    # Secrets are often copied with grouping spaces or dashes; base32 decoding
+    # would reject those, so strip them first.
+    key = key.replace(" ", "").replace("-", "")
     key_bytes = base64.b32decode(key.upper() + "=" * ((8 - len(key)) % 8))
     counter_bytes = struct.pack(">Q", counter)
     mac = hmac.new(key_bytes, counter_bytes, digest).digest()

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,164 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+import syncmymoodle.cli as cli
+from syncmymoodle import moodle
+from syncmymoodle.moodle import MOODLE_REST_URL
+from syncmymoodle.moodle_files import add_moodle_content_file_node
+from syncmymoodle.node import Node
+from syncmymoodle.totp import hotp
+
+from .helpers import FakeResponse, FakeSession
+
+INVALID_TOKEN_PAYLOAD = {
+    "exception": "moodle_exception",
+    "errorcode": "invalidtoken",
+    "message": "Invalid token - token expired",
+}
+
+
+# --------------------------------------------------------------------------
+# cli: explicit --config pointing at a missing file must fail clearly
+# --------------------------------------------------------------------------
+
+
+def test_missing_config_file_fails_clearly(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(
+        sys, "argv", ["syncmymoodle", "--config", str(tmp_path / "nope.json")]
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main()
+
+    # argparse error exits with 2 and prints to stderr; previously this was an
+    # UnboundLocalError traceback.
+    assert excinfo.value.code == 2
+    assert "config file not found" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------
+# cli: keyring TOTP guard must check the real config key
+# --------------------------------------------------------------------------
+
+
+def test_keyring_totp_secret_without_totp_provider_is_rejected(
+    tmp_path, monkeypatch, capsys
+):
+    keyring_calls = []
+    fake_keyring = SimpleNamespace(
+        get_password=lambda service, name: keyring_calls.append(name),
+        set_password=lambda service, name, value: keyring_calls.append(name),
+    )
+    monkeypatch.setattr(cli, "keyring", fake_keyring)
+    # Keep the run from picking up real config files.
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["syncmymoodle", "--secretservice", "--secretservicetotpsecret", "--user", "u"],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main()
+
+    # The guard used to check a key that is never set ("secretservicetotpsecret"),
+    # letting the run continue into keyring lookups keyed on None.
+    assert excinfo.value.code == 1
+    assert "TOTP provider" in capsys.readouterr().out
+    assert keyring_calls == []
+
+
+# --------------------------------------------------------------------------
+# moodle: API error payloads must not raise KeyError tracebacks
+# --------------------------------------------------------------------------
+
+
+def _error_session():
+    session = FakeSession()
+    session.add(
+        "POST", MOODLE_REST_URL, FakeResponse(json_payload=INVALID_TOKEN_PAYLOAD)
+    )
+    return session
+
+
+def test_get_all_courses_exits_clearly_on_api_error(caplog):
+    with pytest.raises(SystemExit) as excinfo:
+        moodle.get_all_courses(_error_session(), "token", 1)
+
+    assert excinfo.value.code == 1
+    assert "invalidtoken" in caplog.text
+
+
+def test_get_course_skips_course_on_api_error(caplog):
+    assert moodle.get_course(_error_session(), "token", 101) == []
+    assert "invalidtoken" in caplog.text
+
+
+def test_get_assignment_skips_course_on_api_error(caplog):
+    assert moodle.get_assignment(_error_session(), "token", 101) is None
+    assert "invalidtoken" in caplog.text
+
+
+def test_get_folders_skips_course_on_api_error(caplog):
+    assert moodle.get_folders_by_courses(_error_session(), "token", 101) == []
+    assert "invalidtoken" in caplog.text
+
+
+def test_submission_files_tolerate_null_fields():
+    # Moodle may serialize optional structures as JSON null; .get(key, {})
+    # does not guard against that.
+    session = FakeSession()
+    session.add(
+        "POST",
+        MOODLE_REST_URL,
+        FakeResponse(
+            json_payload={
+                "lastattempt": {"submission": None, "teamsubmission": None},
+                "feedback": {
+                    "plugins": [
+                        {
+                            "fileareas": [
+                                {"files": [{"filename": "f.pdf"}]},  # no "area"
+                                {
+                                    "area": "feedback_files",
+                                    "files": [{"filename": "graded.pdf"}],
+                                },
+                            ]
+                        }
+                    ]
+                },
+            }
+        ),
+    )
+
+    files = moodle.get_assignment_submission_files(session, "token", 1, 2)
+    assert files == [{"filename": "graded.pdf"}]
+
+
+# --------------------------------------------------------------------------
+# totp: secrets pasted with grouping separators must work
+# --------------------------------------------------------------------------
+
+
+def test_hotp_accepts_formatted_secrets():
+    clean = hotp("GEZDGNBVGY3TQOJQ", 42)
+    assert hotp("gezd gnbv gy3t qojq", 42) == clean
+    assert hotp("GEZD-GNBV-GY3T-QOJQ", 42) == clean
+
+
+# --------------------------------------------------------------------------
+# moodle_files: unnamed content files must not produce a None node name
+# --------------------------------------------------------------------------
+
+
+def test_content_file_without_filename_gets_placeholder_name():
+    parent = Node("Section", 1, "Section", None)
+    node = add_moodle_content_file_node(
+        parent,
+        {"fileurl": "https://moodle.rwth-aachen.de/pluginfile.php/1/dir/"},
+    )
+    assert node is not None
+    assert node.name == "file"


### PR DESCRIPTION
Handle missing config files, TOTP edge cases, Moodle API error payloads, and nameless file URLs without tracebacks.