### PR TITLE
Download multiple Opencast video tracks

### DIFF
--- a/syncmymoodle/context.py
+++ b/syncmymoodle/context.py
@@ -93,7 +93,9 @@ class SyncContext:
     sciebo_link_cache: dict[str, Node | None] = field(default_factory=dict)
     service_outages: ServiceOutageTracker = field(default_factory=ServiceOutageTracker)
     opencast_episode_auth_cache: set[tuple[Any, str]] = field(default_factory=set)
-    opencast_track_cache: dict[str, OpencastTrack] = field(default_factory=dict)
+    opencast_track_cache: dict[str, tuple[OpencastTrack, ...]] = field(
+        default_factory=dict
+    )
     downloaded_paths: set[Path] = field(default_factory=set)
     filtered_items: set[FilteredItem] = field(default_factory=set)
     quiz_review_cache: dict[str, str] = field(default_factory=dict)

--- a/syncmymoodle/links.py
+++ b/syncmymoodle/links.py
@@ -266,17 +266,12 @@ def scan_for_links(  # noqa: C901 - legacy parser awaiting decomposition
                 continue
             if not opencast_api.authenticate_episode(ctx, course_id, vid_id, log):
                 continue
-            track = opencast_api.resolve_track_from_episode(ctx, vid_id, log)
-            if track is None:
-                continue
-            if filters.should_skip_url(ctx, track.url, "Opencast video URL"):
-                continue
-
-            opencast_api.add_track_node(
+            opencast_api.add_episode_nodes(
+                ctx,
                 parent_node,
-                module_title or track.url.split("/")[-1],
+                module_title,
                 vid_id,
-                track,
+                log,
             )
 
     # https://rwth-aachen.sciebo.de/s/XXX

--- a/syncmymoodle/opencast.py
+++ b/syncmymoodle/opencast.py
@@ -1,11 +1,13 @@
+import hashlib
 import logging
 import re
 import urllib.parse
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, Iterator, cast
 
 import requests
 
+from syncmymoodle import filters
 from syncmymoodle.constants import (
     CHECKSUM_LENGTHS_BY_ALGO,
     HTTP_TIMEOUT_SECONDS,
@@ -38,6 +40,7 @@ class OpencastTrack:
     checksum: str | None = None
     size: int | None = None
     duration: int | None = None
+    flavor_type: str | None = None
 
     @property
     def remote_marker(self) -> str | None:
@@ -52,22 +55,45 @@ class OpencastTrack:
         return RemoteMarkerKind.CONTENT_HASH if self.checksum else None
 
 
-def add_track_node(
-    parent_node: Node,
-    name: str,
-    episode_id: Any,
+def _track_node_name(
+    name: Any,
     track: OpencastTrack,
-) -> Node | None:
-    """Add a downloadable Opencast track with its remote metadata."""
-    return parent_node.add_child(
-        name,
-        episode_id,
-        "Opencast",
-        url=track.url,
-        etag=track.remote_marker,
-        etag_kind=track.remote_marker_kind,
-        remote_size=track.size,
+) -> str:
+    flavor_label = track.flavor_type or (
+        f"video-{hashlib.sha256(track.url.encode()).hexdigest()[:8]}"
     )
+    base_name = (
+        str(name) if name else urllib.parse.urlparse(track.url).path.rsplit("/", 1)[-1]
+    )
+    base_name = base_name or flavor_label
+    extension = base_name[-4:] if base_name.casefold().endswith(".mp4") else ""
+    stem = base_name[: -len(extension)] if extension else base_name
+    return f"{stem} ({flavor_label}){extension}"
+
+
+def add_episode_nodes(
+    ctx: SyncContext,
+    parent_node: Node,
+    name: Any,
+    episode_id: str,
+    log: logging.Logger = logger,
+) -> None:
+    tracks = resolve_tracks_from_episode(ctx, episode_id, log)
+    if tracks is None:
+        return
+
+    for track in tracks:
+        if filters.should_skip_url(ctx, track.url, "Opencast video URL"):
+            continue
+        parent_node.add_child(
+            _track_node_name(name, track),
+            episode_id,
+            "Opencast",
+            url=track.url,
+            etag=track.remote_marker,
+            etag_kind=track.remote_marker_kind,
+            remote_size=track.size,
+        )
 
 
 def log_backend_issue(
@@ -390,28 +416,23 @@ def opencast_track_from_api(track: dict[str, Any]) -> OpencastTrack | None:
         return None
 
     checksum_type, checksum = extract_checksum(track)
+    raw_flavor = track.get("type")
+    flavor_type = (
+        raw_flavor.partition("/")[0].strip().casefold()
+        if isinstance(raw_flavor, str)
+        else ""
+    )
     return OpencastTrack(
         url=url,
         checksum_type=checksum_type,
         checksum=checksum,
         size=optional_int(track.get("size")),
         duration=optional_int(track.get("duration")),
+        flavor_type=flavor_type or None,
     )
 
 
-def resolve_track_from_episode(  # noqa: C901 - legacy resolver awaiting decomposition
-    ctx: SyncContext,
-    episode_id: str,
-    log: logging.Logger = logger,
-) -> OpencastTrack | None:
-    if episode_id in ctx.opencast_track_cache:
-        return ctx.opencast_track_cache[episode_id]
-
-    episode_url = f"{OPENCAST_SEARCH_URL}?id={episode_id}"
-    tracks: list[tuple[int, OpencastTrack]] = []
-    entries = fetch_result_list(ctx, episode_url, f"episode {episode_id}", log)
-    if entries is None:
-        return None
+def _episode_track_data(entries: list[Any]) -> Iterator[dict[str, Any]]:
     for entry in entries:
         if not isinstance(entry, dict):
             continue
@@ -419,23 +440,55 @@ def resolve_track_from_episode(  # noqa: C901 - legacy resolver awaiting decompo
         media = mediapackage.get("media") if isinstance(mediapackage, dict) else None
         track_data = media.get("track") if isinstance(media, dict) else None
         if isinstance(track_data, dict):
-            track_data = [track_data]
-        if not isinstance(track_data, list):
-            continue
-        for track in track_data:
-            if not isinstance(track, dict):
-                continue
-            opencast_track = opencast_track_from_api(track)
-            if opencast_track is None:
-                continue
-            video = cast(dict[str, Any], track["video"])
-            tracks.append((resolution_width(video.get("resolution")), opencast_track))
+            yield track_data
+        elif isinstance(track_data, list):
+            yield from (track for track in track_data if isinstance(track, dict))
 
-    if not tracks:
+
+def resolve_tracks_from_episode(
+    ctx: SyncContext,
+    episode_id: str,
+    log: logging.Logger = logger,
+) -> tuple[OpencastTrack, ...] | None:
+    if episode_id in ctx.opencast_track_cache:
+        return ctx.opencast_track_cache[episode_id]
+
+    episode_url = f"{OPENCAST_SEARCH_URL}?id={episode_id}"
+    selected: dict[
+        tuple[str, str], tuple[tuple[int, int, int, str], OpencastTrack]
+    ] = {}
+    entries = fetch_result_list(ctx, episode_url, f"episode {episode_id}", log)
+    if entries is None:
+        return None
+    for track_data in _episode_track_data(entries):
+        track = opencast_track_from_api(track_data)
+        if track is None:
+            continue
+        video = cast(dict[str, Any], track_data["video"])
+        quality = (
+            resolution_width(video.get("resolution")),
+            optional_int(video.get("bitrate")) or 0,
+            track.size or 0,
+            track.url,
+        )
+        # Multiple encodings of a known logical flavor are renditions of the
+        # same track. Without flavor metadata, retain every distinct URL rather
+        # than silently treating unrelated videos as one generic track.
+        track_key = (
+            ("flavor", track.flavor_type)
+            if track.flavor_type is not None
+            else ("url", track.url)
+        )
+        current = selected.get(track_key)
+        if current is None or quality > current[0]:
+            selected[track_key] = (quality, track)
+
+    if not selected:
         log.warning("Opencast: no downloadable mp4 track found for %s", episode_id)
         return None
 
-    # Prefer the highest resolution plain HTTPS mp4 track.
-    selected_track = max(tracks, key=lambda track: track[0])[1]
-    ctx.opencast_track_cache[episode_id] = selected_track
-    return selected_track
+    # Select the best plain MP4 rendition per known logical flavor and keep
+    # untyped tracks distinct. Sorting makes node order independent of the API.
+    tracks = tuple(selected[track_key][1] for track_key in sorted(selected))
+    ctx.opencast_track_cache[episode_id] = tracks
+    return tracks

--- a/syncmymoodle/sync_handlers.py
+++ b/syncmymoodle/sync_handlers.py
@@ -399,22 +399,12 @@ def handle_embedded_link_module(  # noqa: C901 - legacy handler awaiting decompo
                             ctx, course_id, vid_id, log
                         ):
                             continue
-                        track = opencast_api.resolve_track_from_episode(
-                            ctx, vid_id, log
-                        )
-                        if track is None:
-                            continue
-
-                        if filters.should_skip_url(
-                            ctx, track.url, "Opencast video URL"
-                        ):
-                            continue
-
-                        opencast_api.add_track_node(
+                        opencast_api.add_episode_nodes(
+                            ctx,
                             section_node,
                             module["name"],
                             vid_id,
-                            track,
+                            log,
                         )
 
                 if scan_page_links:
@@ -531,16 +521,12 @@ def handle_opencast_lti_module(  # noqa: C901 - legacy handler awaiting decompos
         series_node = cast(Node, course_node.add_child(name, series_id, "Section"))
 
         for episode_id, episode_title in episodes:
-            track = opencast_api.resolve_track_from_episode(ctx, episode_id, log)
-            if track is None:
-                continue
-            if filters.should_skip_url(ctx, track.url, "Opencast video URL"):
-                continue
-            opencast_api.add_track_node(
+            opencast_api.add_episode_nodes(
+                ctx,
                 series_node,
                 episode_title,
                 episode_id,
-                track,
+                log,
             )
     else:
         if not engage_single_id:
@@ -557,16 +543,12 @@ def handle_opencast_lti_module(  # noqa: C901 - legacy handler awaiting decompos
                 endpoint=endpoint,
             ):
                 return
-            track = opencast_api.resolve_track_from_episode(ctx, engage_single_id, log)
-            if track is None:
-                return
-            if filters.should_skip_url(ctx, track.url, "Opencast video URL"):
-                return
-            opencast_api.add_track_node(
+            opencast_api.add_episode_nodes(
+                ctx,
                 section_node,
                 name,
                 engage_single_id,
-                track,
+                log,
             )
 
 

--- a/tests/fixtures/opencast/episode_series_a.json
+++ b/tests/fixtures/opencast/episode_series_a.json
@@ -4,6 +4,7 @@
       "mediapackage": {
         "media": {
           "track": {
+            "type": "presenter/delivery",
             "mimetype": "video/mp4",
             "url": "https://video.example.test/opencast/series-a.mp4",
             "checksum": {

--- a/tests/fixtures/opencast/episode_series_b.json
+++ b/tests/fixtures/opencast/episode_series_b.json
@@ -12,6 +12,7 @@
               }
             },
             {
+              "type": "presenter/delivery",
               "mimetype": "video/mp4",
               "url": "https://video.example.test/opencast/series-b.mp4",
               "checksum": {

--- a/tests/fixtures/opencast/episode_single.json
+++ b/tests/fixtures/opencast/episode_single.json
@@ -5,6 +5,7 @@
         "media": {
           "track": [
             {
+              "type": "presenter/delivery",
               "mimetype": "video/mp4",
               "url": "https://video.example.test/opencast/single-low.mp4",
               "checksum": {
@@ -18,6 +19,21 @@
               }
             },
             {
+              "type": "presentation/delivery",
+              "mimetype": "video/mp4",
+              "url": "https://video.example.test/opencast/presentation-high.mp4",
+              "checksum": {
+                "type": "md5",
+                "$": "44444444444444444444444444444444"
+              },
+              "size": 2500,
+              "duration": 120000,
+              "video": {
+                "resolution": "1920x1080"
+              }
+            },
+            {
+              "type": "presenter/delivery",
               "mimetype": "video/mp4",
               "url": "https://video.example.test/opencast/single-high.mp4",
               "checksum": {
@@ -31,6 +47,21 @@
               }
             },
             {
+              "type": "presentation/delivery",
+              "mimetype": "video/mp4",
+              "url": "https://video.example.test/opencast/presentation-low.mp4",
+              "checksum": {
+                "type": "md5",
+                "$": "33333333333333333333333333333333"
+              },
+              "size": 1500,
+              "duration": 120000,
+              "video": {
+                "resolution": "1280x720"
+              }
+            },
+            {
+              "type": "presentation/delivery",
               "mimetype": "video/mp4",
               "url": "https://video.example.test/opencast/single-stream.mp4",
               "transport": "hls",

--- a/tests/snapshots/assignment_opencast_tree.txt
+++ b/tests/snapshots/assignment_opencast_tree.txt
@@ -2,4 +2,4 @@ Semester | 26ss |  |  |
 Course | 26ss/(UE) Software Quality |  |  |
 Section | 26ss/(UE) Software Quality/Assignments |  |  |
 Assignment | 26ss/(UE) Software Quality/Assignments/Video reflection |  |  |
-Opencast | 26ss/(UE) Software Quality/Assignments/Video reflection/Video reflection | https://video.example.test/11111111-2222-4333-8444-555555555555/presentation.mp4 |  | 11111111111111111111111111111111
+Opencast | 26ss/(UE) Software Quality/Assignments/Video reflection/Video reflection (presentation) | https://video.example.test/11111111-2222-4333-8444-555555555555/presentation.mp4 |  | 11111111111111111111111111111111

--- a/tests/snapshots/mixed_course_tree.txt
+++ b/tests/snapshots/mixed_course_tree.txt
@@ -13,7 +13,7 @@ Folder | 26ss/Comprehensive Sync/Materials/Essay upload/Feedback |  |  |
 Assignment File | 26ss/Comprehensive Sync/Materials/Essay upload/Feedback/feedback.txt | https://moodle.rwth-aachen.de/pluginfile.php/104/mod_assign/feedback/feedback.txt | 1710000106 |
 Linked file [application/pdf] | 26ss/Comprehensive Sync/Materials/direct.pdf | https://files.example.test/direct.pdf |  | "direct-file-v1"
 Youtube | 26ss/Comprehensive Sync/Materials/Youtube: External HTML page | https://www.youtube.com/watch?v=directvid01 |  |
-Opencast | 26ss/Comprehensive Sync/Materials/Page module | https://video.example.test/33333333-4444-4555-8666-777777777777/presentation.mp4 |  | 33333333333333333333333333333333
+Opencast | 26ss/Comprehensive Sync/Materials/Page module (presentation) | https://video.example.test/33333333-4444-4555-8666-777777777777/presentation.mp4 |  | 33333333333333333333333333333333
 Embedded videojs | 26ss/Comprehensive Sync/Materials/page-video.mp4 | https://moodle.rwth-aachen.de/pluginfile.php/104/mod_page/content/315/page-video.mp4 |  |
 Youtube | 26ss/Comprehensive Sync/Materials/Youtube: Page module | https://www.youtube.com/watch?v=pagevideo01 |  |
 Youtube | 26ss/Comprehensive Sync/Materials/Youtube: Label module | https://www.youtube.com/watch?v=labelvid001 |  |

--- a/tests/snapshots/opencast_lti_tree.txt
+++ b/tests/snapshots/opencast_lti_tree.txt
@@ -1,7 +1,8 @@
 Semester | 26ss |  |  |
 Course | 26ss/(VO) Data Science |  |  |
 Section | 26ss/(VO) Data Science/Opencast |  |  |
-Opencast | 26ss/(VO) Data Science/Opencast/Single recording | https://video.example.test/opencast/single-high.mp4 |  | 22222222222222222222222222222222
+Opencast | 26ss/(VO) Data Science/Opencast/Single recording (presentation) | https://video.example.test/opencast/presentation-high.mp4 |  | 44444444444444444444444444444444
+Opencast | 26ss/(VO) Data Science/Opencast/Single recording (presenter) | https://video.example.test/opencast/single-high.mp4 |  | 22222222222222222222222222222222
 Section | 26ss/(VO) Data Science/Series recordings |  |  |
-Opencast | 26ss/(VO) Data Science/Series recordings/Series episode A | https://video.example.test/opencast/series-a.mp4 |  | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-Opencast | 26ss/(VO) Data Science/Series recordings/Series episode B | https://video.example.test/opencast/series-b.mp4 |  | bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+Opencast | 26ss/(VO) Data Science/Series recordings/Series episode A (presenter) | https://video.example.test/opencast/series-a.mp4 |  | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+Opencast | 26ss/(VO) Data Science/Series recordings/Series episode B (presenter) | https://video.example.test/opencast/series-b.mp4 |  | bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb

--- a/tests/test_sync_fixtures.py
+++ b/tests/test_sync_fixtures.py
@@ -153,11 +153,14 @@ def test_assignment_intro_opencast_embed_is_added_to_assignment_node(monkeypatch
     )
     monkeypatch.setattr(
         opencast,
-        "resolve_track_from_episode",
-        lambda ctx, episode_id, *a, **k: opencast.OpencastTrack(
-            f"https://video.example.test/{episode_id}/presentation.mp4",
-            checksum_type="md5",
-            checksum="11111111111111111111111111111111",
+        "resolve_tracks_from_episode",
+        lambda ctx, episode_id, *a, **k: (
+            opencast.OpencastTrack(
+                f"https://video.example.test/{episode_id}/presentation.mp4",
+                checksum_type="md5",
+                checksum="11111111111111111111111111111111",
+                flavor_type="presentation",
+            ),
         ),
     )
 
@@ -317,6 +320,78 @@ def test_opencast_malformed_results_open_shared_service_circuit(caplog):
         "this sync. Check the RWTH ITC status page: "
         f"{opencast.RWTH_MOODLE_STATUS_URL}"
     )
+
+
+def test_opencast_track_name_does_not_depend_on_sibling_count(monkeypatch):
+    syncer = make_context()
+    presenter = opencast.OpencastTrack(
+        "https://video.example.test/presenter.mp4",
+        flavor_type="presenter",
+    )
+    presentation = opencast.OpencastTrack(
+        "https://video.example.test/presentation.mp4",
+        flavor_type="presentation",
+    )
+    resolved_tracks = (presenter,)
+    monkeypatch.setattr(
+        opencast,
+        "resolve_tracks_from_episode",
+        lambda *args, **kwargs: resolved_tracks,
+    )
+
+    single_parent = Node("Single", 1, "Section", None)
+    opencast.add_episode_nodes(syncer, single_parent, "Lecture.mp4", "episode")
+    resolved_tracks = (presentation, presenter)
+    multi_parent = Node("Multiple", 2, "Section", None)
+    opencast.add_episode_nodes(syncer, multi_parent, "Lecture.mp4", "episode")
+
+    single_name = single_parent.children[0].name
+    multi_name = next(
+        child.name for child in multi_parent.children if child.url == presenter.url
+    )
+    assert single_name == multi_name == "Lecture (presenter).mp4"
+
+
+def test_opencast_keeps_distinct_tracks_without_flavor_metadata(monkeypatch):
+    episode_id = "untyped-episode"
+    urls = [
+        "https://video.example.test/camera-a.mp4",
+        "https://video.example.test/camera-b.mp4",
+    ]
+    syncer = make_context()
+    monkeypatch.setattr(
+        opencast,
+        "fetch_result_list",
+        lambda *args, **kwargs: [
+            {
+                "mediapackage": {
+                    "media": {
+                        "track": [
+                            {
+                                "mimetype": "video/mp4",
+                                "url": url,
+                                "video": {"resolution": resolution},
+                            }
+                            for url, resolution in zip(
+                                urls, ["1280x720", "1920x1080"], strict=True
+                            )
+                        ]
+                    }
+                }
+            }
+        ],
+    )
+
+    tracks = opencast.resolve_tracks_from_episode(syncer, episode_id)
+
+    assert tracks is not None
+    assert [track.url for track in tracks] == urls
+    assert all(track.flavor_type is None for track in tracks)
+
+    parent = Node("Section", 1, "Section", None)
+    opencast.add_episode_nodes(syncer, parent, "Lecture.mp4", episode_id)
+    assert len({child.name for child in parent.children}) == 2
+    assert all(child.name.startswith("Lecture (video-") for child in parent.children)
 
 
 def test_sharing_token_from_link_extracts_url_segment():
@@ -831,12 +906,15 @@ def test_mixed_course_sync_tree_covers_common_module_surfaces(monkeypatch):
     )
     monkeypatch.setattr(
         opencast,
-        "resolve_track_from_episode",
-        lambda ctx, episode_id, *a, **k: opencast.OpencastTrack(
-            f"https://video.example.test/{episode_id}/presentation.mp4",
-            checksum_type="md5",
-            checksum="33333333333333333333333333333333",
-            size=5678,
+        "resolve_tracks_from_episode",
+        lambda ctx, episode_id, *a, **k: (
+            opencast.OpencastTrack(
+                f"https://video.example.test/{episode_id}/presentation.mp4",
+                checksum_type="md5",
+                checksum="33333333333333333333333333333333",
+                size=5678,
+                flavor_type="presentation",
+            ),
         ),
     )
 
@@ -852,7 +930,8 @@ def test_mixed_course_sync_tree_covers_common_module_surfaces(monkeypatch):
         syncer.root_node, ["26ss", "Comprehensive Sync", "Materials", "direct.pdf"]
     )
     opencast_node = node_at_path(
-        syncer.root_node, ["26ss", "Comprehensive Sync", "Materials", "Page module"]
+        syncer.root_node,
+        ["26ss", "Comprehensive Sync", "Materials", "Page module (presentation)"],
     )
     assert direct_node.remote_size == 1234
     assert opencast_node.remote_size == 5678


### PR DESCRIPTION
Downloads the best MP4 rendition for each Opencast video flavor, such as presenter and presentation tracks. Track filenames remain stable, and videos without flavor metadata are preserved independently.

Closes #109 