### PR TITLE
Filter courses by Moodle role

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,14 @@ The main course selectors are:
 - `courses.selected`: sync only these course URLs or numeric IDs
 - `courses.semesters`: sync courses from these semester IDs
 - `courses.skip`: exclude these course URLs or numeric IDs
+- `courses.exclude_roles`: exclude courses where a directly assigned Moodle
+  course-role shortname matches, such as `tutor`
 
-`courses.selected` takes priority over both `semesters` and `skip`.
+`courses.selected` takes priority over `semesters`, `skip`, and `exclude_roles`.
+Role lookups are only made when `exclude_roles` is configured. If Moodle cannot
+determine your role for a course, that course is kept.
+Moodle's mobile API exposes only roles assigned directly in the course; roles
+inherited from a course category or the system cannot be matched by this filter.
 
 `exclude_sections` skips complete topic or week blocks. `exclude_modules` skips
 individual activities or resources by name, type, ID, URL, or pattern. Both can

--- a/syncmymoodle/config.py
+++ b/syncmymoodle/config.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import difflib
 import os
 import re
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field, fields
 from pathlib import Path
 from typing import Any, Callable, Literal, TypeAlias, cast
@@ -54,6 +54,14 @@ def as_string_list(value: Any) -> list[str]:
     else:
         values = [value]
     return [str(item) for item in values if item is not None]
+
+
+def normalize_role_shortnames(value: Any) -> list[str]:
+    return list(
+        dict.fromkeys(
+            role for item in as_string_list(value) if (role := item.strip().casefold())
+        )
+    )
 
 
 def as_command_argv(value: Any) -> list[str]:
@@ -420,6 +428,18 @@ class Config:
             aliases=("skipcourses",),
         ),
     )
+    exclude_course_roles: list[str] = option(
+        group="courses",
+        key="exclude_roles",
+        factory=list,
+        normalize=normalize_role_shortnames,
+        cli=cli_csv(
+            "exclude-course-roles",
+            "exclude courses where one of your directly assigned Moodle course "
+            "roles has one of these comma-separated shortnames, e.g. tutor; "
+            "ignored when --courses is set",
+        ),
+    )
     only_sync_semester: list[str] = option(
         group="courses",
         key="semesters",
@@ -688,6 +708,18 @@ class Config:
             "sciebo": self.link_sciebo,
         }
         return self.follow_links and flags.get(name, False)
+
+    def matching_excluded_course_role(
+        self, role_shortnames: Iterable[str] | None
+    ) -> str | None:
+        """Return the first configured role matching Moodle's direct assignments."""
+        if role_shortnames is None:
+            return None
+        normalized = set(normalize_role_shortnames(list(role_shortnames)))
+        return next(
+            (role for role in self.exclude_course_roles if role in normalized),
+            None,
+        )
 
 
 @dataclass(frozen=True)

--- a/syncmymoodle/config.toml.example
+++ b/syncmymoodle/config.toml.example
@@ -26,8 +26,9 @@ cookie_file = "" # Defaults to the user config directory, e.g. ~/.config/syncmym
 browser = "" # Optional Chrome/Chromium/Edge path for quiz PDFs; empty auto-detects
 
 [courses]
-selected = [] # Course URLs or numeric IDs; overrides skip and semesters
+selected = [] # Course URLs or numeric IDs; overrides skip, exclude_roles, and semesters
 skip = [] # Course URLs or numeric IDs to exclude
+exclude_roles = [] # Directly assigned course-role shortnames to exclude, such as ["tutor"]
 semesters = [] # Semester IDs such as 25ws or 26ss
 prefix_handling = "suffix" # keep, remove, or suffix
 

--- a/syncmymoodle/moodle.py
+++ b/syncmymoodle/moodle.py
@@ -547,6 +547,37 @@ def get_quiz_attempt_review(
     return payload if isinstance(payload, dict) else None
 
 
+def _mobile_request_data(
+    calls: list[tuple[str, dict[str, Any]]],
+    *,
+    filter_content: bool,
+    rewrite_file_urls: bool,
+) -> dict[str, Any]:
+    data: dict[str, Any] = {}
+    for index, (function, arguments) in enumerate(calls):
+        prefix = f"requests[{index}]"
+        data[f"{prefix}[function]"] = function
+        data[f"{prefix}[arguments]"] = json.dumps(arguments)
+        data[f"{prefix}[settingfilter]"] = int(filter_content)
+        data[f"{prefix}[settingfileurl]"] = int(rewrite_file_urls)
+    return data
+
+
+def _mobile_response_data(response: Any) -> tuple[Any, str | None]:
+    if not isinstance(response, dict):
+        return None, "unexpected response shape"
+    if response.get("error"):
+        return None, str(
+            response.get("exception")
+            or response.get("data")
+            or "web service request failed"
+        )
+    try:
+        return json.loads(response["data"]), None
+    except (KeyError, TypeError, ValueError):
+        return None, "unexpected response shape"
+
+
 def get_all_courses(
     session: requests.Session,
     wstoken: str,
@@ -557,14 +588,16 @@ def get_all_courses(
         session,
         wstoken,
         "tool_mobile_call_external_functions",
-        {
-            "requests[0][function]": "core_enrol_get_users_courses",
-            "requests[0][arguments]": json.dumps(
-                {"userid": str(user_id), "returnusercount": "0"}
-            ),
-            "requests[0][settingfilter]": 1,
-            "requests[0][settingfileurl]": 1,
-        },
+        _mobile_request_data(
+            [
+                (
+                    "core_enrol_get_users_courses",
+                    {"userid": str(user_id), "returnusercount": "0"},
+                )
+            ],
+            filter_content=True,
+            rewrite_file_urls=True,
+        ),
         log,
     )
 
@@ -576,16 +609,11 @@ def get_all_courses(
         first = responses[0] if isinstance(responses, list) and responses else None
         if not isinstance(first, dict):
             error = "unexpected response shape"
-        elif first.get("error"):
-            error = str(first.get("exception") or first.get("data"))
         else:
-            try:
-                courses = json.loads(first["data"])
-            except (KeyError, TypeError, ValueError):
-                error = "unexpected response shape"
-            else:
-                if isinstance(courses, list):
-                    return courses
+            courses, error = _mobile_response_data(first)
+            if error is None and isinstance(courses, list):
+                return courses
+            if error is None:
                 error = "unexpected response shape"
     log.critical(
         "Failed to retrieve the course list from Moodle: %s. Run "
@@ -594,6 +622,103 @@ def get_all_courses(
         error,
     )
     sys.exit(1)
+
+
+def _direct_course_role_shortnames(payload: Any, user_id: Any) -> set[str] | None:
+    if not isinstance(payload, list):
+        return None
+    profile = next(
+        (
+            item
+            for item in payload
+            if isinstance(item, dict) and str(item.get("id")) == str(user_id)
+        ),
+        None,
+    )
+    if profile is None or not isinstance((roles := profile.get("roles")), list):
+        return None
+
+    shortnames: set[str] = set()
+    for role in roles:
+        if (
+            not isinstance(role, dict)
+            or not isinstance((shortname := role.get("shortname")), str)
+            or not shortname.strip()
+        ):
+            return None
+        shortnames.add(shortname)
+    return shortnames
+
+
+def get_direct_course_roles_by_course(
+    session: requests.Session,
+    wstoken: str,
+    user_id: Any,
+    course_ids: list[Any],
+    log: logging.Logger = logger,
+) -> dict[str, set[str] | None]:
+    """Return direct course-context role assignments in one mobile API call.
+
+    Moodle's core profile API calls ``get_user_roles(..., false)`` and therefore
+    does not expose assignments inherited from course categories or the system.
+    """
+    roles_by_course: dict[str, set[str] | None] = {
+        str(course_id): None for course_id in course_ids
+    }
+    if not course_ids:
+        return roles_by_course
+
+    payload = call_webservice(
+        session,
+        wstoken,
+        "tool_mobile_call_external_functions",
+        _mobile_request_data(
+            [
+                (
+                    "core_user_get_course_user_profiles",
+                    {
+                        "userlist": [
+                            {"userid": str(user_id), "courseid": str(course_id)}
+                        ]
+                    },
+                )
+                for course_id in course_ids
+            ],
+            filter_content=False,
+            rewrite_file_urls=False,
+        ),
+        log,
+    )
+    if payload is None:
+        return roles_by_course
+    responses = payload.get("responses") if isinstance(payload, dict) else None
+    error = None
+    if not isinstance(responses, list):
+        responses = []
+        error = "unexpected batch response shape"
+
+    for course_id, response in zip(course_ids, responses, strict=False):
+        response_payload, response_error = _mobile_response_data(response)
+        if response_error is not None:
+            error = response_error
+            break
+        roles = _direct_course_role_shortnames(response_payload, user_id)
+        if roles is None:
+            error = error or "profile roles were missing or malformed"
+            continue
+        roles_by_course[str(course_id)] = roles
+
+    unknown_count = sum(roles is None for roles in roles_by_course.values())
+    if unknown_count:
+        if error is None:
+            error = "the batch response ended early"
+        log.warning(
+            "Could not determine directly assigned Moodle course roles for %s "
+            "course(s): %s; keeping those courses",
+            unknown_count,
+            error,
+        )
+    return roles_by_course
 
 
 def get_course(

--- a/syncmymoodle/sync.py
+++ b/syncmymoodle/sync.py
@@ -20,7 +20,8 @@ def sync(ctx: SyncContext) -> None:  # noqa: C901 - legacy sync awaiting decompo
     root_node = Node("", -1, "Root", None)
     ctx.root_node = root_node
 
-    # Syncing all courses
+    selected_courses = config.selected_courses
+    course_candidates = []
     for course in moodle_api.get_all_courses(session, wstoken, user_id):
         course_name = filters.format_course_name(
             course.get("shortname") or f"course-{course.get('id')}",
@@ -29,10 +30,9 @@ def sync(ctx: SyncContext) -> None:  # noqa: C901 - legacy sync awaiting decompo
         )
         course_id = course["id"]
 
-        selected_courses = config.selected_courses
         if selected_courses:
             # selected_courses is an explicit allowlist that overrides
-            # skip_courses (and, below, only_sync_semester).
+            # skip_courses, only_sync_semester and exclude_course_roles.
             if (
                 filters.matching_course_filter_entry(course_id, selected_courses)
                 is None
@@ -71,6 +71,33 @@ def sync(ctx: SyncContext) -> None:  # noqa: C901 - legacy sync awaiting decompo
                 f"semester {semestername!r} is not selected",
             )
             continue
+
+        course_candidates.append((course_name, course_id, semestername))
+
+    direct_roles_by_course = {}
+    if not selected_courses and config.exclude_course_roles:
+        direct_roles_by_course = moodle_api.get_direct_course_roles_by_course(
+            session,
+            wstoken,
+            user_id,
+            [course_id for _, course_id, _ in course_candidates],
+            logger,
+        )
+
+    # Syncing all courses that passed the local course filters.
+    for course_name, course_id, semestername in course_candidates:
+        if config.exclude_course_roles:
+            excluded_role = config.matching_excluded_course_role(
+                direct_roles_by_course.get(str(course_id))
+            )
+            if excluded_role is not None:
+                ctx.record_filtered(
+                    "courses.exclude_roles",
+                    "course",
+                    f"{course_name} ({course_id})",
+                    f"your directly assigned Moodle course role is {excluded_role!r}",
+                )
+                continue
 
         print(f"Syncing {course_name}...")
         course_sections = moodle_api.get_course(session, wstoken, course_id)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -43,6 +43,7 @@ def test_config_options_record_cli_overrides():
         "browser": "paths.browser",
         "courses": "courses.selected",
         "skip-courses": "courses.skip",
+        "exclude-course-roles": "courses.exclude_roles",
         "semesters": "courses.semesters",
         "course-prefix-handling": "courses.prefix_handling",
         "update-files": "downloads.update_files",
@@ -115,6 +116,8 @@ def test_cli_help_groups_config_options():
     assert "--update-files, --no-update-files" in help_text
     assert "Moodle course URLs or" in help_text
     assert "numeric IDs" in help_text
+    assert "one of your directly assigned" in help_text
+    assert "Moodle course roles has" in help_text
     assert "whose size is known" in help_text
     assert "--show-filtered" in help_text
 
@@ -544,6 +547,7 @@ def test_defaults_applied_for_empty_config(tmp_path, monkeypatch):
     assert cfg.follow_links is True
     assert cfg.update_files is False
     assert cfg.selected_courses == []
+    assert cfg.exclude_course_roles == []
     assert cfg.exclude_links == {}
     # Default module and link toggles are on.
     assert cfg.module_assignment
@@ -752,6 +756,7 @@ def test_filter_values_are_normalized():
     cfg = Config.from_dict(
         {
             "courses.selected": 12,
+            "courses.exclude_roles": ["Tutor", " tutor ", ""],
             "filters.exclude_links": "*calendar*",
             "filters.allowed_domains": "moodle.rwth-aachen.de",
             "filters.exclude_sections": {"*": "General", 42: ["Hidden", None]},
@@ -760,6 +765,9 @@ def test_filter_values_are_normalized():
     )
 
     assert cfg.selected_courses == ["12"]
+    assert cfg.exclude_course_roles == ["tutor"]
+    assert cfg.matching_excluded_course_role({" Student ", "TUTOR"}) == "tutor"
+    assert cfg.matching_excluded_course_role(None) is None
     assert cfg.exclude_links == {"*": ["*calendar*"]}
     assert cfg.allowed_domains == {"*": ["moodle.rwth-aachen.de"]}
     assert cfg.exclude_sections == {"*": ["General"], "42": ["Hidden"]}

--- a/tests/test_sync_filtering.py
+++ b/tests/test_sync_filtering.py
@@ -1,6 +1,9 @@
+import json
 import logging
 
-from syncmymoodle import filters, sync
+import pytest
+
+from syncmymoodle import filters, moodle, sync
 
 from .helpers import FakeSession, make_context, node_rows
 
@@ -37,9 +40,16 @@ def test_selected_courses_override_semester_filter(monkeypatch):
                 "https://moodle.rwth-aachen.de/course/view.php?id=202"
             ],
             "courses.semesters": ["26ss"],
+            "courses.exclude_roles": ["tutor"],
         }
     )
     install_filter_fixtures(monkeypatch, synced_course_ids, FILTER_COURSES)
+    monkeypatch.setattr(
+        "syncmymoodle.moodle.get_direct_course_roles_by_course",
+        lambda *args, **kwargs: pytest.fail(
+            "an explicit course selection must not perform role filtering"
+        ),
+    )
     syncer.session = FakeSession()
 
     sync.sync(syncer)
@@ -116,6 +126,152 @@ def test_skip_courses_and_semester_filter_limit_synced_courses(monkeypatch):
             "matches 'https://moodle.rwth-aachen.de/course/view.php?id=203'",
         ),
     ]
+
+
+def test_excluded_course_roles_skip_matches_and_keep_unknowns(monkeypatch):
+    synced_course_ids = []
+    role_lookup_batches = []
+    syncer = make_context({"courses.exclude_roles": ["Tutor"]})
+    install_filter_fixtures(monkeypatch, synced_course_ids, FILTER_COURSES)
+    roles_by_course = {
+        "201": {" Student "},
+        "202": {"student", "TUTOR"},
+        "203": None,
+    }
+
+    def get_direct_course_roles_by_course(session, wstoken, user_id, course_ids, log):
+        role_lookup_batches.append(course_ids)
+        return roles_by_course
+
+    monkeypatch.setattr(
+        "syncmymoodle.moodle.get_direct_course_roles_by_course",
+        get_direct_course_roles_by_course,
+    )
+    syncer.session = FakeSession()
+
+    sync.sync(syncer)
+
+    assert role_lookup_batches == [[201, 202, 203]]
+    assert synced_course_ids == [201, 203]
+    assert filtered_rows(syncer) == [
+        (
+            "courses.exclude_roles",
+            "course",
+            "Selected Old Semester (202)",
+            "your directly assigned Moodle course role is 'tutor'",
+        )
+    ]
+
+
+def test_get_direct_course_roles_batches_course_profiles(monkeypatch):
+    call = {}
+
+    def call_webservice(session, wstoken, function, data, log):
+        call.update(
+            session=session,
+            wstoken=wstoken,
+            function=function,
+            data=data,
+            log=log,
+        )
+        return {
+            "responses": [
+                {
+                    "error": False,
+                    "data": json.dumps(
+                        [
+                            {
+                                "id": 17,
+                                "roles": [
+                                    {
+                                        "roleid": 5,
+                                        "name": "Student",
+                                        "shortname": "Student",
+                                    },
+                                    {
+                                        "roleid": 9,
+                                        "name": "Tutor",
+                                        "shortname": "tutor",
+                                    },
+                                ],
+                            }
+                        ]
+                    ),
+                },
+                {
+                    "error": False,
+                    "data": json.dumps([{"id": 17, "roles": []}]),
+                },
+            ]
+        }
+
+    monkeypatch.setattr(moodle, "call_webservice", call_webservice)
+    session = FakeSession()
+
+    assert moodle.get_direct_course_roles_by_course(
+        session, "token", 17, [201, 202]
+    ) == {
+        "201": {"Student", "tutor"},
+        "202": set(),
+    }
+    assert call["session"] is session
+    assert call["wstoken"] == "token"
+    assert call["function"] == "tool_mobile_call_external_functions"
+    assert call["data"]["requests[0][function]"] == (
+        "core_user_get_course_user_profiles"
+    )
+    assert call["data"]["requests[1][function]"] == (
+        "core_user_get_course_user_profiles"
+    )
+    assert json.loads(call["data"]["requests[0][arguments]"]) == {
+        "userlist": [{"userid": "17", "courseid": "201"}]
+    }
+    assert json.loads(call["data"]["requests[1][arguments]"]) == {
+        "userlist": [{"userid": "17", "courseid": "202"}]
+    }
+    assert call["data"]["requests[0][settingfilter]"] == 0
+    assert call["data"]["requests[0][settingfileurl]"] == 0
+
+
+@pytest.mark.parametrize(
+    "profile_payload",
+    [
+        [{"id": 17}],
+        [{"id": 17, "roles": [{"shortname": "student"}, {"name": "Broken"}]}],
+        {"id": 17, "roles": []},
+    ],
+)
+def test_get_direct_course_roles_keeps_malformed_profiles_unknown(
+    monkeypatch, caplog, profile_payload
+):
+    monkeypatch.setattr(
+        moodle,
+        "call_webservice",
+        lambda *args, **kwargs: {
+            "responses": [{"error": False, "data": json.dumps(profile_payload)}]
+        },
+    )
+
+    assert moodle.get_direct_course_roles_by_course(
+        FakeSession(), "token", 17, [201]
+    ) == {"201": None}
+    assert "profile roles were missing or malformed" in caplog.text
+
+
+def test_get_direct_course_roles_stops_after_batch_error(monkeypatch, caplog):
+    calls = []
+
+    def call_webservice(*args, **kwargs):
+        calls.append((args, kwargs))
+        return {"responses": [{"error": True, "exception": "not allowed"}]}
+
+    monkeypatch.setattr(moodle, "call_webservice", call_webservice)
+
+    assert moodle.get_direct_course_roles_by_course(
+        FakeSession(), "token", 17, [201, 202, 203]
+    ) == {"201": None, "202": None, "203": None}
+    assert len(calls) == 1
+    assert caplog.text.count("not allowed") == 1
 
 
 def test_section_and_module_filters_record_the_matching_patterns():


### PR DESCRIPTION
Adds `courses.exclude_roles` and `--exclude-course-roles` to skip courses based on directly assigned Moodle course-role shortnames. Role lookups are batched, and courses are retained when roles cannot be determined.

Closes #70