### PR TITLE
Fix Windows file storage and path handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ dependencies = [
   "yt-dlp>=2021.12.27",
   "tqdm>=4.0.0",
   "lxml>=5.0.0",
-  "latex2mathml>=3.77.0"
+  "latex2mathml>=3.77.0",
+  "pywin32>=306; platform_system == 'Windows'"
 ]
 
 [project.optional-dependencies]

--- a/syncmymoodle/downloader.py
+++ b/syncmymoodle/downloader.py
@@ -340,8 +340,12 @@ def conflict_action(
 
 
 def prepare_transfer_plan(node: Node, downloadpath: Path) -> TransferPlan:
-    tmp_path = downloadpath.parent / f".{downloadpath.name}.smmpart"
-    etag_sidecar = tmp_path.with_name(tmp_path.name + ".etag")
+    tmp_path = pathing.with_windows_extended_length_prefix(
+        downloadpath.parent / f".{downloadpath.name}.smmpart"
+    )
+    etag_sidecar = pathing.with_windows_extended_length_prefix(
+        tmp_path.with_name(tmp_path.name + ".etag")
+    )
     plan = TransferPlan(tmp_path=tmp_path, etag_sidecar=etag_sidecar, headers={})
 
     if tmp_path.exists():
@@ -612,8 +616,12 @@ def scan_and_download_youtube(
     if path.exists():
         if any(link[-YOUTUBE_ID_LENGTH:] in f.name for f in path.iterdir()):
             return False
+    outtmpl = pathing.with_windows_extended_length_prefix(
+        path / "%(title)s-%(id)s.%(ext)s",
+        force=True,
+    )
     ydl_opts = {
-        "outtmpl": "{}/%(title)s-%(id)s.%(ext)s".format(path),
+        "outtmpl": os.fspath(outtmpl),
         "ignoreerrors": True,
         "nooverwrites": True,
         "retries": 15,

--- a/syncmymoodle/node.py
+++ b/syncmymoodle/node.py
@@ -6,6 +6,8 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
+from syncmymoodle.pathing import sanitize_path_part
+
 NAME_CLASH_ID_UNSET = object()
 
 
@@ -200,8 +202,12 @@ class Node:
         return f"{Path(self.name).name}_{str(self.url).split('/')[-1]}"
 
     @staticmethod
-    def _general_name_clash(left: Node, right: Node) -> bool:
-        if left.name != right.name:
+    def _filesystem_name_key(node: Node) -> str:
+        return sanitize_path_part(node.name).casefold()
+
+    @classmethod
+    def _general_name_clash(cls, left: Node, right: Node) -> bool:
+        if cls._filesystem_name_key(left) != cls._filesystem_name_key(right):
             return False
         if left.url != right.url:
             return True
@@ -211,8 +217,8 @@ class Node:
             and left.name_clash_id != right.name_clash_id
         )
 
-    @staticmethod
-    def _apply_opencast_name_clashes(children: list[Node]) -> list[Node]:
+    @classmethod
+    def _apply_opencast_name_clashes(cls, children: list[Node]) -> list[Node]:
         remaining = children.copy()
         renamed: list[Node] = []
 
@@ -225,7 +231,8 @@ class Node:
             siblings = [
                 sibling
                 for sibling in remaining
-                if sibling.name == child.name and sibling.url != child.url
+                if cls._filesystem_name_key(sibling) == cls._filesystem_name_key(child)
+                and sibling.url != child.url
             ]
             if not siblings:
                 continue

--- a/syncmymoodle/pathing.py
+++ b/syncmymoodle/pathing.py
@@ -1,36 +1,76 @@
+from __future__ import annotations
+
 import hashlib
+import ntpath
+import os
 import urllib.parse
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
+from typing import TYPE_CHECKING
 
 from syncmymoodle.constants import INVALID_CHARS
-from syncmymoodle.node import Node
+
+if TYPE_CHECKING:
+    from syncmymoodle.node import Node
+
+WINDOWS_EXTENDED_PATH_THRESHOLD = 240
+
+
+def is_windows() -> bool:
+    return os.name == "nt"
+
+
+def is_windows_reserved_path_part(path: str) -> bool:
+    isreserved = getattr(ntpath, "isreserved", None)
+    if isreserved is not None:
+        return bool(isreserved(path))
+    return PureWindowsPath(path).is_reserved()
 
 
 def sanitize_path_part(path: str) -> str:
     path = urllib.parse.unquote(path)
-    path = "".join([s for s in path if s not in INVALID_CHARS])
-    while path and path[-1] == " ":
-        path = path[:-1]
-    while path and path[0] == " ":
-        path = path[1:]
+    path = "".join(
+        character
+        for character in path
+        if character not in INVALID_CHARS and ord(character) >= 32
+    )
+    path = path.lstrip(" ").rstrip(" .")
 
     # Folders downloaded from Moodle display amp; in places where an
     # ampersand should be displayed instead. In the web UI, however, the
     # ampersand is shown correctly, and we're trying to emulate that here.
     path = path.replace("amp;", "&")
+    if path in {"", ".", ".."}:
+        path = "_"
+    if is_windows_reserved_path_part(path):
+        path = f"_{path}"
 
     return path
+
+
+def windows_extended_length_path(path: str) -> str:
+    if path.startswith("\\\\?\\"):
+        return path
+    if path.startswith("\\\\"):
+        return "\\\\?\\UNC\\" + path[2:]
+    return "\\\\?\\" + path
+
+
+def with_windows_extended_length_prefix(path: Path, *, force: bool = False) -> Path:
+    if not is_windows():
+        return path
+    absolute_path = os.path.abspath(os.fspath(path))
+    if not force and len(absolute_path) < WINDOWS_EXTENDED_PATH_THRESHOLD:
+        return path
+    return Path(windows_extended_length_path(absolute_path))
 
 
 def get_sanitized_node_path(node: Node, basedir: Path) -> Path:
     basedir = basedir.expanduser()
     path_segments = []
-    for part in node.get_path():
-        if part == "":
+    for index, part in enumerate(node.get_path()):
+        if index == 0 and part == "":
             continue
         sanitized = sanitize_path_part(part)
-        if sanitized in {"", ".", ".."}:
-            sanitized = "_"
         path_segments.append(sanitized)
 
     target_path = basedir.joinpath(*path_segments)
@@ -38,7 +78,7 @@ def get_sanitized_node_path(node: Node, basedir: Path) -> Path:
     resolved_target = target_path.resolve(strict=False)
     if not resolved_target.is_relative_to(resolved_basedir):
         raise ValueError(f"Refusing to write outside basedir: {target_path}")
-    return target_path
+    return with_windows_extended_length_prefix(target_path)
 
 
 def make_conflict_path(path: Path) -> Path:
@@ -63,4 +103,4 @@ def make_conflict_path(path: Path) -> Path:
             f"{stem}.syncconflict.{hash_str}.{index}{suffix}"
         )
         index += 1
-    return conflict_path
+    return with_windows_extended_length_prefix(conflict_path)

--- a/syncmymoodle/quiz.py
+++ b/syncmymoodle/quiz.py
@@ -862,8 +862,8 @@ def download_quiz(ctx: SyncContext, node: Any, log: logging.Logger = logger) -> 
 
     path = pathing.get_sanitized_node_path(node.parent, Path(ctx.config.basedir))
     safe_name = pathing.sanitize_path_part(str(node.name or "quiz")) or "quiz"
-    html_path = path / f"{safe_name}.html"
-    pdf_path = path / f"{safe_name}.pdf"
+    html_path = pathing.with_windows_extended_length_prefix(path / f"{safe_name}.html")
+    pdf_path = pathing.with_windows_extended_length_prefix(path / f"{safe_name}.pdf")
 
     # Idempotency: skip when every wanted artifact is already on disk.
     html_done = html_path.exists() if want_html else True

--- a/syncmymoodle/storage.py
+++ b/syncmymoodle/storage.py
@@ -1,4 +1,5 @@
 import gzip
+import importlib
 import json
 import logging
 import os
@@ -11,19 +12,70 @@ import requests
 logger = logging.getLogger(__name__)
 
 
+def is_windows() -> bool:
+    return os.name == "nt"
+
+
+def restrict_private_file_windows(path: Path) -> None:
+    win32api: Any = importlib.import_module("win32api")
+    win32con: Any = importlib.import_module("win32con")
+    win32security: Any = importlib.import_module("win32security")
+    ntsecuritycon: Any = importlib.import_module("ntsecuritycon")
+
+    process = win32api.GetCurrentProcess()
+    token = win32security.OpenProcessToken(process, win32con.TOKEN_QUERY)
+    try:
+        user_sid = win32security.GetTokenInformation(token, win32security.TokenUser)[0]
+        access_mask = (
+            ntsecuritycon.FILE_GENERIC_READ
+            | ntsecuritycon.FILE_GENERIC_WRITE
+            | ntsecuritycon.DELETE
+        )
+
+        dacl = win32security.ACL()
+        dacl.AddAccessAllowedAce(win32security.ACL_REVISION, access_mask, user_sid)
+        win32security.SetNamedSecurityInfo(
+            os.path.abspath(path),
+            win32security.SE_FILE_OBJECT,
+            win32security.DACL_SECURITY_INFORMATION
+            | win32security.PROTECTED_DACL_SECURITY_INFORMATION,
+            None,
+            None,
+            dacl,
+            None,
+        )
+    finally:
+        win32api.CloseHandle(token)
+
+
 def harden_private_file(path: Path, description: str) -> bool:
     if not path.exists():
         return True
     if path.is_symlink():
         logger.warning("Refusing to use symlinked %s file: %s", description, path)
         return False
+    chmod_private_best_effort(path, description)
+    return True
+
+
+def chmod_private_best_effort(path: Path, description: str) -> None:
+    if is_windows():
+        try:
+            restrict_private_file_windows(path)
+        except Exception as error:
+            logger.warning(
+                "Could not restrict permissions for %s file on Windows: %s: %s",
+                description,
+                path,
+                error,
+            )
+        return
     try:
         path.chmod(0o600)
     except OSError:
         logger.warning(
             "Could not restrict permissions for %s file: %s", description, path
         )
-    return True
 
 
 def write_private_gzip_json(path: Path, payload: Any) -> None:
@@ -36,14 +88,28 @@ def write_private_gzip_json(path: Path, payload: Any) -> None:
     fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
     tmp_path = Path(tmp_name)
     try:
-        os.fchmod(fd, 0o600)
+        if is_windows():
+            chmod_private_best_effort(tmp_path, "temporary private data")
+        elif (fchmod := getattr(os, "fchmod", None)) is not None:
+            try:
+                fchmod(fd, 0o600)
+            except OSError:
+                logger.warning(
+                    "Could not restrict permissions for temporary private file: %s",
+                    tmp_path,
+                )
         with os.fdopen(fd, "wb") as f:
+            fd = -1
             f.write(data)
         os.replace(tmp_path, path)
-        path.chmod(0o600)
+        chmod_private_best_effort(path, "private data")
     finally:
-        if tmp_path.exists():
-            tmp_path.unlink()
+        if fd >= 0:
+            os.close(fd)
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            logger.warning("Could not remove temporary private file: %s", tmp_path)
 
 
 def read_private_gzip_json(path: Path, description: str) -> Any:

--- a/tests/test_course_prefix_handling.py
+++ b/tests/test_course_prefix_handling.py
@@ -3,6 +3,7 @@ import logging
 from syncmymoodle.config import Config
 from syncmymoodle.filters import format_course_name as format_course_name_impl
 from syncmymoodle.node import Node
+from syncmymoodle.pathing import sanitize_path_part
 
 
 def format_course_name(handling, name):
@@ -148,6 +149,58 @@ def test_clashing_files_without_name_clash_id_use_url_for_distinct_names():
     assert "slides.pdf" not in names
 
 
+def test_names_that_sanitize_to_same_windows_path_get_distinct_suffixes():
+    root = Node("", -1, "Root", None)
+    section = root.add_child("General", None, "Section")
+    section.add_child(
+        "CON.pdf",
+        None,
+        "Linked file [application/pdf]",
+        url="https://a.example/con.pdf",
+        name_clash_id=None,
+    )
+    section.add_child(
+        "_CON.pdf",
+        None,
+        "Linked file [application/pdf]",
+        url="https://b.example/con.pdf",
+        name_clash_id=None,
+    )
+
+    root.remove_children_nameclashes()
+
+    materialized_names = [
+        sanitize_path_part(child.name).casefold() for child in section.children
+    ]
+    assert len(set(materialized_names)) == 2
+
+
+def test_case_only_file_name_clashes_get_distinct_suffixes():
+    root = Node("", -1, "Root", None)
+    section = root.add_child("General", None, "Section")
+    section.add_child(
+        "Notes.pdf",
+        None,
+        "Linked file [application/pdf]",
+        url="https://a.example/notes.pdf",
+        name_clash_id=None,
+    )
+    section.add_child(
+        "notes.pdf",
+        None,
+        "Linked file [application/pdf]",
+        url="https://b.example/notes.pdf",
+        name_clash_id=None,
+    )
+
+    root.remove_children_nameclashes()
+
+    materialized_names = [
+        sanitize_path_part(child.name).casefold() for child in section.children
+    ]
+    assert len(set(materialized_names)) == 2
+
+
 def test_opencast_name_clashes_use_uploaded_filename_suffix():
     root = Node("", -1, "Root", None)
     section = root.add_child("General", None, "Section")
@@ -170,3 +223,27 @@ def test_opencast_name_clashes_use_uploaded_filename_suffix():
         "Recording_high.mp4",
         "Recording_low.mp4",
     ]
+
+
+def test_case_only_opencast_name_clashes_use_uploaded_filename_suffix():
+    root = Node("", -1, "Root", None)
+    section = root.add_child("General", None, "Section")
+    section.add_child(
+        "Recording",
+        "episode-a",
+        "Opencast",
+        url="https://video.example.test/opencast/high.mp4",
+    )
+    section.add_child(
+        "recording",
+        "episode-b",
+        "Opencast",
+        url="https://video.example.test/opencast/low.mp4",
+    )
+
+    root.remove_children_nameclashes()
+
+    materialized_names = [
+        sanitize_path_part(child.name).casefold() for child in section.children
+    ]
+    assert len(set(materialized_names)) == 2

--- a/tests/test_download_behavior.py
+++ b/tests/test_download_behavior.py
@@ -1,7 +1,7 @@
 import hashlib
 import os
 
-from syncmymoodle import course_cache, downloader
+from syncmymoodle import course_cache, downloader, pathing
 from syncmymoodle.node import Node, RemoteMarkerKind
 from syncmymoodle.storage import write_private_gzip_json
 
@@ -51,6 +51,61 @@ def test_classify_local_file_is_tristate(tmp_path):
     assert classify_local_file(f, None) is FileMatch.UNKNOWN
     assert classify_local_file(f, "") is FileMatch.UNKNOWN
     assert classify_local_file(tmp_path / "nope", sha1(b"x")) is FileMatch.UNKNOWN
+
+
+def test_transfer_plan_applies_windows_prefix_to_appended_temp_paths(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(pathing, "is_windows", lambda: True)
+    monkeypatch.setattr(pathing, "WINDOWS_EXTENDED_PATH_THRESHOLD", 1)
+
+    plan = downloader.prepare_transfer_plan(
+        Node("file.pdf", "id", "Linked file [application/pdf]", None),
+        tmp_path / "file.pdf",
+    )
+
+    assert os.fspath(plan.tmp_path).startswith("\\\\?\\")
+    assert os.fspath(plan.etag_sidecar).startswith("\\\\?\\")
+
+
+def test_youtube_outtmpl_applies_windows_prefix_after_template_suffix(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(pathing, "is_windows", lambda: True)
+    monkeypatch.setattr(pathing, "WINDOWS_EXTENDED_PATH_THRESHOLD", 100_000)
+    captured = {}
+
+    class FakeYoutubeDL:
+        def __init__(self, opts):
+            captured["opts"] = opts
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def download(self, links):
+            captured["links"] = links
+
+    monkeypatch.setattr(downloader.yt_dlp, "YoutubeDL", FakeYoutubeDL)
+    ctx = make_context({"basedir": str(tmp_path)})
+    root = Node("", -1, "Root", None)
+    section = root.add_child("Section", 1, "Section")
+    assert section is not None
+    node = section.add_child(
+        "Video",
+        "video-id",
+        "Youtube",
+        url="https://youtu.be/abcdefghijk",
+    )
+    assert node is not None
+
+    assert downloader.scan_and_download_youtube(ctx, node)
+
+    assert captured["opts"]["outtmpl"].startswith("\\\\?\\")
+    assert "%(title)s-%(id)s.%(ext)s" in captured["opts"]["outtmpl"]
+    assert captured["links"] == ["https://youtu.be/abcdefghijk"]
 
 
 def seed_course_cache(config, *, timemodified, etag, is_downloaded=True):

--- a/tests/test_quiz.py
+++ b/tests/test_quiz.py
@@ -366,3 +366,24 @@ def test_render_pdf_with_chromium_failure(tmp_path, monkeypatch):
     )
     assert quiz.render_pdf_with_chromium("/fake/chrome", html_path, pdf_path) is False
     assert not pdf_path.exists()
+
+
+def test_download_quiz_applies_long_path_check_after_file_extension(
+    tmp_path, monkeypatch
+):
+    ctx = quiz_context(tmp_path, "html")
+    node = quiz_node()
+    checked_paths = []
+
+    def record_path(path):
+        checked_paths.append(path)
+        return path
+
+    monkeypatch.setattr(
+        quiz.pathing, "with_windows_extended_length_prefix", record_path
+    )
+
+    assert quiz.download_quiz(ctx, node)
+
+    assert any(str(path).endswith("My Quiz, Versuch 1.html") for path in checked_paths)
+    assert any(str(path).endswith("My Quiz, Versuch 1.pdf") for path in checked_paths)

--- a/tests/test_storage_safety.py
+++ b/tests/test_storage_safety.py
@@ -1,10 +1,23 @@
 import gzip
 import json
+import os
 import stat
+from types import SimpleNamespace
+
+import pytest
 
 from syncmymoodle import course_cache
 from syncmymoodle.node import Node
-from syncmymoodle.storage import read_private_gzip_json, write_private_gzip_json
+from syncmymoodle.pathing import (
+    make_conflict_path,
+    sanitize_path_part,
+    windows_extended_length_path,
+)
+from syncmymoodle.storage import (
+    chmod_private_best_effort,
+    read_private_gzip_json,
+    write_private_gzip_json,
+)
 
 from .helpers import FakeSession, download_file, make_context, node_path
 
@@ -18,6 +31,52 @@ def test_sanitized_node_path_stays_inside_basedir(tmp_path):
 
     assert target_path == tmp_path / "_"
     assert target_path.resolve(strict=False).is_relative_to(tmp_path)
+
+
+def test_sanitize_path_part_avoids_windows_reserved_names():
+    assert sanitize_path_part("...") == "_"
+    assert sanitize_path_part(". . .") == "_"
+    assert sanitize_path_part("Chapter 3 .") == "Chapter 3"
+    assert sanitize_path_part("notes ..") == "notes"
+    assert sanitize_path_part("CON") == "_CON"
+    assert sanitize_path_part("CON .txt") == "_CON .txt"
+    assert sanitize_path_part("aux.txt") == "_aux.txt"
+    assert sanitize_path_part("COM²") == "_COM²"
+    assert sanitize_path_part("lecture.") == "lecture"
+    assert sanitize_path_part("bad\x00name") == "badname"
+
+
+def test_empty_child_node_name_materializes_as_placeholder(tmp_path):
+    syncer = make_context({"basedir": str(tmp_path)})
+    root = Node("", -1, "Root", None)
+    child = root.add_child("", 1, "Section")
+
+    assert child is not None
+    assert node_path(syncer, child) == tmp_path / "_"
+
+
+def test_windows_extended_length_path_formats_drive_and_unc_paths():
+    assert (
+        windows_extended_length_path(r"C:\Moodle\Course\file.pdf")
+        == r"\\?\C:\Moodle\Course\file.pdf"
+    )
+    assert (
+        windows_extended_length_path(r"\\server\share\file.pdf")
+        == r"\\?\UNC\server\share\file.pdf"
+    )
+    assert (
+        windows_extended_length_path(r"\\?\C:\Moodle\Course\file.pdf")
+        == r"\\?\C:\Moodle\Course\file.pdf"
+    )
+
+
+def test_conflict_path_applies_windows_prefix_after_suffix(tmp_path, monkeypatch):
+    target = tmp_path / "file.pdf"
+    target.write_bytes(b"content")
+    monkeypatch.setattr("syncmymoodle.pathing.is_windows", lambda: True)
+    monkeypatch.setattr("syncmymoodle.pathing.WINDOWS_EXTENDED_PATH_THRESHOLD", 1)
+
+    assert os.fspath(make_conflict_path(target)).startswith("\\\\?\\")
 
 
 def test_private_gzip_json_roundtrip_uses_private_permissions(tmp_path):
@@ -35,6 +94,147 @@ def test_private_gzip_json_roundtrip_uses_private_permissions(tmp_path):
         "format": "test",
         "value": 1,
     }
+
+
+def test_private_chmod_warns_on_windows(tmp_path, monkeypatch, caplog):
+    target = tmp_path / "session"
+    target.write_bytes(b"data")
+    monkeypatch.setattr("syncmymoodle.storage.is_windows", lambda: True)
+
+    def missing_pywin32(name):
+        raise ImportError(name)
+
+    monkeypatch.setattr("syncmymoodle.storage.importlib.import_module", missing_pywin32)
+
+    chmod_private_best_effort(target, "session cookie")
+
+    assert (
+        "Could not restrict permissions for session cookie file on Windows"
+        in caplog.text
+    )
+
+
+def test_private_chmod_uses_windows_acl(tmp_path, monkeypatch):
+    target = tmp_path / "session"
+    target.write_bytes(b"data")
+    monkeypatch.setattr("syncmymoodle.storage.is_windows", lambda: True)
+    calls = {}
+
+    class FakeACL:
+        def __init__(self):
+            self.entries = []
+            calls["dacl"] = self
+
+        def AddAccessAllowedAce(self, revision, access_mask, sid):
+            self.entries.append((revision, access_mask, sid))
+
+    def set_security_info(*args):
+        calls["security_info"] = args
+
+    modules = {
+        "win32api": SimpleNamespace(
+            CloseHandle=lambda handle: calls.setdefault("closed", []).append(handle),
+            GetCurrentProcess=lambda: "process",
+        ),
+        "win32con": SimpleNamespace(TOKEN_QUERY=8),
+        "win32security": SimpleNamespace(
+            ACL=FakeACL,
+            ACL_REVISION=2,
+            DACL_SECURITY_INFORMATION=4,
+            PROTECTED_DACL_SECURITY_INFORMATION=8,
+            SE_FILE_OBJECT=1,
+            TokenUser=1,
+            GetTokenInformation=lambda token, token_type: ("user-sid",),
+            OpenProcessToken=lambda process, access: ("token", process, access),
+            SetNamedSecurityInfo=set_security_info,
+        ),
+        "ntsecuritycon": SimpleNamespace(
+            DELETE=4,
+            FILE_GENERIC_READ=1,
+            FILE_GENERIC_WRITE=2,
+        ),
+    }
+
+    def fake_import_module(name):
+        return modules[name]
+
+    monkeypatch.setattr(
+        "syncmymoodle.storage.importlib.import_module", fake_import_module
+    )
+
+    chmod_private_best_effort(target, "session cookie")
+
+    assert calls["dacl"].entries == [(2, 7, "user-sid")]
+    assert calls["security_info"] == (
+        os.path.abspath(target),
+        1,
+        12,
+        None,
+        None,
+        calls["dacl"],
+        None,
+    )
+    assert calls["closed"] == [("token", "process", 8)]
+
+
+def test_private_gzip_json_restricts_temp_file_before_writing_on_windows(
+    tmp_path, monkeypatch
+):
+    target = tmp_path / "session"
+    restricted_paths = []
+
+    monkeypatch.setattr("syncmymoodle.storage.is_windows", lambda: True)
+    monkeypatch.setattr(
+        "syncmymoodle.storage.restrict_private_file_windows",
+        lambda path: restricted_paths.append(path),
+    )
+
+    write_private_gzip_json(target, {"format": "test", "value": 1})
+
+    assert len(restricted_paths) == 2
+    assert restricted_paths[0].name.startswith(".session.")
+    assert restricted_paths[0].parent == tmp_path
+    assert restricted_paths[1] == target
+    assert read_private_gzip_json(target, "test data") == {
+        "format": "test",
+        "value": 1,
+    }
+
+
+def test_private_gzip_json_write_does_not_require_fchmod(tmp_path, monkeypatch):
+    target = tmp_path / "session"
+    monkeypatch.delattr(os, "fchmod", raising=False)
+
+    write_private_gzip_json(target, {"format": "test", "value": 1})
+
+    assert read_private_gzip_json(target, "test data") == {
+        "format": "test",
+        "value": 1,
+    }
+    assert list(tmp_path.glob(".session.*")) == []
+
+
+def test_private_gzip_json_closes_temp_file_before_cleanup(tmp_path, monkeypatch):
+    target = tmp_path / "session"
+    real_close = os.close
+    closed_fds = []
+
+    def broken_fdopen(fd, mode):
+        raise OSError("simulated write setup failure")
+
+    def recording_close(fd):
+        closed_fds.append(fd)
+        real_close(fd)
+
+    monkeypatch.setattr(os, "fdopen", broken_fdopen)
+    monkeypatch.setattr(os, "close", recording_close)
+
+    with pytest.raises(OSError, match="simulated write setup failure"):
+        write_private_gzip_json(target, {"format": "test", "value": 1})
+
+    assert closed_fds
+    assert not target.exists()
+    assert list(tmp_path.glob(".session.*")) == []
 
 
 def test_download_uses_course_cache_to_skip_unchanged_file(tmp_path):


### PR DESCRIPTION
Fix Windows-specific storage and path issues:
    - restrict session/cache file permissions on Windows via pywin32 ACLs
    - avoid Unix-only `os.fchmod` crashes
    - close temp files before cleanup/replacement
    - sanitize Windows-reserved path names
    - avoid case-insensitive filename overwrites
    - apply long-path prefixes after final filenames are assembled

closes #161