### PR TITLE
Re-add safe quiz attempt snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Downloads the following materials:
 * Resource files
 * URLs: OpenCast, Youtube and Sciebo videos/files, and all other non HTML files
 * Folders
-* Quizzes (**Disabled by default**)
+* Quizzes: Downloads offline HTML of quiz attempts, with opt-in PDF generation
 * Pages and Labels: Embedded Opencast and Youtube Videos
 
 On subsequent runs, *syncMyMoodle* can also update existing files when the
@@ -180,6 +180,7 @@ configuration does:
     "basedir": "./", // The base directory where all your files will be synced to
     "course_prefix_handling": "suffix", // How to handle local course folders starting with a two-character prefix like "(VO) ": "keep" (backwards-compatible default), "remove", or "suffix" (recommended)
     "cookie_file": "./session", // The location of the session/cookie file, which can be used instead of a password.
+    "chromium_path": "", // Optional path to a Chrome/Chromium/Edge binary for quiz PDF rendering. Leave empty to auto-detect.
     "use_secret_service": false, // Use the system keyring (see README), instead of a password.
     "secret_service_store_totp_secret": false, // Store the TOTP secret in the system keyring.
     "no_links": false, // Skip links embedded in pages. Warning: This *will* prevent Onlycast videos from being downloaded.
@@ -190,7 +191,7 @@ configuration does:
             "youtube": true, // Include YouTube Links/Embeds
             "opencast": true, // Include Opencast Links/Embeds
             "sciebo": true, // Include Sciebo Links/Embeds
-            "quiz": false // Quiz PDF generation is currently disabled for security reasons
+            "quiz": "html" // Save quiz review attempts: "off", "html" (self-contained snapshot, default), "pdf" (browser-rendered PDF), or "both"
         },
         "folder": true // Include folders
     },
@@ -235,9 +236,19 @@ syncMyMoodle stores per-course metadata in a hidden `.syncmymoodle_cache` file
 inside each synced course directory. Delete that file to force a fresh metadata
 cache for a course.
 
-Quiz PDF generation is currently disabled. The previous optional
-`pdfkit`/`wkhtmltopdf` renderer is no longer maintained
-and has open security issues leading to RCE.
+Quiz review attempts are saved as self-contained HTML snapshots by default
+(`url.quiz = "html"`). The snapshot inlines same-origin Moodle assets and strips
+network-bearing content so it remains readable offline and does not contact
+Moodle when opened later. Set `url.quiz` to `"off"` to disable quiz snapshots.
+
+PDF rendering is separate and opt-in: set `url.quiz` to `"pdf"` or `"both"` to
+render snapshots with a locally installed Chrome, Chromium or Edge browser. This
+uses the browser's built-in headless PDF output, which avoids the old
+`pdfkit`/`wkhtmltopdf` renderer and its security issues, but syncMyMoodle does
+not launch a browser unless you explicitly choose one of the PDF modes. The
+browser is auto-detected on PATH and in the usual macOS/Windows install
+locations, or you can point `chromium_path` at a specific binary. When no
+browser is found, the HTML snapshot is kept as a fallback so nothing is lost.
 
 ### TOTP
 

--- a/config.json.example
+++ b/config.json.example
@@ -9,6 +9,7 @@
     "basedir": "./",
     "course_prefix_handling": "suffix",
     "cookie_file": "./session",
+    "chromium_path": "",
     "use_secret_service": false,
     "secret_service_store_totp_secret": false,
     "no_links": false,
@@ -19,7 +20,7 @@
             "youtube": true,
             "opencast": true,
             "sciebo": true,
-            "quiz": false
+            "quiz": "html"
         },
         "folder": true
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ dependencies = [
   "beautifulsoup4>=4.0.0",
   "yt-dlp>=2021.12.27",
   "tqdm>=4.0.0",
-  "lxml>=5.0.0"
+  "lxml>=5.0.0",
+  "latex2mathml>=3.77.0"
 ]
 
 [project.optional-dependencies]
@@ -69,6 +70,7 @@ module = [
   "bs4",
   "yt_dlp",
   "tqdm",
+  "latex2mathml",
   "keyring",
 ]
 ignore_missing_imports = true

--- a/syncmymoodle/__init__.py
+++ b/syncmymoodle/__init__.py
@@ -25,6 +25,7 @@ Sync tree:
 
 Download:
     downloader      tree walk, update/conflict policy, ETag/resume handling
+    quiz            quiz review HTML snapshots and Chromium PDF rendering
 
 Persistence:
     storage         private gzip-JSON and cookie (de)serialization
@@ -36,5 +37,6 @@ Core (cross-cutting):
     context         SyncContext: per-run mutable state (session, caches, ...)
     config          Config: typed, normalized view of user settings
     constants       shared URLs, regexes and option constants
+    http_utils      small shared HTTP response helpers
     filters         course/section/module/link skip rules
 """

--- a/syncmymoodle/cli.py
+++ b/syncmymoodle/cli.py
@@ -191,17 +191,6 @@ def main() -> None:
 
     logging.basicConfig(level=args.loglevel)
 
-    url_modules = (
-        config.get("used_modules", {}).get("url")
-        if isinstance(config.get("used_modules"), dict)
-        else None
-    )
-    if isinstance(url_modules, dict) and url_modules.get("quiz"):
-        logger.warning(
-            "Quiz PDF generation is disabled until the pdfkit/wkhtmltopdf "
-            "renderer is replaced with a safer implementation."
-        )
-
     if keyring and config.get("use_secret_service"):
         if config.get("password"):
             logger.critical("You need to remove your password from your config file!")

--- a/syncmymoodle/config.py
+++ b/syncmymoodle/config.py
@@ -1,17 +1,22 @@
 from __future__ import annotations
 
 import copy
+import logging
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, TypeAlias
 
+from syncmymoodle.constants import QUIZ_MODES
+
 PatternConfig: TypeAlias = dict[str, list[str]]
+
+logger = logging.getLogger(__name__)
 
 # Default module toggle tree used when the config file does not define one.
 DEFAULT_USED_MODULES: dict[str, Any] = {
     "assign": True,
     "resource": True,
-    "url": {"youtube": True, "opencast": True, "sciebo": True, "quiz": False},
+    "url": {"youtube": True, "opencast": True, "sciebo": True, "quiz": "html"},
     "folder": True,
 }
 
@@ -37,6 +42,32 @@ def normalize_pattern_config(value: Any) -> PatternConfig:
     return {"*": patterns} if patterns else {}
 
 
+def normalize_quiz_mode(value: Any, log: logging.Logger = logger) -> str:
+    """Map a configured quiz value onto one of :data:`QUIZ_MODES`.
+
+    Accepts the legacy booleans (``True`` -> ``"both"``, ``False``/absent ->
+    ``"off"``) as well as the mode strings ``"off"``/``"html"``/``"pdf"``/
+    ``"both"``. Unrecognized values are treated as ``"off"`` with a warning.
+    """
+    if value is True:
+        return "both"
+    if value is False or value is None:
+        return "off"
+    mode = str(value).strip().lower()
+    if mode in QUIZ_MODES:
+        return mode
+    if mode in ("none", "false", "no"):
+        return "off"
+    if mode in ("true", "yes"):
+        return "both"
+    log.warning(
+        "Unrecognized quiz mode %r; expected one of %s. Disabling quizzes.",
+        value,
+        ", ".join(QUIZ_MODES),
+    )
+    return "off"
+
+
 @dataclass
 class Config:
     """Typed view of the user configuration.
@@ -56,6 +87,10 @@ class Config:
     # Local sync target and naming
     basedir: str = "./"
     course_prefix_handling: str = "keep"
+
+    # Explicit path to a Chromium-family browser used to render quiz PDFs. When
+    # unset, the browser is auto-discovered (see downloader.find_chromium).
+    chromium_path: str | None = None
 
     # Link/download behaviour
     nolinks: bool = False
@@ -82,11 +117,12 @@ class Config:
         raw = dict(raw or {})
 
         used_modules = copy.deepcopy(raw.get("used_modules") or DEFAULT_USED_MODULES)
-        # Quiz PDF generation is disabled until the pdfkit/wkhtmltopdf renderer
-        # is replaced with a safer implementation. Enforce it regardless of the
-        # configured value so no entry point can accidentally re-enable it.
+        # Normalize the quiz toggle to a mode string so the rest of the code can
+        # branch on off/html/pdf/both without re-parsing legacy booleans.
         if isinstance(used_modules.get("url"), dict):
-            used_modules["url"]["quiz"] = False
+            used_modules["url"]["quiz"] = normalize_quiz_mode(
+                used_modules["url"].get("quiz")
+            )
 
         return cls(
             user=raw.get("user"),
@@ -94,6 +130,7 @@ class Config:
             totp=raw.get("totp"),
             totpsecret=raw.get("totpsecret"),
             cookie_file=raw.get("cookie_file") or "./session",
+            chromium_path=raw.get("chromium_path") or None,
             basedir=raw.get("basedir") or "./",
             course_prefix_handling=raw.get("course_prefix_handling") or "keep",
             nolinks=bool(raw.get("nolinks", raw.get("no_links", False))),
@@ -122,4 +159,16 @@ class Config:
     def url_module_enabled(self, name: str) -> bool:
         """Whether a url sub-module is enabled (youtube/opencast/sciebo/quiz)."""
         url = self.used_modules.get("url")
-        return bool(url.get(name)) if isinstance(url, dict) else False
+        if not isinstance(url, dict):
+            return False
+        if name == "quiz":
+            # quiz is a mode string ("off"/"html"/"pdf"/"both"), not a bool.
+            return normalize_quiz_mode(url.get("quiz")) != "off"
+        return bool(url.get(name))
+
+    @property
+    def quiz_mode(self) -> str:
+        """Quiz output mode: one of off/html/pdf/both (see QUIZ_MODES)."""
+        url = self.used_modules.get("url")
+        value = url.get("quiz") if isinstance(url, dict) else None
+        return normalize_quiz_mode(value)

--- a/syncmymoodle/constants.py
+++ b/syncmymoodle/constants.py
@@ -1,7 +1,11 @@
 import re
+import urllib.parse
 
 # Characters removed from any path segment derived from Moodle names/URLs.
 INVALID_CHARS = '~"#%&*:<>?/\\{|}'
+
+# Chunk size for streamed HTTP reads.
+DEFAULT_BLOCK_SIZE = 1024
 
 YOUTUBE_ID_LENGTH = 11
 HASH_ALGOS_BY_LENGTH = {32: "md5", 40: "sha1", 64: "sha256"}
@@ -16,6 +20,8 @@ OPENCAST_LINK_RE = re.compile(
 )
 SCIEBO_LINK_RE = re.compile(r"https://rwth-aachen\.sciebo\.de/s/[a-zA-Z0-9-]+")
 MOODLE_URL = "https://moodle.rwth-aachen.de/"
+# Canonical host for same-origin checks (no port, lowercase).
+MOODLE_NETLOC = urllib.parse.urlparse(MOODLE_URL).netloc.lower()
 RWTH_HOMEPAGE_URL = "https://www.rwth-aachen.de/"
 RWTH_STATUS_URL = "https://maintenance.itc.rwth-aachen.de/ticket/status/messages"
 RWTH_MOODLE_STATUS_URL = (
@@ -32,3 +38,44 @@ RWTH_DISRUPTIVE_STATUS_CLASSES = {
 }
 COURSE_PREFIX_RE = re.compile(r"^\((?P<prefix>[^()]{2})\) +(?P<course_name>.+)$")
 COURSE_PREFIX_HANDLING_OPTIONS = ("keep", "remove", "suffix")
+
+# Quiz review pages can be saved as a self-contained HTML snapshot ("html"),
+# rendered to PDF via a headless Chromium-family browser ("pdf"), both, or not
+# at all ("off"). Legacy boolean config values map to "both"/"off".
+QUIZ_MODES = ("off", "html", "pdf", "both")
+
+# Per-resource and total budgets for inlining quiz snapshot assets. This keeps
+# quiz snapshots offline-safe without accidentally pulling huge media files.
+QUIZ_ASSET_MAX_BYTES = 10 * 1024 * 1024
+QUIZ_SNAPSHOT_MAX_ASSET_BYTES = 50 * 1024 * 1024
+
+# Chromium-family binaries used to render quiz snapshots to PDF, in preference
+# order. Looked up on PATH via shutil.which; CHROMIUM_KNOWN_PATHS covers the
+# platform-specific install locations that are usually not on PATH.
+CHROMIUM_BINARY_NAMES = (
+    "chromium",
+    "chromium-browser",
+    "chrome",
+    "google-chrome",
+    "google-chrome-stable",
+    "msedge",
+    "microsoft-edge",
+    "microsoft-edge-stable",
+)
+
+# Absolute locations checked when none of CHROMIUM_BINARY_NAMES is on PATH
+# (macOS app bundles and Windows Program Files installs).
+CHROMIUM_KNOWN_PATHS = (
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+    r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+    r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe",
+    r"C:\Program Files\Microsoft\Edge\Application\msedge.exe",
+    r"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe",
+)
+
+# Headless render budget (ms). Chromium's --virtual-time-budget lets client-side
+# MathJax finish typesetting before the page is printed, replacing the fixed
+# javascript-delay the old wkhtmltopdf renderer relied on.
+CHROMIUM_PDF_TIMEOUT_MS = 30000

--- a/syncmymoodle/downloader.py
+++ b/syncmymoodle/downloader.py
@@ -20,7 +20,10 @@ from syncmymoodle.constants import (
     YOUTUBE_ID_LENGTH,
 )
 from syncmymoodle.context import SyncContext
-from syncmymoodle.http_utils import content_type_without_parameters
+from syncmymoodle.http_utils import (
+    HTML_CONTENT_TYPES,
+    content_type_without_parameters,
+)
 from syncmymoodle.node import Node, RemoteMarkerKind
 
 logger = logging.getLogger(__name__)
@@ -124,7 +127,7 @@ def download_response_is_usable(
         return False
 
     content_type = content_type_without_parameters(response)
-    if content_type in {"text/html", "application/xhtml+xml"}:
+    if content_type in HTML_CONTENT_TYPES:
         if not node_allows_html_download(node):
             log.warning(
                 "Skipping download of %s from %s because the server returned "
@@ -209,6 +212,20 @@ def remote_unchanged(
     return False
 
 
+def align_mtime_with_timemodified(node: Node, downloadpath: Path) -> None:
+    """Set the local file's mtime to Moodle's timemodified.
+
+    Later runs use the timestamp to detect local changes
+    """
+    if getattr(node, "timemodified", None) is None:
+        return
+    try:
+        ts = int(node.timemodified)
+        os.utime(downloadpath, (ts, ts))
+    except (OSError, OverflowError, ValueError):
+        pass
+
+
 def local_verification_marker(old_node: Node | None) -> str | None:
     if old_node is None:
         return None
@@ -248,12 +265,7 @@ def assess_local_copy(
     ):
         node.etag = remote_etag
         node.etag_kind = remote_etag_kind
-        if getattr(node, "timemodified", None) is not None:
-            try:
-                ts = int(node.timemodified)
-                os.utime(downloadpath, (ts, ts))
-            except (OSError, OverflowError, ValueError):
-                pass
+        align_mtime_with_timemodified(node, downloadpath)
         return LocalCopyState.UP_TO_DATE
     return LocalCopyState.MODIFIED
 
@@ -468,12 +480,7 @@ def record_download_metadata(
     except OSError:
         pass
 
-    if node.timemodified is not None:
-        try:
-            ts = int(node.timemodified)
-            os.utime(downloadpath, (ts, ts))
-        except (OSError, OverflowError, ValueError):
-            pass
+    align_mtime_with_timemodified(node, downloadpath)
 
     if etag_header is not None and node.etag is None:
         node.etag = etag_header

--- a/syncmymoodle/downloader.py
+++ b/syncmymoodle/downloader.py
@@ -13,14 +13,17 @@ from typing import Any
 import yt_dlp
 from tqdm import tqdm
 
-from syncmymoodle import course_cache, filters, pathing
-from syncmymoodle.constants import HASH_ALGOS_BY_LENGTH, YOUTUBE_ID_LENGTH
+from syncmymoodle import course_cache, filters, pathing, quiz
+from syncmymoodle.constants import (
+    DEFAULT_BLOCK_SIZE,
+    HASH_ALGOS_BY_LENGTH,
+    YOUTUBE_ID_LENGTH,
+)
 from syncmymoodle.context import SyncContext
+from syncmymoodle.http_utils import content_type_without_parameters
 from syncmymoodle.node import Node, RemoteMarkerKind
 
 logger = logging.getLogger(__name__)
-
-DEFAULT_BLOCK_SIZE = 1024
 
 
 class FileMatch(Enum):
@@ -81,11 +84,6 @@ def classify_local_file(path: Path, marker: str | None) -> FileMatch:
     except OSError:
         return FileMatch.UNKNOWN
     return FileMatch.MATCH if digest == hex_str else FileMatch.DIFFER
-
-
-def content_type_without_parameters(response: Any) -> str:
-    content_type = str(response.headers.get("Content-Type", ""))
-    return content_type.split(";", 1)[0].strip().lower()
 
 
 def node_allows_html_download(node: Any) -> bool:
@@ -575,11 +573,11 @@ def download_node_tree(
                 except Exception:
                     log.exception(f"Failed to download the module {cur_node}")
             elif cur_node.type == "Quiz":
-                log.warning(
-                    "Skipping quiz PDF generation for %s because it is disabled "
-                    "for security.",
-                    cur_node.name,
-                )
+                try:
+                    if quiz.download_quiz(ctx, cur_node, log):
+                        cur_node.mark_handled()
+                except Exception:
+                    log.exception(f"Failed to download the module {cur_node}")
             else:
                 try:
                     if download_file(ctx, cur_node, log):
@@ -618,11 +616,3 @@ def scan_and_download_youtube(
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:
         ydl.download([link])
     return True
-
-
-def download_quiz(node: Any, log: logging.Logger = logger) -> bool:
-    log.warning(
-        "Quiz PDF generation is disabled until the pdfkit/wkhtmltopdf "
-        "renderer is replaced with a safer implementation."
-    )
-    return False

--- a/syncmymoodle/http_utils.py
+++ b/syncmymoodle/http_utils.py
@@ -1,0 +1,9 @@
+"""Small helpers for interpreting HTTP responses, shared across modules."""
+
+from typing import Any
+
+
+def content_type_without_parameters(response: Any) -> str:
+    """Return the media type of a response, without parameters like charset."""
+    content_type = str(response.headers.get("Content-Type", ""))
+    return content_type.split(";", 1)[0].strip().lower()

--- a/syncmymoodle/http_utils.py
+++ b/syncmymoodle/http_utils.py
@@ -1,9 +1,41 @@
-"""Small helpers for interpreting HTTP responses, shared across modules."""
+"""Small helpers for interpreting HTTP responses and fetched pages."""
 
-from typing import Any
+import urllib.parse
+from typing import Any, cast
+
+from bs4 import BeautifulSoup
+
+# Media types that indicate an HTML page rather than a downloadable file
+# (e.g. a login or error page served in place of the expected content).
+HTML_CONTENT_TYPES = frozenset({"text/html", "application/xhtml+xml"})
+
+
+def parse_html(markup: str) -> BeautifulSoup:
+    """Parse HTML with the project's canonical parser.
+
+    BeautifulSoup parsers differ in how they repair broken markup
+    """
+    return BeautifulSoup(markup, features="lxml")
+
+
+def media_type_without_parameters(value: Any) -> str:
+    """Strip parameters like charset from a media type string."""
+    return str(value or "").split(";", 1)[0].strip().lower()
 
 
 def content_type_without_parameters(response: Any) -> str:
     """Return the media type of a response, without parameters like charset."""
-    content_type = str(response.headers.get("Content-Type", ""))
-    return content_type.split(";", 1)[0].strip().lower()
+    return media_type_without_parameters(response.headers.get("Content-Type", ""))
+
+
+def filename_from_url(url: Any) -> str:
+    """Return the last path segment of a URL, ignoring query and fragment."""
+    return urllib.parse.urlsplit(str(url)).path.split("/")[-1]
+
+
+def get_input_value(soup: Any, name: str) -> str | None:
+    """Return the value of a named ``<input>`` field in a parsed page."""
+    input_tag = soup.find("input", {"name": name})
+    if input_tag and input_tag.get("value"):
+        return cast(str, input_tag["value"])
+    return None

--- a/syncmymoodle/links.py
+++ b/syncmymoodle/links.py
@@ -4,12 +4,12 @@ from typing import Any, cast
 
 from bs4 import BeautifulSoup as bs
 
-from syncmymoodle import downloader as downloader_api
 from syncmymoodle import filters
 from syncmymoodle import opencast as opencast_api
 from syncmymoodle import sciebo as sciebo_api
 from syncmymoodle.constants import OPENCAST_LINK_RE, YOUTUBE_LINK_RE
 from syncmymoodle.context import SyncContext
+from syncmymoodle.http_utils import content_type_without_parameters
 from syncmymoodle.node import Node, RemoteMarkerKind
 
 logger = logging.getLogger(__name__)
@@ -66,7 +66,7 @@ def scan_for_links(
             if filters.should_skip_url(ctx.config, text, "link", log):
                 return
             response = ctx.require_session().head(text, allow_redirects=True)
-            content_type = downloader_api.content_type_without_parameters(response)
+            content_type = content_type_without_parameters(response)
             if "youtube.com" in text or "youtu.be" in text:
                 # workaround for youtube providing bad headers when using HEAD
                 pass

--- a/syncmymoodle/links.py
+++ b/syncmymoodle/links.py
@@ -2,14 +2,17 @@ import logging
 import urllib.parse
 from typing import Any, cast
 
-from bs4 import BeautifulSoup as bs
-
 from syncmymoodle import filters
 from syncmymoodle import opencast as opencast_api
 from syncmymoodle import sciebo as sciebo_api
 from syncmymoodle.constants import OPENCAST_LINK_RE, YOUTUBE_LINK_RE
 from syncmymoodle.context import SyncContext
-from syncmymoodle.http_utils import content_type_without_parameters
+from syncmymoodle.http_utils import (
+    HTML_CONTENT_TYPES,
+    content_type_without_parameters,
+    filename_from_url,
+    parse_html,
+)
 from syncmymoodle.node import Node, RemoteMarkerKind
 
 logger = logging.getLogger(__name__)
@@ -25,7 +28,7 @@ def scan_html_text_for_links(
     log: logging.Logger = logger,
 ) -> None:
     if "video-js" in html_text and "<source" in html_text.lower():
-        soup = bs(html_text, features="lxml")
+        soup = parse_html(html_text)
         videojs = soup.select_one(".video-js")
         if videojs:
             videojs = videojs.select_one("source")
@@ -73,10 +76,10 @@ def scan_for_links(
             elif (
                 200 <= response.status_code < 300
                 and content_type
-                and content_type not in {"text/html", "application/xhtml+xml"}
+                and content_type not in HTML_CONTENT_TYPES
             ):
                 # non html links, assume the filename is in the path
-                filename = urllib.parse.urlsplit(text).path.split("/")[-1]
+                filename = filename_from_url(text)
                 parent_node.add_child(
                     filename,
                     None,

--- a/syncmymoodle/moodle.py
+++ b/syncmymoodle/moodle.py
@@ -7,11 +7,12 @@ from typing import Any
 
 import requests
 
+from syncmymoodle.constants import MOODLE_URL
+
 logger = logging.getLogger(__name__)
 
-MOODLE_HOST = "moodle.rwth-aachen.de"
-MOODLE_REST_URL = f"https://{MOODLE_HOST}/webservice/rest/server.php"
-MOODLE_MOBILE_LAUNCH_URL = f"https://{MOODLE_HOST}/admin/tool/mobile/launch.php"
+MOODLE_REST_URL = f"{MOODLE_URL}webservice/rest/server.php"
+MOODLE_MOBILE_LAUNCH_URL = f"{MOODLE_URL}admin/tool/mobile/launch.php"
 
 
 def get_moodle_wstoken(

--- a/syncmymoodle/moodle_files.py
+++ b/syncmymoodle/moodle_files.py
@@ -1,6 +1,10 @@
-import urllib.parse
 from typing import Any
 
+from syncmymoodle.http_utils import (
+    HTML_CONTENT_TYPES,
+    filename_from_url,
+    media_type_without_parameters,
+)
 from syncmymoodle.node import NAME_CLASH_ID_UNSET, Node
 from syncmymoodle.pathing import sanitize_path_part
 
@@ -69,11 +73,7 @@ def add_moodle_content_file_node(
     # may lack a filename too; a None node name would crash path sanitization
     # at download time, so fall back to a placeholder (name-clash resolution
     # disambiguates duplicates by URL).
-    filename = (
-        urllib.parse.urlsplit(file_url).path.split("/")[-1]
-        or content.get("filename")
-        or "file"
-    )
+    filename = filename_from_url(file_url) or content.get("filename") or "file"
     return add_moodle_file_node(
         parent_node,
         "/",
@@ -93,13 +93,8 @@ def is_direct_moodle_file_content(
     if not file_url or content.get("type") != "file":
         return False
 
-    mimetype = str(content.get("mimetype") or "").split(";", 1)[0].lower()
-    if not mimetype or mimetype in {
-        "document/unknown",
-        "unknown",
-        "text/html",
-        "application/xhtml+xml",
-    }:
+    mimetype = media_type_without_parameters(content.get("mimetype"))
+    if not mimetype or mimetype in {"document/unknown", "unknown"} | HTML_CONTENT_TYPES:
         return False
     if mimetype.startswith("text/"):
         return False

--- a/syncmymoodle/opencast.py
+++ b/syncmymoodle/opencast.py
@@ -5,14 +5,13 @@ import urllib.parse
 from dataclasses import dataclass
 from typing import Any, cast
 
-from bs4 import BeautifulSoup as bs
-
 from syncmymoodle.constants import (
     CHECKSUM_LENGTHS_BY_ALGO,
     MOODLE_URL,
     RWTH_MOODLE_STATUS_URL,
 )
 from syncmymoodle.context import SyncContext
+from syncmymoodle.http_utils import parse_html
 from syncmymoodle.node import RemoteMarkerKind
 
 logger = logging.getLogger(__name__)
@@ -95,13 +94,6 @@ def extract_lti_form_data(soup: Any) -> dict[str, Any]:
     }
 
 
-def get_input_value(soup: Any, name: str) -> str | None:
-    input_tag = soup.find("input", {"name": name})
-    if input_tag and input_tag.get("value"):
-        return cast(str, input_tag["value"])
-    return None
-
-
 def submit_lti_form(
     ctx: SyncContext,
     engage_data: dict[str, Any],
@@ -153,7 +145,7 @@ def fetch_lti_form_data(
         log_backend_issue(ctx, response.text, log)
         return None
 
-    soup = bs(response.text, features="lxml")
+    soup = parse_html(response.text)
     engage_data = extract_lti_form_data(soup)
     if not engage_data:
         log.info("Opencast: no LTI form fields found for %s", context)

--- a/syncmymoodle/quiz.py
+++ b/syncmymoodle/quiz.py
@@ -35,7 +35,11 @@ from syncmymoodle.constants import (
     QUIZ_SNAPSHOT_MAX_ASSET_BYTES,
 )
 from syncmymoodle.context import SyncContext
-from syncmymoodle.http_utils import content_type_without_parameters
+from syncmymoodle.http_utils import (
+    HTML_CONTENT_TYPES,
+    content_type_without_parameters,
+    parse_html,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -241,7 +245,7 @@ def _fetch_quiz_asset_data_uri(
         url,
         remaining_bytes,
         # Never embed HTML (login/error pages) as an asset.
-        lambda ct: ct not in {"text/html", "application/xhtml+xml"},
+        lambda ct: ct not in HTML_CONTENT_TYPES,
         "asset",
         "application/octet-stream",
         log,
@@ -698,7 +702,7 @@ def build_quiz_snapshot(
     referenced assets are stripped, direct quiz images and inline-style assets
     are embedded as data URIs with size budgets.
     """
-    soup = bs(html, features="lxml")
+    soup = parse_html(html)
     head = _ensure_quiz_snapshot_head(soup)
     asset_cache: dict[str, str | None] = {}
     remaining_bytes = [QUIZ_SNAPSHOT_MAX_ASSET_BYTES]
@@ -814,7 +818,7 @@ def quiz_response_is_usable(
         return False
 
     content_type = content_type_without_parameters(response)
-    if content_type and content_type not in {"text/html", "application/xhtml+xml"}:
+    if content_type and content_type not in HTML_CONTENT_TYPES:
         log.warning(
             "Skipping quiz snapshot for %s because Moodle returned %s",
             requested_url,

--- a/syncmymoodle/quiz.py
+++ b/syncmymoodle/quiz.py
@@ -1,0 +1,921 @@
+"""Quiz review capture: offline HTML snapshots and optional Chromium PDF rendering.
+
+The snapshot pipeline strips active content, inlines same-origin assets as
+data URIs within size budgets, converts LaTeX to MathML, removes network-
+bearing attributes, and pins a restrictive Content-Security-Policy, so the
+saved page renders offline without executing or fetching anything.
+"""
+
+import base64
+import logging
+import mimetypes
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import urllib.parse
+from contextlib import closing
+from pathlib import Path
+from typing import Any
+
+import latex2mathml.converter
+from bs4 import BeautifulSoup as bs
+
+from syncmymoodle import pathing
+from syncmymoodle.config import Config
+from syncmymoodle.constants import (
+    CHROMIUM_BINARY_NAMES,
+    CHROMIUM_KNOWN_PATHS,
+    CHROMIUM_PDF_TIMEOUT_MS,
+    DEFAULT_BLOCK_SIZE,
+    MOODLE_NETLOC,
+    MOODLE_URL,
+    QUIZ_ASSET_MAX_BYTES,
+    QUIZ_SNAPSHOT_MAX_ASSET_BYTES,
+)
+from syncmymoodle.context import SyncContext
+from syncmymoodle.http_utils import content_type_without_parameters
+
+logger = logging.getLogger(__name__)
+
+CSS_IMPORT_RE = re.compile(r"@import\s+(?:url\()?[^;]+;", re.IGNORECASE)
+CSS_URL_RE = re.compile(r"url\(\s*(['\"]?)(.*?)\1\s*\)", re.IGNORECASE)
+CSS_FONT_FACE_RE = re.compile(
+    r"@font-face\s*\{(?P<body>.*?)\}", re.IGNORECASE | re.DOTALL
+)
+CSS_RULE_RE = re.compile(r"(?P<selectors>[^{}@][^{}]*)\{(?P<body>[^{}]*)\}", re.DOTALL)
+CSS_FONT_FAMILY_RE = re.compile(r"font-family\s*:\s*(?P<value>[^;{}]+)", re.IGNORECASE)
+CSS_PSEUDO_ELEMENT_RE = re.compile(
+    r"::?(?:after|backdrop|before|cue|cue-region|first-letter|first-line|"
+    r"file-selector-button|grammar-error|marker|part\([^)]*\)|placeholder|"
+    r"selection|slotted\([^)]*\)|spelling-error|target-text)"
+)
+TEX_MATH_RE = re.compile(
+    r"\\\((?P<inline>.+?)\\\)|\\\[(?P<block>.+?)\\\]|\$\$(?P<dollar_block>.+?)\$\$",
+    re.DOTALL,
+)
+ICON_FONT_FAMILY_MARKERS = ("font awesome", "fontawesome")
+QUIZ_URL_ATTRS = {
+    "action",
+    "background",
+    "cite",
+    "data",
+    "formaction",
+    "href",
+    "longdesc",
+    "manifest",
+    "ping",
+    "poster",
+    "src",
+    "srcset",
+    "xlink:href",
+}
+
+
+def _quiz_asset_url(raw_url: Any, base_url: str) -> str | None:
+    raw = str(raw_url or "").strip()
+    if not raw:
+        return None
+    lowered = raw.lower()
+    if lowered.startswith("data:"):
+        return raw
+    if (
+        raw.startswith("#")
+        or lowered.startswith("javascript:")
+        or lowered.startswith("mailto:")
+        or lowered.startswith("tel:")
+        or lowered.startswith("blob:")
+    ):
+        return None
+
+    url = urllib.parse.urljoin(base_url, raw)
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        return None
+    if parsed.netloc.lower() != MOODLE_NETLOC:
+        return None
+    return url
+
+
+def _response_body_bytes(response: Any) -> bytes:
+    content = getattr(response, "content", None)
+    if content is not None:
+        return bytes(content)
+
+    chunks = list(response.iter_content(DEFAULT_BLOCK_SIZE))
+    if chunks:
+        return b"".join(chunks)
+
+    text = getattr(response, "text", "")
+    return str(text).encode("utf-8")
+
+
+def _read_capped_body(response: Any, cap: int) -> bytes | None:
+    """Read a response body incrementally, returning None once it exceeds cap.
+
+    Streaming means an asset that omits Content-Length cannot buffer an
+    unbounded amount into memory before we notice it is too large.
+    """
+    if cap < 0:
+        return None
+    total = 0
+    chunks: list[bytes] = []
+    streamed = False
+    for chunk in response.iter_content(DEFAULT_BLOCK_SIZE):
+        streamed = True
+        if not chunk:
+            continue
+        total += len(chunk)
+        if total > cap:
+            return None
+        chunks.append(chunk)
+    if streamed:
+        return b"".join(chunks)
+
+    # No streamed content (e.g. a fake exposing only .text/.content); fall back
+    # to the buffered body but still honor the cap.
+    body = _response_body_bytes(response)
+    return body if len(body) <= cap else None
+
+
+def _response_content_type(
+    response: Any,
+    url: str,
+    default: str = "application/octet-stream",
+) -> str:
+    content_type = content_type_without_parameters(response)
+    if not content_type:
+        guessed = mimetypes.guess_type(urllib.parse.urlparse(url).path)[0]
+        content_type = guessed or default
+    return content_type
+
+
+def _content_length_too_large(response: Any) -> bool:
+    content_length = response.headers.get("Content-Length")
+    if not content_length:
+        return False
+    try:
+        return int(content_length) > QUIZ_ASSET_MAX_BYTES
+    except ValueError:
+        return False
+
+
+def _fetch_quiz_body(
+    session: Any,
+    url: str,
+    remaining_bytes: list[int],
+    accept_content_type: Any,
+    description: str,
+    default_content_type: str,
+    log: logging.Logger = logger,
+) -> tuple[bytes, str, str | None] | None:
+    """Shared, size-capped transport for quiz snapshot resources.
+
+    Performs the streamed same-origin GET with the status, Content-Length,
+    content-type and byte-budget checks in one place. Returns ``(body, content_type,
+    response_encoding)`` or ``None`` when the resource must be skipped.
+    """
+    try:
+        with closing(session.get(url, timeout=15, stream=True)) as response:
+            if not (200 <= response.status_code < 300):
+                log.info(
+                    "Skipping quiz snapshot %s %s because Moodle returned HTTP %s",
+                    description,
+                    url,
+                    response.status_code,
+                )
+                return None
+            if _content_length_too_large(response):
+                log.info("Skipping oversized quiz snapshot %s %s", description, url)
+                return None
+
+            content_type = _response_content_type(response, url, default_content_type)
+            if not accept_content_type(content_type):
+                log.info(
+                    "Skipping quiz snapshot %s %s with content type %s",
+                    description,
+                    url,
+                    content_type,
+                )
+                return None
+
+            encoding = getattr(response, "encoding", None)
+            body = _read_capped_body(
+                response, min(QUIZ_ASSET_MAX_BYTES, remaining_bytes[0])
+            )
+    except Exception:
+        log.info(
+            "Skipping quiz snapshot %s %s because it could not be fetched",
+            description,
+            url,
+        )
+        return None
+
+    if body is None:
+        log.info("Skipping oversized quiz snapshot %s %s", description, url)
+        return None
+
+    remaining_bytes[0] -= len(body)
+    return body, content_type, encoding
+
+
+def _fetch_quiz_asset_data_uri(
+    session: Any,
+    raw_url: Any,
+    base_url: str,
+    asset_cache: dict[str, str | None],
+    remaining_bytes: list[int],
+    log: logging.Logger = logger,
+) -> str | None:
+    url = _quiz_asset_url(raw_url, base_url)
+    if url is None:
+        return None
+    if url.lower().startswith("data:"):
+        return url
+    if url in asset_cache:
+        return asset_cache[url]
+
+    fetched = _fetch_quiz_body(
+        session,
+        url,
+        remaining_bytes,
+        # Never embed HTML (login/error pages) as an asset.
+        lambda ct: ct not in {"text/html", "application/xhtml+xml"},
+        "asset",
+        "application/octet-stream",
+        log,
+    )
+    if fetched is None or not fetched[0]:
+        asset_cache[url] = None
+        return None
+
+    body, content_type, _ = fetched
+    encoded = base64.b64encode(body).decode("ascii")
+    data_uri = f"data:{content_type};base64,{encoded}"
+    asset_cache[url] = data_uri
+    return data_uri
+
+
+def _fetch_quiz_stylesheet(
+    session: Any,
+    raw_url: Any,
+    base_url: str,
+    remaining_bytes: list[int],
+    log: logging.Logger = logger,
+) -> str | None:
+    url = _quiz_asset_url(raw_url, base_url)
+    if url is None or url.lower().startswith("data:"):
+        return None
+
+    def accepts(content_type: str) -> bool:
+        if content_type in {"text/css", "text/plain", "application/x-css"}:
+            return True
+        return Path(urllib.parse.urlparse(url).path).suffix.lower() == ".css"
+
+    fetched = _fetch_quiz_body(
+        session, url, remaining_bytes, accepts, "stylesheet", "text/css", log
+    )
+    if fetched is None:
+        return None
+
+    body, _, encoding = fetched
+    css = body.decode(encoding or "utf-8", errors="replace")
+    return _resolve_quiz_css_urls(CSS_IMPORT_RE.sub("", css), url)
+
+
+def _inline_quiz_css_urls(
+    css: str,
+    session: Any | None,
+    base_url: str,
+    asset_cache: dict[str, str | None],
+    remaining_bytes: list[int],
+    log: logging.Logger = logger,
+) -> str:
+    css = CSS_IMPORT_RE.sub("", css)
+
+    def replace(match: re.Match[str]) -> str:
+        raw_url = match.group(2).strip()
+        if not raw_url or raw_url.startswith("#"):
+            return match.group(0)
+        if raw_url.lower().startswith("data:"):
+            return match.group(0)
+        if session is None:
+            return 'url("data:,")'
+        data_uri = _fetch_quiz_asset_data_uri(
+            session,
+            raw_url,
+            base_url,
+            asset_cache,
+            remaining_bytes,
+            log,
+        )
+        if data_uri is None:
+            return 'url("data:,")'
+        return f'url("{data_uri}")'
+
+    return CSS_URL_RE.sub(replace, css)
+
+
+def _resolve_quiz_css_urls(css: str, base_url: str) -> str:
+    def replace(match: re.Match[str]) -> str:
+        raw_url = match.group(2).strip()
+        if (
+            not raw_url
+            or raw_url.startswith("#")
+            or raw_url.lower().startswith("data:")
+        ):
+            return match.group(0)
+        url = _quiz_asset_url(raw_url, base_url)
+        if url is None:
+            return match.group(0)
+        return f'url("{url}")'
+
+    return CSS_URL_RE.sub(replace, css)
+
+
+def _css_font_family_names(value: str) -> set[str]:
+    quoted = {
+        match.group(1).strip()
+        for match in re.finditer(r"""["']([^"']+)["']""", value)
+        if match.group(1).strip()
+    }
+    if quoted:
+        return quoted
+
+    families: set[str] = set()
+    for part in value.split(","):
+        family = part.strip()
+        family = re.sub(r"\s*!important\s*$", "", family, flags=re.IGNORECASE)
+        family = family.strip()
+        if family and not family.lower().startswith(("var(", "inherit", "initial")):
+            families.add(family)
+    return families
+
+
+def _css_font_face_families(font_face_body: str) -> set[str]:
+    families: set[str] = set()
+    for match in CSS_FONT_FAMILY_RE.finditer(font_face_body):
+        families.update(_css_font_family_names(match.group("value")))
+    return families
+
+
+def _is_quiz_icon_font_family(family: str) -> bool:
+    family_lower = family.lower()
+    return any(marker in family_lower for marker in ICON_FONT_FAMILY_MARKERS)
+
+
+def _split_css_selectors(selectors: str) -> list[str]:
+    result: list[str] = []
+    current: list[str] = []
+    depth = 0
+    quote: str | None = None
+    for char in selectors:
+        if quote:
+            current.append(char)
+            if char == quote:
+                quote = None
+            continue
+        if char in {"'", '"'}:
+            current.append(char)
+            quote = char
+            continue
+        if char in "([":  # commas inside :is(), :not(), attributes, etc.
+            depth += 1
+        elif char in ")]" and depth:
+            depth -= 1
+        if char == "," and depth == 0:
+            selector = "".join(current).strip()
+            if selector:
+                result.append(selector)
+            current = []
+            continue
+        current.append(char)
+
+    selector = "".join(current).strip()
+    if selector:
+        result.append(selector)
+    return result
+
+
+def _quiz_selector_matches(soup: Any, selector: str) -> bool:
+    selector = CSS_PSEUDO_ELEMENT_RE.sub("", selector).strip()
+    if not selector:
+        return False
+    try:
+        return soup.select_one(selector) is not None
+    except Exception:
+        return False
+
+
+def _needed_quiz_icon_font_families(css: str, soup: Any) -> set[str]:
+    needed: set[str] = set()
+    css_without_font_faces = CSS_FONT_FACE_RE.sub("", css)
+
+    for match in CSS_RULE_RE.finditer(css_without_font_faces):
+        body = match.group("body")
+        if "font-family" not in body.lower():
+            continue
+
+        families: set[str] = set()
+        for family_match in CSS_FONT_FAMILY_RE.finditer(body):
+            families.update(_css_font_family_names(family_match.group("value")))
+        icon_families = {
+            family for family in families if _is_quiz_icon_font_family(family)
+        }
+        if not icon_families:
+            continue
+
+        if any(
+            _quiz_selector_matches(soup, selector)
+            for selector in _split_css_selectors(match.group("selectors"))
+        ):
+            needed.update(icon_families)
+
+    return needed
+
+
+def _inline_needed_quiz_stylesheet_assets(
+    css: str,
+    soup: Any,
+    session: Any | None,
+    base_url: str,
+    asset_cache: dict[str, str | None],
+    remaining_bytes: list[int],
+    log: logging.Logger = logger,
+) -> str:
+    needed_icon_families = _needed_quiz_icon_font_families(css, soup)
+
+    def replace_font_face(match: re.Match[str]) -> str:
+        families = _css_font_face_families(match.group("body"))
+        if not families.intersection(needed_icon_families):
+            return ""
+        return _inline_quiz_css_urls(
+            match.group(0), session, base_url, asset_cache, remaining_bytes, log
+        )
+
+    css = CSS_FONT_FACE_RE.sub(replace_font_face, css)
+    return _inline_quiz_css_urls(css, None, base_url, {}, remaining_bytes, log)
+
+
+def _ensure_quiz_snapshot_head(soup: Any) -> Any:
+    html_tag = soup.find("html")
+    if html_tag is None:
+        html_tag = soup.new_tag("html")
+        html_tag.extend(soup.contents)
+        soup.append(html_tag)
+
+    head = soup.find("head")
+    if head is None:
+        head = soup.new_tag("head")
+        html_tag.insert(0, head)
+    return head
+
+
+def _add_quiz_snapshot_meta(soup: Any, head: Any) -> None:
+    for meta in soup.find_all("meta"):
+        http_equiv = str(meta.get("http-equiv") or "").lower()
+        name = str(meta.get("name") or "").lower()
+        if http_equiv in {"content-security-policy", "refresh"} or name == "referrer":
+            meta.decompose()
+
+    csp = soup.new_tag("meta")
+    csp["http-equiv"] = "Content-Security-Policy"
+    csp["content"] = (
+        "default-src 'none'; "
+        "img-src data:; "
+        "font-src data:; "
+        "style-src 'unsafe-inline'; "
+        "script-src 'none'; "
+        "connect-src 'none'; "
+        "media-src 'none'; "
+        "object-src 'none'; "
+        "frame-src 'none'; "
+        "form-action 'none'; "
+        "base-uri 'none'"
+    )
+    head.insert(0, csp)
+
+    referrer = soup.new_tag("meta")
+    referrer["name"] = "referrer"
+    referrer["content"] = "no-referrer"
+    head.insert(1, referrer)
+
+    # The snapshot is written as UTF-8; make that explicit so it decodes
+    # correctly when opened from disk even if the source page relied on the
+    # HTTP charset header. Keep it first so detection happens early.
+    has_charset = soup.find("meta", attrs={"charset": True}) is not None or any(
+        str(meta.get("http-equiv") or "").lower() == "content-type"
+        for meta in soup.find_all("meta")
+    )
+    if not has_charset:
+        charset = soup.new_tag("meta")
+        charset["charset"] = "utf-8"
+        head.insert(0, charset)
+
+
+def _strip_quiz_snapshot_active_content(soup: Any) -> None:
+    for tag in soup.find_all(["script", "iframe", "object", "embed", "video", "audio"]):
+        tag.decompose()
+    for base in soup.find_all("base"):
+        base.decompose()
+    for footer in soup.select(
+        "footer, #page-footer, #footnote, .footer-popover, "
+        ".footer-container, [data-region='footer-container']"
+    ):
+        footer.decompose()
+    for nav in soup.select("nav[aria-label='Site-Navigation'], .activity-navigation"):
+        nav.decompose()
+    for nav in soup.find_all("div", {"id": "nav-drawer"}):
+        nav.decompose()
+    for form in soup.find_all("form"):
+        form.attrs.pop("action", None)
+        form.attrs.pop("method", None)
+
+
+def _inline_quiz_snapshot_stylesheets(
+    soup: Any,
+    session: Any | None,
+    base_url: str,
+    remaining_bytes: list[int],
+    log: logging.Logger = logger,
+) -> None:
+    for link in list(soup.find_all("link")):
+        rel = link.get("rel") or []
+        rel_values = {str(value).lower() for value in rel}
+        href = link.get("href")
+        if "stylesheet" in rel_values and href and session is not None:
+            css = _fetch_quiz_stylesheet(
+                session,
+                href,
+                base_url,
+                remaining_bytes,
+                log,
+            )
+            if css is not None:
+                style = soup.new_tag("style")
+                style.string = css
+                link.replace_with(style)
+                continue
+        link.decompose()
+
+
+def _inline_quiz_snapshot_element_assets(
+    soup: Any,
+    session: Any | None,
+    base_url: str,
+    asset_cache: dict[str, str | None],
+    remaining_bytes: list[int],
+    log: logging.Logger = logger,
+) -> None:
+    for style in soup.find_all("style"):
+        if style.string:
+            style.string.replace_with(
+                _inline_needed_quiz_stylesheet_assets(
+                    str(style.string),
+                    soup,
+                    session,
+                    base_url,
+                    asset_cache,
+                    remaining_bytes,
+                    log,
+                )
+            )
+
+    for tag in soup.find_all(True):
+        style_value = tag.get("style")
+        if style_value:
+            tag["style"] = _inline_quiz_css_urls(
+                str(style_value),
+                session,
+                base_url,
+                asset_cache,
+                remaining_bytes,
+                log,
+            )
+
+        if tag.name == "img":
+            data_uri = (
+                _fetch_quiz_asset_data_uri(
+                    session,
+                    tag.get("src"),
+                    base_url,
+                    asset_cache,
+                    remaining_bytes,
+                    log,
+                )
+                if session is not None
+                else None
+            )
+            if data_uri is not None:
+                tag["src"] = data_uri
+            else:
+                tag.attrs.pop("src", None)
+                tag["alt"] = tag.get("alt") or "[image omitted from offline snapshot]"
+            tag.attrs.pop("srcset", None)
+
+
+def _remove_quiz_snapshot_network_attributes(soup: Any) -> None:
+    for tag in soup.find_all(True):
+        for attr in list(tag.attrs):
+            attr_lower = str(attr).lower()
+            value = tag.attrs[attr]
+            if attr_lower.startswith("on"):
+                del tag.attrs[attr]
+                continue
+            if attr_lower not in QUIZ_URL_ATTRS:
+                continue
+            value_str = str(value or "").strip()
+            if attr_lower in {"src", "xlink:href"} and value_str.lower().startswith(
+                "data:"
+            ):
+                continue
+            if attr_lower == "href" and value_str.startswith("#"):
+                continue
+            del tag.attrs[attr]
+
+
+def _latex_match_to_node(soup: Any, match: re.Match[str], log: logging.Logger) -> Any:
+    """Convert one TEX_MATH_RE match into a MathML tag.
+
+    Falls back to the original text when the expression has no capture or
+    cannot be converted.
+    """
+    display = "inline"
+    latex = match.group("inline")
+    if latex is None:
+        display = "block"
+        latex = match.group("block") or match.group("dollar_block")
+    if latex is None:
+        return soup.new_string(match.group(0))
+
+    try:
+        mathml = latex2mathml.converter.convert(latex.strip(), display=display)
+        math_tag = bs(mathml, features="xml").find("math")
+    except Exception:
+        log.info("Could not convert quiz LaTeX expression to MathML: %s", latex)
+        math_tag = None
+
+    if math_tag is None:
+        return soup.new_string(match.group(0))
+    return math_tag
+
+
+def _convert_quiz_latex_to_mathml(
+    soup: Any,
+    log: logging.Logger = logger,
+) -> None:
+    for text_node in list(soup.find_all(string=TEX_MATH_RE)):
+        if text_node.find_parent(["style", "script", "template", "textarea"]):
+            continue
+        text = str(text_node)
+        pieces: list[Any] = []
+        last_end = 0
+        for match in TEX_MATH_RE.finditer(text):
+            if match.start() > last_end:
+                pieces.append(soup.new_string(text[last_end : match.start()]))
+            pieces.append(_latex_match_to_node(soup, match, log))
+            last_end = match.end()
+
+        if last_end < len(text):
+            pieces.append(soup.new_string(text[last_end:]))
+
+        for piece in pieces:
+            text_node.insert_before(piece)
+        text_node.extract()
+
+
+def build_quiz_snapshot(
+    html: str,
+    session: Any | None = None,
+    base_url: str = MOODLE_URL,
+    log: logging.Logger = logger,
+) -> str:
+    """Turn a fetched quiz-review page into an offline HTML snapshot.
+
+    The output contains a restrictive CSP, no active script/frame content, and
+    no network-bearing URL attributes. Stylesheets are kept for layout but their
+    referenced assets are stripped, direct quiz images and inline-style assets
+    are embedded as data URIs with size budgets.
+    """
+    soup = bs(html, features="lxml")
+    head = _ensure_quiz_snapshot_head(soup)
+    asset_cache: dict[str, str | None] = {}
+    remaining_bytes = [QUIZ_SNAPSHOT_MAX_ASSET_BYTES]
+
+    _strip_quiz_snapshot_active_content(soup)
+    _inline_quiz_snapshot_stylesheets(
+        soup,
+        session,
+        base_url,
+        remaining_bytes,
+        log,
+    )
+    _inline_quiz_snapshot_element_assets(
+        soup,
+        session,
+        base_url,
+        asset_cache,
+        remaining_bytes,
+        log,
+    )
+    _convert_quiz_latex_to_mathml(soup, log)
+    _remove_quiz_snapshot_network_attributes(soup)
+    _add_quiz_snapshot_meta(soup, head)
+    return str(soup)
+
+
+def find_chromium(config: Config, log: logging.Logger = logger) -> str | None:
+    """Locate a Chromium-family browser for PDF rendering.
+
+    Prefers an explicitly configured ``chromium_path``, then binaries on PATH,
+    then well-known macOS/Windows install locations. Returns ``None`` when no
+    browser is found.
+    """
+    if config.chromium_path:
+        if Path(config.chromium_path).exists():
+            return config.chromium_path
+        log.warning(
+            "Configured chromium_path %s does not exist; falling back to "
+            "auto-discovery.",
+            config.chromium_path,
+        )
+    for name in CHROMIUM_BINARY_NAMES:
+        found = shutil.which(name)
+        if found:
+            return found
+    for path in CHROMIUM_KNOWN_PATHS:
+        if Path(path).exists():
+            return path
+    return None
+
+
+def render_pdf_with_chromium(
+    browser: str,
+    html_path: Path,
+    pdf_path: Path,
+    log: logging.Logger = logger,
+) -> bool:
+    """Render a local HTML snapshot to PDF via headless Chromium.
+
+    Uses the browser's built-in ``--print-to-pdf`` so we depend only on an
+    (actively maintained, sandboxed) browser the user already has.
+    Returns ``True`` only if a PDF was produced.
+    """
+    try:
+        with tempfile.TemporaryDirectory(prefix="syncmymoodle-chromium-") as profile:
+            cmd = [
+                browser,
+                "--headless=new",
+                "--disable-gpu",
+                "--disable-background-networking",
+                "--disable-component-update",
+                "--disable-default-apps",
+                "--disable-extensions",
+                "--disable-sync",
+                "--no-default-browser-check",
+                "--no-first-run",
+                "--no-pdf-header-footer",
+                f"--user-data-dir={profile}",
+                f"--virtual-time-budget={CHROMIUM_PDF_TIMEOUT_MS}",
+                f"--print-to-pdf={os.fspath(pdf_path)}",
+                html_path.resolve().as_uri(),
+            ]
+            result = subprocess.run(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                timeout=CHROMIUM_PDF_TIMEOUT_MS / 1000 + 60,
+            )
+    except (OSError, subprocess.SubprocessError) as exc:
+        log.warning("Failed to run %s for quiz PDF rendering: %s", browser, exc)
+        return False
+    if result.returncode != 0 or not pdf_path.exists():
+        log.warning(
+            "Chromium (%s) did not produce a quiz PDF (exit code %s).",
+            browser,
+            result.returncode,
+        )
+        return False
+    return True
+
+
+def quiz_response_is_usable(
+    response: Any,
+    requested_url: str,
+    log: logging.Logger = logger,
+) -> bool:
+    if not (200 <= response.status_code < 300):
+        log.warning(
+            "Skipping quiz snapshot for %s because Moodle returned HTTP %s",
+            requested_url,
+            response.status_code,
+        )
+        return False
+
+    content_type = content_type_without_parameters(response)
+    if content_type and content_type not in {"text/html", "application/xhtml+xml"}:
+        log.warning(
+            "Skipping quiz snapshot for %s because Moodle returned %s",
+            requested_url,
+            content_type,
+        )
+        return False
+
+    final_url = response.url or requested_url
+    parsed = urllib.parse.urlparse(final_url)
+    if parsed.netloc and parsed.netloc.lower() != MOODLE_NETLOC:
+        log.warning(
+            "Skipping quiz snapshot for %s because it redirected to %s",
+            requested_url,
+            final_url,
+        )
+        return False
+    if parsed.path and not parsed.path.endswith("/mod/quiz/review.php"):
+        log.warning(
+            "Skipping quiz snapshot for %s because the response URL is not a "
+            "quiz review page: %s",
+            requested_url,
+            final_url,
+        )
+        return False
+    return True
+
+
+def download_quiz(ctx: SyncContext, node: Any, log: logging.Logger = logger) -> bool:
+    """Save a quiz review attempt as an HTML snapshot and/or a rendered PDF.
+
+    The output is controlled by ``config.quiz_mode`` (off/html/pdf/both). The
+    snapshot is always written first because it doubles as the source Chromium
+    prints from; in pure ``pdf`` mode it is removed once a PDF exists, but kept
+    as a usable fallback when no browser is available.
+    """
+    mode = ctx.config.quiz_mode
+    if mode == "off":
+        return False
+    want_html = mode in ("html", "both")
+    want_pdf = mode in ("pdf", "both")
+
+    path = pathing.get_sanitized_node_path(node.parent, Path(ctx.config.basedir))
+    safe_name = pathing.sanitize_path_part(str(node.name or "quiz")) or "quiz"
+    html_path = path / f"{safe_name}.html"
+    pdf_path = path / f"{safe_name}.pdf"
+
+    # Idempotency: skip when every wanted artifact is already on disk.
+    html_done = html_path.exists() if want_html else True
+    pdf_done = pdf_path.exists() if want_pdf else True
+    if html_done and pdf_done:
+        return True
+
+    # Only (re)build the snapshot when it is not already on disk. When just the
+    # PDF is missing (e.g. a "both"/"pdf" run that previously found no browser),
+    # we render from the existing snapshot rather than re-downloading the page
+    # and re-inlining every asset.
+    if not html_path.exists():
+        print(f"Downloading {html_path} [Quiz]")
+        try:
+            response = ctx.require_session().get(node.url)
+        except Exception:
+            log.exception("Failed to fetch quiz page %s", node.url)
+            return False
+        if not quiz_response_is_usable(response, node.url, log):
+            return False
+
+        path.mkdir(parents=True, exist_ok=True)
+        html_path.write_text(
+            build_quiz_snapshot(
+                response.text,
+                ctx.require_session(),
+                response.url or node.url,
+                log,
+            ),
+            encoding="utf-8",
+        )
+
+    if not want_pdf or pdf_path.exists():
+        return True
+
+    browser = find_chromium(ctx.config, log)
+    if browser is None:
+        log.warning(
+            "No Chromium-family browser found to render the quiz PDF for %s; "
+            "keeping the HTML snapshot instead. Install Chrome, Chromium or "
+            "Edge, or set 'chromium_path' in your config.",
+            node.name,
+        )
+        pdf_ok = False
+    else:
+        print(f"Rendering {pdf_path} [Quiz PDF]")
+        pdf_ok = render_pdf_with_chromium(browser, html_path, pdf_path, log)
+        if not pdf_ok:
+            log.warning(
+                "Keeping the HTML snapshot for %s after PDF rendering failed.",
+                node.name,
+            )
+
+    # In pure "pdf" mode the HTML was only a means to the PDF; drop it on
+    # success but keep it as a fallback when rendering was not possible.
+    if mode == "pdf" and pdf_ok:
+        html_path.unlink(missing_ok=True)
+
+    return not want_pdf or pdf_ok

--- a/syncmymoodle/rwth.py
+++ b/syncmymoodle/rwth.py
@@ -4,10 +4,9 @@ import sys
 import time
 import urllib.parse
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import requests
-from bs4 import BeautifulSoup as bs
 
 from syncmymoodle.constants import (
     MOODLE_URL,
@@ -18,6 +17,7 @@ from syncmymoodle.constants import (
     RWTH_STATUS_URL,
 )
 from syncmymoodle.context import SyncContext
+from syncmymoodle.http_utils import get_input_value, parse_html
 from syncmymoodle.storage import (
     load_cookies_from_data,
     read_private_gzip_json,
@@ -37,13 +37,6 @@ def _tag_classes(tag: Any) -> set[str]:
     return {str(class_name) for class_name in classes or []}
 
 
-def _get_input_value(soup: Any, name: str) -> str | None:
-    input_tag = soup.find("input", {"name": name})
-    if input_tag and input_tag.get("value"):
-        return cast(str, input_tag["value"])
-    return None
-
-
 def _get_session_key(soup: Any, log: logging.Logger = logger) -> str:
     script = soup.find("script", string=lambda text: text and "sesskey" in text)
     match = re.search(r'"sesskey":"(.*?)"', script.text) if script is not None else None
@@ -59,7 +52,7 @@ def _require_input_value(
     context: str,
     log: logging.Logger = logger,
 ) -> str:
-    value = _get_input_value(soup, name)
+    value = get_input_value(soup, name)
     if value is None:
         log.critical(
             "Failed to login: expected form field %r was missing at the "
@@ -120,7 +113,7 @@ def current_rwth_service_issues(
         )
         return []
 
-    soup = bs(response.text, features="lxml")
+    soup = parse_html(response.text)
     issues: list[dict[str, str]] = []
     for card in soup.select(".notification-card"):
         indicator = card.select_one(".notification-status-indicator")
@@ -234,13 +227,13 @@ def login(ctx: SyncContext, log: logging.Logger = logger) -> None:
         check_rwth_status_page(log)
         sys.exit(1)
     if resp.url.startswith(f"{MOODLE_URL}my/"):
-        soup = bs(resp.text, features="lxml")
+        soup = parse_html(resp.text)
         ctx.session_key = _get_session_key(soup, log)
         save_session_cookies(cookie_file, session.cookies)
         return
 
     # Create a separate soup for maintenance detection
-    soup_check = bs(resp.text, features="lxml")
+    soup_check = parse_html(resp.text)
 
     # Remove known info banners by class
     for banner in soup_check.select(".themeboostunioninfobanner"):
@@ -262,7 +255,7 @@ def login(ctx: SyncContext, log: logging.Logger = logger) -> None:
         log.info(f"Cleaned page body:\n{body_text}")
         sys.exit()
 
-    soup = bs(resp.text, features="lxml")
+    soup = parse_html(resp.text)
     if soup.find("input", {"name": "RelayState"}) is None:
         csrf_token = _require_input_value(
             soup, "csrf_token", "username/password form", log
@@ -275,7 +268,7 @@ def login(ctx: SyncContext, log: logging.Logger = logger) -> None:
         }
         resp2 = session.post(resp.url, data=login_data)
 
-        soup = bs(resp2.text, features="lxml")
+        soup = parse_html(resp2.text)
 
         if soup.find(id="fudis_selected_token_ids_input") is None:
             log.critical(
@@ -302,7 +295,7 @@ def login(ctx: SyncContext, log: logging.Logger = logger) -> None:
 
         resp3 = session.post(resp2.url, data=totp_selection_data)
 
-        soup = bs(resp3.text, features="lxml")
+        soup = parse_html(resp3.text)
         if soup.find(id="fudis_otp_input") is None:
             log.critical(
                 "Failed to select TOTP generator. Maybe your TOTP serial "
@@ -333,7 +326,7 @@ def login(ctx: SyncContext, log: logging.Logger = logger) -> None:
         resp4 = session.post(resp3.url, data=totp_login_data)
 
         time.sleep(1)  # if we go too fast, we might have our connection closed
-        soup = bs(resp4.text, features="lxml")
+        soup = parse_html(resp4.text)
     if soup.find("input", {"name": "RelayState"}) is None:
         log.critical(
             "Failed to login. Maybe your login-info was wrong or the RWTH "
@@ -352,6 +345,6 @@ def login(ctx: SyncContext, log: logging.Logger = logger) -> None:
         ),
     }
     resp = session.post(f"{MOODLE_URL}Shibboleth.sso/SAML2/POST", data=data)
-    soup = bs(resp.text, features="lxml")
+    soup = parse_html(resp.text)
     ctx.session_key = _get_session_key(soup, log)
     save_session_cookies(cookie_file, session.cookies)

--- a/syncmymoodle/sciebo.py
+++ b/syncmymoodle/sciebo.py
@@ -7,6 +7,7 @@ from bs4 import BeautifulSoup as bs
 from syncmymoodle import filters
 from syncmymoodle.constants import SCIEBO_LINK_RE
 from syncmymoodle.context import SyncContext
+from syncmymoodle.http_utils import get_input_value, parse_html
 from syncmymoodle.node import Node, RemoteMarkerKind
 
 logger = logging.getLogger(__name__)
@@ -64,7 +65,7 @@ def scan_public_shares(
             continue
 
         # parse html code
-        soup = bs(response.text, features="lxml")
+        soup = parse_html(response.text)
 
         # get the requesttoken
         requestToken = cast(
@@ -76,16 +77,13 @@ def scan_public_shares(
             continue
         log.info(f"Sciebo request token: {requestToken}")
 
-        # get the property value of the input tag with the name sharingToken
-        sharing_input = soup.find("input", {"name": "sharingToken"})
-        if sharing_input and sharing_input.get("value"):
-            sharingToken = cast(str, sharing_input["value"])
-        else:
-            # Newer Sciebo/Nextcloud share pages no longer render the token as a
-            # hidden input. It matches the /s/<token> segment of the share URL,
-            # which is what the public WebDAV endpoint expects, so fall back to
-            # deriving it from the link instead of skipping the share.
-            sharingToken = sharing_token_from_link(link)
+        # Newer Sciebo/Nextcloud share pages no longer render the token as a
+        # hidden input. It matches the /s/<token> segment of the share URL,
+        # which is what the public WebDAV endpoint expects, so fall back to
+        # deriving it from the link instead of skipping the share.
+        sharingToken = get_input_value(soup, "sharingToken") or sharing_token_from_link(
+            link
+        )
         if not sharingToken:
             log.warning("Sciebo: missing sharingToken for link %s, skipping", link)
             continue

--- a/syncmymoodle/sync_handlers.py
+++ b/syncmymoodle/sync_handlers.py
@@ -3,14 +3,13 @@ import urllib.parse
 from dataclasses import dataclass
 from typing import Any, Callable, cast
 
-from bs4 import BeautifulSoup as bs
-
 from syncmymoodle import filters, moodle_files, pathing
 from syncmymoodle import links as links_api
 from syncmymoodle import moodle as moodle_api
 from syncmymoodle import opencast as opencast_api
 from syncmymoodle.constants import MOODLE_URL
 from syncmymoodle.context import SyncContext
+from syncmymoodle.http_utils import get_input_value, parse_html
 from syncmymoodle.node import Node
 
 logger = logging.getLogger(__name__)
@@ -211,10 +210,7 @@ def handle_embedded_link_module(
                 response = None
             if response:
                 if opencast_enabled:
-                    html = bs(
-                        response.text,
-                        features="lxml",
-                    )
+                    html = parse_html(response.text)
                     for iframe in html.find_all("iframe"):
                         iframe_src_value = iframe.get("src")
                         if not iframe_src_value:
@@ -262,21 +258,13 @@ def handle_embedded_link_module(
     # "Interactive" h5p videos
     elif module["modname"] == "h5pactivity":
         html_url = f"{MOODLE_URL}mod/h5pactivity/view.php?id={module['id']}"
-        html = bs(
-            ctx.require_session().get(html_url).text,
-            features="lxml",
-        )
+        html = parse_html(ctx.require_session().get(html_url).text)
         # Get h5p iframe
         h5p_iframe = html.find("iframe")
         iframe_src_value = h5p_iframe.get("src") if h5p_iframe else None
         if iframe_src_value:
             iframe_src = urllib.parse.urljoin(html_url, cast(str, iframe_src_value))
-            iframe_html = str(
-                bs(
-                    ctx.require_session().get(iframe_src).text,
-                    features="lxml",
-                )
-            )
+            iframe_html = str(parse_html(ctx.require_session().get(iframe_src).text))
             # Moodle devs dont know how to use CDATA correctly, so we need to remove all backslashes
             sanitized_html = iframe_html.replace("\\", "")
         else:
@@ -333,13 +321,11 @@ def handle_opencast_lti_module(
         opencast_api.log_backend_issue(ctx, info_response.text, log)
         return
 
-    info_res = bs(info_response.text, features="lxml")
+    info_res = parse_html(info_response.text)
 
-    engage_series_id = opencast_api.get_input_value(info_res, "custom_series")
-    engage_single_id = opencast_api.get_input_value(info_res, "custom_id")
-    name = (
-        opencast_api.get_input_value(info_res, "resource_link_title") or module["name"]
-    )
+    engage_series_id = get_input_value(info_res, "custom_series")
+    engage_single_id = get_input_value(info_res, "custom_id")
+    name = get_input_value(info_res, "resource_link_title") or module["name"]
     engage_data = opencast_api.extract_lti_form_data(info_res)
 
     if engage_series_id:
@@ -429,7 +415,7 @@ def handle_quiz_module(
         return
 
     info_url = f"{MOODLE_URL}mod/quiz/view.php?id={module['id']}"
-    info_res = bs(ctx.require_session().get(info_url).text, features="lxml")
+    info_res = parse_html(ctx.require_session().get(info_url).text)
     attempts = info_res.find_all(
         "a",
         {"title": "Überprüfung der eigenen Antworten dieses Versuchs"},
@@ -438,10 +424,7 @@ def handle_quiz_module(
     for attempt in attempts:
         attempt_cnt += 1
         review_url = cast(str, attempt.get("href"))
-        quiz_res = bs(
-            ctx.require_session().get(review_url).text,
-            features="lxml",
-        )
+        quiz_res = parse_html(ctx.require_session().get(review_url).text)
         title = cast(Any, quiz_res.find("title"))
         name = (
             title.get_text().replace(": Überprüfung des Testversuchs", "")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -49,16 +49,41 @@ def test_canonical_keys_win_over_aliases():
     assert cfg.updatefiles is False
 
 
-def test_quiz_is_forced_off_even_when_enabled():
-    cfg = Config.from_dict({"used_modules": {"url": {"quiz": True, "opencast": True}}})
-    assert cfg.url_module_enabled("quiz") is False
-    assert cfg.url_module_enabled("opencast") is True
+def test_quiz_mode_normalizes_values():
+    # Legacy booleans map onto the mode strings.
+    assert (
+        Config.from_dict({"used_modules": {"url": {"quiz": True}}}).quiz_mode == "both"
+    )
+    assert (
+        Config.from_dict({"used_modules": {"url": {"quiz": False}}}).quiz_mode == "off"
+    )
+    # Explicit modes are passed through (case-insensitively).
+    for mode in ("off", "html", "pdf", "both"):
+        cfg = Config.from_dict({"used_modules": {"url": {"quiz": mode.upper()}}})
+        assert cfg.quiz_mode == mode
+    # Unrecognized values disable quizzes rather than crashing.
+    assert (
+        Config.from_dict({"used_modules": {"url": {"quiz": "wat"}}}).quiz_mode == "off"
+    )
+
+
+def test_quiz_enabled_helper_tracks_mode():
+    on = Config.from_dict({"used_modules": {"url": {"quiz": "pdf", "opencast": True}}})
+    assert on.url_module_enabled("quiz") is True
+    assert on.url_module_enabled("opencast") is True
+    off = Config.from_dict({"used_modules": {"url": {"quiz": "off"}}})
+    assert off.url_module_enabled("quiz") is False
+
+
+def test_quiz_defaults_to_html_when_no_modules_configured():
+    # HTML is the safe default: it archives e-tests without launching a browser.
+    assert Config.from_dict({}).quiz_mode == "html"
 
 
 def test_from_dict_does_not_mutate_input():
     raw = {"used_modules": {"url": {"quiz": True, "opencast": True}}}
     cfg = Config.from_dict(raw)
-    assert cfg.url_module_enabled("quiz") is False
+    assert cfg.quiz_mode == "both"
     assert raw["used_modules"]["url"]["quiz"] is True
 
 

--- a/tests/test_quiz.py
+++ b/tests/test_quiz.py
@@ -1,0 +1,368 @@
+import subprocess
+from types import SimpleNamespace
+
+from syncmymoodle import quiz
+from syncmymoodle.node import Node
+
+from .helpers import FakeResponse, FakeSession, make_context
+
+QUIZ_URL = "https://moodle.rwth-aachen.de/mod/quiz/review.php?attempt=5"
+CSS_URL = "https://moodle.rwth-aachen.de/theme/styles.css"
+IMG_URL = "https://moodle.rwth-aachen.de/pluginfile.php/1/question.png"
+BG_URL = "https://moodle.rwth-aachen.de/theme/bg.png"
+CSS_ONLY_ASSET_URL = "https://moodle.rwth-aachen.de/theme/theme-only.png"
+FONT_URL = "https://moodle.rwth-aachen.de/theme/fa-solid.woff2"
+TEXT_FONT_URL = "https://moodle.rwth-aachen.de/theme/free-sans.woff2"
+QUIZ_HTML = (
+    "<html><head><title>Test: X</title>"
+    '<link rel="stylesheet" href="/theme/styles.css">'
+    '<script src="https://example.test/leak.js"></script>'
+    "</head><body>"
+    '<nav aria-label="Site-Navigation">Site nav</nav>'
+    "<div id='nav-drawer'>navigation</div>"
+    '<img src="/pluginfile.php/1/question.png" srcset="/pluginfile.php/1/big.png 2x">'
+    '<img src="https://example.test/tracker.png">'
+    '<a href="https://example.test/leak">external</a>'
+    "<p style=\"background-image: url('/theme/bg.png')\">"
+    "My answer with <span class='nolink'>\\(\\sigma_i \\mapsto G_i\\)</span>"
+    "</p>"
+    '<i class="icon fa fa-check"></i>'
+    '<nav class="activity-navigation">Activity nav</nav>'
+    '<footer id="page-footer">Moodle footer</footer>'
+    '<div id="footnote">RWTH footnote footer</div>'
+    "</body></html>"
+)
+
+
+def quiz_context(tmp_path, mode):
+    ctx = make_context(
+        {
+            "basedir": str(tmp_path),
+            "used_modules": {
+                "assign": True,
+                "resource": True,
+                "folder": True,
+                "url": {
+                    "youtube": True,
+                    "opencast": True,
+                    "sciebo": True,
+                    "quiz": mode,
+                },
+            },
+        }
+    )
+    session = FakeSession()
+    session.add(
+        "GET",
+        QUIZ_URL,
+        FakeResponse(text=QUIZ_HTML, headers={"Content-Type": "text/html"}),
+    )
+    session.add(
+        "GET",
+        CSS_URL,
+        FakeResponse(
+            text=(
+                "@import 'https://example.test/leak.css';"
+                "@font-face{font-family:'Font Awesome 6 Free';"
+                "src:url('fa-solid.woff2') format('woff2');}"
+                "@font-face{font-family:'FreeSans';"
+                "src:url('free-sans.woff2') format('woff2');}"
+                ".fa{font-family:'Font Awesome 6 Free';font-weight:900}"
+                ".fa-check:before{content:'\\f00c'}"
+                "body{color:black;background:url('theme-only.png')}"
+            ),
+            headers={"Content-Type": "text/css"},
+        ),
+    )
+    session.add(
+        "GET",
+        IMG_URL,
+        FakeResponse(
+            headers={"Content-Type": "image/png"},
+            chunks=[b"question-image"],
+        ),
+    )
+    session.add(
+        "GET",
+        BG_URL,
+        FakeResponse(headers={"Content-Type": "image/png"}, chunks=[b"background"]),
+    )
+    session.add(
+        "GET",
+        FONT_URL,
+        FakeResponse(headers={"Content-Type": "font/woff2"}, chunks=[b"font-awesome"]),
+    )
+    ctx.session = session
+    return ctx
+
+
+def quiz_node():
+    root = Node("root", None, "Root", None)
+    node = root.add_child("My Quiz, Versuch 1", 1, "Quiz", url=QUIZ_URL)
+    assert node is not None
+    return node
+
+
+def test_build_quiz_snapshot_is_self_contained_and_network_silent(tmp_path):
+    ctx = quiz_context(tmp_path, "html")
+
+    snapshot = quiz.build_quiz_snapshot(QUIZ_HTML, ctx.session, QUIZ_URL)
+
+    assert "Content-Security-Policy" in snapshot
+    assert "default-src 'none'" in snapshot
+    assert "data:image/png;base64," in snapshot
+    assert "data:font/woff2;base64," in snapshot
+    assert 'url("data:,")' in snapshot
+    assert "My answer" in snapshot
+    assert "<math" in snapshot
+    assert "\\(" not in snapshot
+    assert "\\mapsto" not in snapshot
+    assert "Site nav" not in snapshot
+    assert "nav-drawer" not in snapshot
+    assert "Activity nav" not in snapshot
+    assert "Moodle footer" not in snapshot
+    assert "RWTH footnote footer" not in snapshot
+    assert "<script" not in snapshot
+    assert "<link" not in snapshot
+    assert "srcset" not in snapshot
+    assert "https://" not in snapshot
+    assert "/pluginfile.php" not in snapshot
+    assert ctx.session.count("GET", CSS_URL) == 1
+    assert ctx.session.count("GET", IMG_URL) == 1
+    assert ctx.session.count("GET", BG_URL) == 1
+    assert ctx.session.count("GET", CSS_ONLY_ASSET_URL) == 0
+    assert ctx.session.count("GET", FONT_URL) == 1
+    assert ctx.session.count("GET", TEXT_FONT_URL) == 0
+
+
+def test_quiz_latex_conversion_skips_stylesheets(tmp_path):
+    ctx = quiz_context(tmp_path, "html")
+    html = (
+        "<html><head>"
+        "<style>.size-\\(raw-css\\){background:url('/theme/theme-only.png')}</style>"
+        "</head><body><p>\\(x_i\\)</p></body></html>"
+    )
+
+    snapshot = quiz.build_quiz_snapshot(html, ctx.session, QUIZ_URL)
+
+    assert ".size-\\(raw-css\\)" in snapshot
+    assert 'url("data:,")' in snapshot
+    assert snapshot.count("<math") == 1
+    assert ctx.session.count("GET", CSS_ONLY_ASSET_URL) == 0
+
+
+def test_quiz_stylesheet_keeps_only_used_icon_fonts(tmp_path):
+    ctx = quiz_context(tmp_path, "html")
+    html = (
+        "<html><head>"
+        '<link rel="stylesheet" href="/theme/styles.css">'
+        "</head><body><p>No icon here</p></body></html>"
+    )
+
+    snapshot = quiz.build_quiz_snapshot(html, ctx.session, QUIZ_URL)
+
+    assert "data:font/woff2;base64," not in snapshot
+    assert ctx.session.count("GET", FONT_URL) == 0
+    assert ctx.session.count("GET", TEXT_FONT_URL) == 0
+
+
+def test_html_mode_writes_snapshot_without_browser(tmp_path, monkeypatch, capsys):
+    # A browser must never be needed for HTML output.
+    monkeypatch.setattr(
+        quiz,
+        "find_chromium",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError),
+    )
+    ctx = quiz_context(tmp_path, "html")
+    node = quiz_node()
+    html_path = tmp_path / "root" / "My Quiz, Versuch 1.html"
+
+    assert quiz.download_quiz(ctx, node) is True
+    assert capsys.readouterr().out == f"Downloading {html_path} [Quiz]\n"
+    assert html_path.exists()
+    snapshot = html_path.read_text(encoding="utf-8")
+    assert "Content-Security-Policy" in snapshot
+    assert "https://" not in snapshot
+    assert not (tmp_path / "root" / "My Quiz, Versuch 1.pdf").exists()
+
+
+def test_html_mode_is_idempotent(tmp_path, capsys):
+    ctx = quiz_context(tmp_path, "html")
+    node = quiz_node()
+
+    assert quiz.download_quiz(ctx, node) is True
+    capsys.readouterr()
+    assert quiz.download_quiz(ctx, node) is True
+    assert capsys.readouterr().out == ""
+    # The page is fetched only on the first run; the second is a no-op.
+    assert ctx.session.count("GET", QUIZ_URL) == 1
+
+
+def test_pdf_mode_removes_html_on_success(tmp_path, monkeypatch, capsys):
+    def fake_render(browser, html_path, pdf_path, log=quiz.logger):
+        pdf_path.write_bytes(b"%PDF-1.4 fake")
+        return True
+
+    monkeypatch.setattr(quiz, "find_chromium", lambda *a, **k: "/fake/chrome")
+    monkeypatch.setattr(quiz, "render_pdf_with_chromium", fake_render)
+
+    ctx = quiz_context(tmp_path, "pdf")
+    node = quiz_node()
+    html_path = tmp_path / "root" / "My Quiz, Versuch 1.html"
+    pdf_path = tmp_path / "root" / "My Quiz, Versuch 1.pdf"
+
+    assert quiz.download_quiz(ctx, node) is True
+    assert capsys.readouterr().out == (
+        f"Downloading {html_path} [Quiz]\nRendering {pdf_path} [Quiz PDF]\n"
+    )
+    assert pdf_path.exists()
+    assert not html_path.exists()
+
+
+def test_pdf_mode_keeps_html_when_no_browser(tmp_path, monkeypatch):
+    monkeypatch.setattr(quiz, "find_chromium", lambda *a, **k: None)
+
+    ctx = quiz_context(tmp_path, "pdf")
+    node = quiz_node()
+
+    assert quiz.download_quiz(ctx, node) is False
+    # Falls back to the HTML snapshot so the attempt is not lost, but returns
+    # False so the missing requested PDF is retried on future runs.
+    assert (tmp_path / "root" / "My Quiz, Versuch 1.html").exists()
+    assert not (tmp_path / "root" / "My Quiz, Versuch 1.pdf").exists()
+
+
+def test_both_mode_retries_pdf_without_refetching(tmp_path, monkeypatch):
+    # First run: no browser, so only the HTML snapshot is written.
+    monkeypatch.setattr(quiz, "find_chromium", lambda *a, **k: None)
+    ctx = quiz_context(tmp_path, "both")
+    node = quiz_node()
+
+    assert quiz.download_quiz(ctx, node) is False
+    html_path = tmp_path / "root" / "My Quiz, Versuch 1.html"
+    assert html_path.exists()
+    assert ctx.session.count("GET", QUIZ_URL) == 1
+
+    # Second run: a browser is now available. The PDF must be produced by
+    # rendering the existing snapshot, without re-fetching the page or assets.
+    def fake_render(browser, html_path, pdf_path, log=quiz.logger):
+        pdf_path.write_bytes(b"%PDF-1.4 fake")
+        return True
+
+    monkeypatch.setattr(quiz, "find_chromium", lambda *a, **k: "/fake/chrome")
+    monkeypatch.setattr(quiz, "render_pdf_with_chromium", fake_render)
+
+    assert quiz.download_quiz(ctx, node) is True
+    assert (tmp_path / "root" / "My Quiz, Versuch 1.pdf").exists()
+    # No additional page fetch, no additional asset fetches.
+    assert ctx.session.count("GET", QUIZ_URL) == 1
+    assert ctx.session.count("GET", CSS_URL) == 1
+    assert ctx.session.count("GET", IMG_URL) == 1
+
+
+def test_snapshot_declares_utf8_charset(tmp_path):
+    # The source QUIZ_HTML has no charset meta, so one must be injected.
+    ctx = quiz_context(tmp_path, "html")
+    snapshot = quiz.build_quiz_snapshot(QUIZ_HTML, ctx.session, QUIZ_URL)
+    assert 'charset="utf-8"' in snapshot
+
+
+def test_download_quiz_rejects_non_quiz_redirect(tmp_path):
+    ctx = quiz_context(tmp_path, "html")
+    ctx.session.routes.clear()
+    ctx.session.add(
+        "GET",
+        QUIZ_URL,
+        FakeResponse(
+            text="<html>login</html>",
+            status_code=200,
+            headers={"Content-Type": "text/html"},
+            url="https://moodle.rwth-aachen.de/login/index.php",
+        ),
+    )
+    node = quiz_node()
+
+    assert quiz.download_quiz(ctx, node) is False
+    assert not (tmp_path / "root").exists()
+
+
+def test_both_mode_writes_html_and_pdf(tmp_path, monkeypatch):
+    def fake_render(browser, html_path, pdf_path, log=quiz.logger):
+        pdf_path.write_bytes(b"%PDF-1.4 fake")
+        return True
+
+    monkeypatch.setattr(quiz, "find_chromium", lambda *a, **k: "/fake/chrome")
+    monkeypatch.setattr(quiz, "render_pdf_with_chromium", fake_render)
+
+    ctx = quiz_context(tmp_path, "both")
+    node = quiz_node()
+
+    assert quiz.download_quiz(ctx, node) is True
+    assert (tmp_path / "root" / "My Quiz, Versuch 1.html").exists()
+    assert (tmp_path / "root" / "My Quiz, Versuch 1.pdf").exists()
+
+
+def test_off_mode_does_nothing(tmp_path):
+    ctx = quiz_context(tmp_path, "off")
+    node = quiz_node()
+
+    assert quiz.download_quiz(ctx, node) is False
+    assert not (tmp_path / "root").exists()
+    assert ctx.session.count("GET", QUIZ_URL) == 0
+
+
+def test_find_chromium_prefers_configured_path(tmp_path):
+    browser = tmp_path / "my-chromium"
+    browser.write_text("#!/bin/sh\n")
+    ctx = quiz_context(tmp_path, "pdf")
+    ctx.config.chromium_path = str(browser)
+    assert quiz.find_chromium(ctx.config) == str(browser)
+
+
+def test_find_chromium_auto_discovers_on_path(tmp_path, monkeypatch):
+    ctx = quiz_context(tmp_path, "pdf")
+    monkeypatch.setattr(
+        quiz.shutil,
+        "which",
+        lambda name: "/usr/bin/chromium" if name == "chromium" else None,
+    )
+    assert quiz.find_chromium(ctx.config) == "/usr/bin/chromium"
+
+
+def test_find_chromium_returns_none_when_missing(tmp_path, monkeypatch):
+    ctx = quiz_context(tmp_path, "pdf")
+    monkeypatch.setattr(quiz.shutil, "which", lambda name: None)
+    monkeypatch.setattr(quiz, "CHROMIUM_KNOWN_PATHS", ())
+    assert quiz.find_chromium(ctx.config) is None
+
+
+def test_render_pdf_with_chromium_success(tmp_path, monkeypatch):
+    html_path = tmp_path / "in.html"
+    html_path.write_text("<html></html>", encoding="utf-8")
+    pdf_path = tmp_path / "out.pdf"
+    command = []
+
+    def fake_run(cmd, **kwargs):
+        command.extend(cmd)
+        # The output path is passed via --print-to-pdf=<path>.
+        pdf_path.write_bytes(b"%PDF-1.4 fake")
+        return SimpleNamespace(returncode=0, stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert quiz.render_pdf_with_chromium("/fake/chrome", html_path, pdf_path)
+    assert pdf_path.exists()
+    assert "--no-pdf-header-footer" in command
+
+
+def test_render_pdf_with_chromium_failure(tmp_path, monkeypatch):
+    html_path = tmp_path / "in.html"
+    html_path.write_text("<html></html>", encoding="utf-8")
+    pdf_path = tmp_path / "out.pdf"
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kw: SimpleNamespace(returncode=1, stderr=b"boom"),
+    )
+    assert quiz.render_pdf_with_chromium("/fake/chrome", html_path, pdf_path) is False
+    assert not pdf_path.exists()


### PR DESCRIPTION
Re-adds quiz review export by saving self-contained offline HTML snapshots by default, with optional PDF generation through a local Chrome/Chromium/Edge browser (Firefox currently does not support pdf printing).

Snapshots strip active/network content, inline safe Moodle assets, and replace the old `pdfkit`/`wkhtmltopdf` path.

Closes #132 and closes #55.
