### PR TITLE
Replace black, isort and flake8 with ruff

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,17 +30,14 @@ jobs:
           python -m pip install --upgrade pip
           pip install .[test]
 
-      - name: Check formatting with black and isort
-        run: |
-          black --check syncmymoodle tests
-          isort --check-only syncmymoodle tests
+      - name: Check formatting with ruff
+        run: ruff format --check syncmymoodle tests
+
+      - name: Lint with ruff
+        run: ruff check syncmymoodle tests
 
       - name: Run tests
         run: python -m pytest
-
-      # Disabled for now, until we refactor the main project
-      # - name: Lint with flake8
-      #   run: flake8 syncmymoodle
 
       - name: Analyze with mypy
         run: mypy syncmymoodle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,20 +34,25 @@ dependencies = [
 [project.optional-dependencies]
 keyring = ["keyring>=20.0.0"]
 test = [
-  "black",
-  "isort",
-  "flake8",
-  "flake8-bugbear",
+  "ruff",
   "mypy",
   "pytest",
   "types-requests"
 ]
 
-[tool.isort]
-profile = "black"
+[tool.ruff]
+target-version = "py311"
 
-[tool.black]
-target-version = ["py311"]
+[tool.ruff.lint]
+# E/W: pycodestyle, F: pyflakes, B: bugbear, I: import sorting (replaces
+# black + isort + flake8 + flake8-bugbear).
+# Complexity checking (C90) is turned off for now; the old flake8 config
+# selected it but never took effect. Enabling it flags several long
+# functions (e.g. rwth.login, sync_handlers) that might be worth a
+# refactor later.
+select = ["E", "W", "F", "B", "I"]
+# Line length is the formatter's job.
+ignore = ["E501"]
 
 [tool.mypy]
 check_untyped_defs = true
@@ -67,8 +72,3 @@ module = [
   "keyring",
 ]
 ignore_missing_imports = true
-
-[tool.flake8]
-max-line-length = 88
-select = ["C", "E", "F", "W", "B", "B901"]
-extend-ignore = ["E203", "E501", "W503"]

--- a/syncmymoodle/cli.py
+++ b/syncmymoodle/cli.py
@@ -9,9 +9,8 @@ from argparse import ArgumentParser
 from pathlib import Path
 from types import ModuleType
 
-from syncmymoodle import course_cache, downloader
+from syncmymoodle import course_cache, downloader, rwth, sync
 from syncmymoodle import moodle as moodle_api
-from syncmymoodle import rwth, sync
 from syncmymoodle.config import Config
 from syncmymoodle.constants import (
     COURSE_PREFIX_HANDLING_OPTIONS,

--- a/syncmymoodle/downloader.py
+++ b/syncmymoodle/downloader.py
@@ -110,7 +110,7 @@ def download_response_is_usable(
 ) -> bool:
     if response.status_code == 204:
         log.warning(
-            "Skipping download of %s from %s because the server returned no " "content",
+            "Skipping download of %s from %s because the server returned no content",
             downloadpath,
             node.url,
         )
@@ -118,7 +118,7 @@ def download_response_is_usable(
 
     if not (200 <= response.status_code < 300):
         log.warning(
-            "Skipping download of %s from %s because the server returned " "HTTP %s",
+            "Skipping download of %s from %s because the server returned HTTP %s",
             downloadpath,
             node.url,
             response.status_code,

--- a/syncmymoodle/filters.py
+++ b/syncmymoodle/filters.py
@@ -130,8 +130,7 @@ def should_skip_section(
     values = [section.get("name"), section.get("id")]
     if matches_any_pattern(values, patterns):
         log.info(
-            "Skipping section %s (%s) in course %s because it matches "
-            "exclude_sections",
+            "Skipping section %s (%s) in course %s because it matches exclude_sections",
             section.get("name"),
             section.get("id"),
             course_id,
@@ -167,8 +166,7 @@ def should_skip_module(
     values = [module_id, module_name, modname, *module_urls]
     if matches_any_pattern(values, patterns):
         log.info(
-            "Skipping module %s (%s) in course %s because it matches "
-            "exclude_modules",
+            "Skipping module %s (%s) in course %s because it matches exclude_modules",
             module_name,
             module_id,
             course_id,

--- a/syncmymoodle/links.py
+++ b/syncmymoodle/links.py
@@ -80,7 +80,7 @@ def scan_for_links(
                 parent_node.add_child(
                     filename,
                     None,
-                    f'Linked file [{response.headers["Content-Type"]}]',
+                    f"Linked file [{response.headers['Content-Type']}]",
                     url=text,
                     etag=response.headers.get("ETag"),
                     etag_kind=(

--- a/syncmymoodle/moodle.py
+++ b/syncmymoodle/moodle.py
@@ -69,12 +69,11 @@ def get_moodle_wstoken(
             "returned an unexpected redirect instead of a token."
         )
         log.info(
-            "Unexpected mobile launch redirect target: "
-            f"{location_path or '<missing>'}"
+            f"Unexpected mobile launch redirect target: {location_path or '<missing>'}"
         )
         if body_prefix:
             log.info(
-                "Unexpected mobile launch response body (truncated): " f"{body_prefix}"
+                f"Unexpected mobile launch response body (truncated): {body_prefix}"
             )
         sys.exit(1)
 

--- a/syncmymoodle/node.py
+++ b/syncmymoodle/node.py
@@ -174,7 +174,11 @@ class Node:
                     ][0]
                 )
             except IndexError:
-                raise Exception("The path is not found in this root node. Wrong path?")
+                # The IndexError just means "no matching child"; its traceback
+                # adds no useful context to the error.
+                raise Exception(
+                    "The path is not found in this root node. Wrong path?"
+                ) from None
         return target_node[-1]
 
     def _clash_suffix(self) -> str:

--- a/syncmymoodle/sync.py
+++ b/syncmymoodle/sync.py
@@ -2,9 +2,8 @@ import json
 import logging
 from typing import cast
 
-from syncmymoodle import filters
+from syncmymoodle import filters, sync_handlers
 from syncmymoodle import moodle as moodle_api
-from syncmymoodle import sync_handlers
 from syncmymoodle.context import SyncContext
 from syncmymoodle.node import Node
 

--- a/syncmymoodle/sync_handlers.py
+++ b/syncmymoodle/sync_handlers.py
@@ -5,12 +5,10 @@ from typing import Any, Callable, cast
 
 from bs4 import BeautifulSoup as bs
 
-from syncmymoodle import filters
+from syncmymoodle import filters, moodle_files, pathing
 from syncmymoodle import links as links_api
 from syncmymoodle import moodle as moodle_api
-from syncmymoodle import moodle_files
 from syncmymoodle import opencast as opencast_api
-from syncmymoodle import pathing
 from syncmymoodle.constants import MOODLE_URL
 from syncmymoodle.context import SyncContext
 from syncmymoodle.node import Node
@@ -190,7 +188,7 @@ def handle_embedded_link_module(
     if module["modname"] == "page":
         opencast_enabled = ctx.config.url_module_enabled("opencast")
         html_url = (
-            module.get("url") or f'{MOODLE_URL}mod/page/view.php?id={module["id"]}'
+            module.get("url") or f"{MOODLE_URL}mod/page/view.php?id={module['id']}"
         )
         scan_page_links = not ctx.config.nolinks and not filters.should_skip_url(
             ctx.config, html_url, "page link"
@@ -263,7 +261,7 @@ def handle_embedded_link_module(
                     )
     # "Interactive" h5p videos
     elif module["modname"] == "h5pactivity":
-        html_url = f'{MOODLE_URL}mod/h5pactivity/view.php?id={module["id"]}'
+        html_url = f"{MOODLE_URL}mod/h5pactivity/view.php?id={module['id']}"
         html = bs(
             ctx.require_session().get(html_url).text,
             features="lxml",
@@ -317,7 +315,7 @@ def handle_opencast_lti_module(
     if module["modname"] != "lti" or not ctx.config.url_module_enabled("opencast"):
         return
 
-    info_url = f'{MOODLE_URL}mod/lti/launch.php?id={module["id"]}' "&triggerview=0"
+    info_url = f"{MOODLE_URL}mod/lti/launch.php?id={module['id']}&triggerview=0"
     try:
         info_response = ctx.require_session().get(info_url)
     except Exception:
@@ -356,7 +354,7 @@ def handle_opencast_lti_module(
             return
 
         series_url = (
-            f"{opencast_api.OPENCAST_SEARCH_URL}" f"?limit=100&offset=0&sid={series_id}"
+            f"{opencast_api.OPENCAST_SEARCH_URL}?limit=100&offset=0&sid={series_id}"
         )
         series_response = opencast_api.fetch_json(
             ctx, series_url, f"series {series_id}", log
@@ -430,7 +428,7 @@ def handle_quiz_module(
     if module["modname"] != "quiz" or not ctx.config.url_module_enabled("quiz"):
         return
 
-    info_url = f'{MOODLE_URL}mod/quiz/view.php?id={module["id"]}'
+    info_url = f"{MOODLE_URL}mod/quiz/view.php?id={module['id']}"
     info_res = bs(ctx.require_session().get(info_url).text, features="lxml")
     attempts = info_res.find_all(
         "a",

--- a/tests/test_course_prefix_handling.py
+++ b/tests/test_course_prefix_handling.py
@@ -71,8 +71,7 @@ def test_page_content_url_normalization_preserves_larger_content_ids():
         "mod_page/content/315/page-video.mp4"
     )
     assert normalized_child.url == (
-        "https://moodle.rwth-aachen.de/pluginfile.php/104/"
-        "mod_page/content/legacy.pdf"
+        "https://moodle.rwth-aachen.de/pluginfile.php/104/mod_page/content/legacy.pdf"
     )
 
 

--- a/tests/test_sync_fixtures.py
+++ b/tests/test_sync_fixtures.py
@@ -52,20 +52,17 @@ def test_assignment_intro_opencast_embed_is_added_to_assignment_node(monkeypatch
     monkeypatch.setattr(
         opencast,
         "authenticate_episode",
-        lambda ctx, course_id, episode_id, *a, **k: authenticated.append(
-            (course_id, episode_id)
-        )
-        or True,
+        lambda ctx, course_id, episode_id, *a, **k: (
+            authenticated.append((course_id, episode_id)) or True
+        ),
     )
     monkeypatch.setattr(
         opencast,
         "resolve_track_from_episode",
-        lambda ctx, episode_id, *a, **k: (
-            opencast.OpencastTrack(
-                f"https://video.example.test/{episode_id}/presentation.mp4",
-                checksum_type="md5",
-                checksum="11111111111111111111111111111111",
-            )
+        lambda ctx, episode_id, *a, **k: opencast.OpencastTrack(
+            f"https://video.example.test/{episode_id}/presentation.mp4",
+            checksum_type="md5",
+            checksum="11111111111111111111111111111111",
         ),
     )
 
@@ -215,8 +212,7 @@ def test_sciebo_share_without_token_input_uses_url_token():
         "Sciebo File | Section/sciebo-share-token-123/readme.pdf | "
         "https://rwth-aachen.sciebo.de/public.php/webdav/readme.pdf |  | "
         "1111111111111111111111111111111111111111",
-        "Sciebo Folder | Section/sciebo-share-token-123/slides |  |  | "
-        '"folder-slides"',
+        'Sciebo Folder | Section/sciebo-share-token-123/slides |  |  | "folder-slides"',
         "Sciebo File | Section/sciebo-share-token-123/slides/deck.pdf | "
         "https://rwth-aachen.sciebo.de/public.php/webdav/slides/deck.pdf |  | "
         "2222222222222222222222222222222222222222",
@@ -288,12 +284,10 @@ def test_mixed_course_sync_tree_covers_common_module_surfaces(monkeypatch):
     monkeypatch.setattr(
         opencast,
         "resolve_track_from_episode",
-        lambda ctx, episode_id, *a, **k: (
-            opencast.OpencastTrack(
-                f"https://video.example.test/{episode_id}/presentation.mp4",
-                checksum_type="md5",
-                checksum="33333333333333333333333333333333",
-            )
+        lambda ctx, episode_id, *a, **k: opencast.OpencastTrack(
+            f"https://video.example.test/{episode_id}/presentation.mp4",
+            checksum_type="md5",
+            checksum="33333333333333333333333333333333",
         ),
     )
 


### PR DESCRIPTION
One tool now covers formatting (ruff format), import sorting (I), pycodestyle/pyflakes (E, W, F) and bugbear (B), with its configuration living natively in pyproject.toml. With the previous refactoring, Lint is now enforced again.

Complexity checking (C90) is disabled for now, enabling it flags several long functions that might be worth a refactor later.