### PR TITLE
Skip unchanged Moodle module requests with incremental caching

### DIFF
--- a/syncmymoodle/cli.py
+++ b/syncmymoodle/cli.py
@@ -2010,14 +2010,7 @@ def run(ctx: SyncContext, *, show_filtered: bool = False) -> None:
         for item in available_functions
         if isinstance(item, dict) and isinstance(item.get("name"), str) and item["name"]
     )
-    ctx.moodle_update_watermark = (
-        max(
-            0,
-            validation.server_time - moodle_api.MOODLE_UPDATE_OVERLAP_SECONDS,
-        )
-        if validation.server_time is not None
-        else None
-    )
+    ctx.moodle_server_time = validation.server_time
     private_access_key = validation.site_info.get("userprivateaccesskey")
     user_private_access_key = (
         private_access_key

--- a/syncmymoodle/cli.py
+++ b/syncmymoodle/cli.py
@@ -2003,6 +2003,21 @@ def run(ctx: SyncContext, *, show_filtered: bool = False) -> None:
 
     assert validation.site_info is not None
     ctx.moodle_account = MoodleAccount(tokens)
+    functions = validation.site_info.get("functions")
+    available_functions = functions if isinstance(functions, list) else []
+    ctx.moodle_functions = frozenset(
+        item["name"]
+        for item in available_functions
+        if isinstance(item, dict) and isinstance(item.get("name"), str) and item["name"]
+    )
+    ctx.moodle_update_watermark = (
+        max(
+            0,
+            validation.server_time - moodle_api.MOODLE_UPDATE_OVERLAP_SECONDS,
+        )
+        if validation.server_time is not None
+        else None
+    )
     private_access_key = validation.site_info.get("userprivateaccesskey")
     user_private_access_key = (
         private_access_key

--- a/syncmymoodle/context.py
+++ b/syncmymoodle/context.py
@@ -98,6 +98,14 @@ class SyncContext:
     emedia_api_session: requests.Session | None = field(default=None, repr=False)
     root_node: Node | None = None
     course_caches: dict[Path, Node] = field(default_factory=dict)
+    course_cache_payloads: dict[Path, dict[str, Any] | None] = field(
+        default_factory=dict,
+        repr=False,
+    )
+    h5p_content_caches: dict[Path, dict[int, tuple[str, str]]] = field(
+        default_factory=dict,
+        repr=False,
+    )
     browser_bootstrap_error_logged: bool = False
     # None negatively caches a share that already failed during this run.
     sciebo_link_cache: dict[str, Node | None] = field(default_factory=dict)

--- a/syncmymoodle/context.py
+++ b/syncmymoodle/context.py
@@ -15,6 +15,7 @@ from syncmymoodle.outcomes import RunStatistics
 from syncmymoodle.output import TerminalOutput, get_output
 
 if TYPE_CHECKING:
+    from syncmymoodle.course_cache import CourseModuleCache
     from syncmymoodle.emedia import EmediaVideo
     from syncmymoodle.opencast import OpencastTrack
 
@@ -106,6 +107,12 @@ class SyncContext:
         default_factory=dict,
         repr=False,
     )
+    course_module_caches: dict[Path, CourseModuleCache] = field(
+        default_factory=dict,
+        repr=False,
+    )
+    moodle_functions: frozenset[str] = field(default_factory=frozenset, repr=False)
+    moodle_update_watermark: int | None = field(default=None, repr=False)
     browser_bootstrap_error_logged: bool = False
     # None negatively caches a share that already failed during this run.
     sciebo_link_cache: dict[str, Node | None] = field(default_factory=dict)

--- a/syncmymoodle/context.py
+++ b/syncmymoodle/context.py
@@ -15,9 +15,14 @@ from syncmymoodle.outcomes import RunStatistics
 from syncmymoodle.output import TerminalOutput, get_output
 
 if TYPE_CHECKING:
-    from syncmymoodle.course_cache import CourseModuleCache
+    from syncmymoodle.course_cache import CourseCacheState
     from syncmymoodle.emedia import EmediaVideo
     from syncmymoodle.opencast import OpencastTrack
+
+
+# Retain a small overlap so a change committed at the integer-second token
+# validation boundary cannot fall between incremental update queries.
+MOODLE_UPDATE_OVERLAP_SECONDS = 5
 
 
 class BrowserSessionUnavailable(RuntimeError):
@@ -98,21 +103,12 @@ class SyncContext:
     )
     emedia_api_session: requests.Session | None = field(default=None, repr=False)
     root_node: Node | None = None
-    course_caches: dict[Path, Node] = field(default_factory=dict)
-    course_cache_payloads: dict[Path, dict[str, Any] | None] = field(
-        default_factory=dict,
-        repr=False,
-    )
-    h5p_content_caches: dict[Path, dict[int, tuple[str, str]]] = field(
-        default_factory=dict,
-        repr=False,
-    )
-    course_module_caches: dict[Path, CourseModuleCache] = field(
+    course_cache_states: dict[Node, CourseCacheState] = field(
         default_factory=dict,
         repr=False,
     )
     moodle_functions: frozenset[str] = field(default_factory=frozenset, repr=False)
-    moodle_update_watermark: int | None = field(default=None, repr=False)
+    moodle_server_time: int | None = field(default=None, repr=False)
     browser_bootstrap_error_logged: bool = False
     # None negatively caches a share that already failed during this run.
     sciebo_link_cache: dict[str, Node | None] = field(default_factory=dict)
@@ -133,6 +129,13 @@ class SyncContext:
 
     def __post_init__(self) -> None:
         self.auth = AuthState.from_config(self.config)
+
+    @property
+    def moodle_update_watermark(self) -> int | None:
+        """Timestamp used for incremental queries, including a safe overlap."""
+        if self.moodle_server_time is None:
+            return None
+        return max(0, self.moodle_server_time - MOODLE_UPDATE_OVERLAP_SECONDS)
 
     def record_filtered(
         self,

--- a/syncmymoodle/course_cache.py
+++ b/syncmymoodle/course_cache.py
@@ -15,10 +15,87 @@ from syncmymoodle.storage import read_private_gzip_json, write_private_gzip_json
 
 logger = logging.getLogger(__name__)
 COURSE_CACHE_FORMAT = "syncmymoodle.course-cache.v1"
+H5P_CONTENT_CACHE_KEY = "h5p_content"
 
 
 def _node_path(ctx: SyncContext, node: Node) -> Path:
     return get_sanitized_node_path(node, Path(ctx.config.sync_directory))
+
+
+def _cache_payload(
+    ctx: SyncContext,
+    course_node: Node,
+    log: logging.Logger,
+) -> dict[str, Any] | None:
+    course_path = _node_path(ctx, course_node)
+    if course_path in ctx.course_cache_payloads:
+        return ctx.course_cache_payloads[course_path]
+
+    cache_path = course_path / COURSE_CACHE_FILENAME
+    payload = (
+        read_private_gzip_json(cache_path, "course cache")
+        if cache_path.exists()
+        else None
+    )
+    if not isinstance(payload, dict):
+        payload = None
+    elif payload.get("format") != COURSE_CACHE_FORMAT:
+        log.warning("Ignoring unsupported course cache format: %s", cache_path)
+        payload = None
+    ctx.course_cache_payloads[course_path] = payload
+    return payload
+
+
+def _h5p_content_cache(
+    ctx: SyncContext,
+    course_node: Node,
+    log: logging.Logger,
+) -> dict[int, tuple[str, str]]:
+    course_path = _node_path(ctx, course_node)
+    if course_path in ctx.h5p_content_caches:
+        return ctx.h5p_content_caches[course_path]
+
+    cache: dict[int, tuple[str, str]] = {}
+    payload = _cache_payload(ctx, course_node, log)
+    cached_items = payload.get(H5P_CONTENT_CACHE_KEY) if payload else None
+    if isinstance(cached_items, dict):
+        for raw_module_id, raw_entry in cached_items.items():
+            try:
+                module_id = int(raw_module_id)
+            except (TypeError, ValueError):
+                continue
+            if not isinstance(raw_entry, dict):
+                continue
+            marker = raw_entry.get("marker")
+            content = raw_entry.get("content")
+            if module_id >= 0 and isinstance(marker, str) and isinstance(content, str):
+                cache[module_id] = (marker, content)
+    ctx.h5p_content_caches[course_path] = cache
+    return cache
+
+
+def get_h5p_content(
+    ctx: SyncContext,
+    course_node: Node,
+    module_id: int,
+    marker: str,
+    log: logging.Logger = logger,
+) -> str | None:
+    """Return cached extracted H5P content when its package is unchanged."""
+    cached = _h5p_content_cache(ctx, course_node, log).get(module_id)
+    return cached[1] if cached is not None and cached[0] == marker else None
+
+
+def store_h5p_content(
+    ctx: SyncContext,
+    course_node: Node,
+    module_id: int,
+    marker: str,
+    content: str,
+    log: logging.Logger = logger,
+) -> None:
+    """Retain extracted H5P content for the next per-course cache write."""
+    _h5p_content_cache(ctx, course_node, log)[module_id] = (marker, content)
 
 
 def match_old_cache_child(old_node: Node | None, child: Node) -> Node | None:
@@ -152,15 +229,8 @@ def get_course_cache_root(
     if course_path in ctx.course_caches:
         return ctx.course_caches[course_path]
 
-    cache_path = course_path / COURSE_CACHE_FILENAME
-    if not cache_path.exists():
-        return None
-
-    payload = read_private_gzip_json(cache_path, "course cache")
-    if not isinstance(payload, dict):
-        return None
-    if payload.get("format") != COURSE_CACHE_FORMAT:
-        log.warning("Ignoring unsupported course cache format: %s", cache_path)
+    payload = _cache_payload(ctx, course_node, log)
+    if payload is None:
         return None
     course_data = payload.get("course")
     if not isinstance(course_data, dict):
@@ -169,7 +239,10 @@ def get_course_cache_root(
     try:
         cached_course_root = node_from_cache_data(course_data)
     except (TypeError, ValueError):
-        log.warning("Ignoring malformed course cache: %s", cache_path)
+        log.warning(
+            "Ignoring malformed course cache: %s",
+            course_path / COURSE_CACHE_FILENAME,
+        )
         return None
 
     ctx.course_caches[course_path] = cached_course_root
@@ -235,10 +308,18 @@ def cache_root_node(
             old_course_root = get_course_cache_root(ctx, course_node, log)
             course_path.mkdir(parents=True, exist_ok=True)
             cache_path = course_path / COURSE_CACHE_FILENAME
+            payload: dict[str, Any] = {
+                "format": COURSE_CACHE_FORMAT,
+                "course": node_to_cache_data(ctx, course_node, old_course_root),
+            }
+            h5p_content = _h5p_content_cache(ctx, course_node, log)
+            if h5p_content:
+                payload[H5P_CONTENT_CACHE_KEY] = {
+                    str(module_id): {"marker": marker, "content": content}
+                    for module_id, (marker, content) in sorted(h5p_content.items())
+                }
             write_private_gzip_json(
                 cache_path,
-                {
-                    "format": COURSE_CACHE_FORMAT,
-                    "course": node_to_cache_data(ctx, course_node, old_course_root),
-                },
+                payload,
             )
+            ctx.course_cache_payloads[course_path] = payload

--- a/syncmymoodle/course_cache.py
+++ b/syncmymoodle/course_cache.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +17,34 @@ from syncmymoodle.storage import read_private_gzip_json, write_private_gzip_json
 logger = logging.getLogger(__name__)
 COURSE_CACHE_FORMAT = "syncmymoodle.course-cache.v1"
 H5P_CONTENT_CACHE_KEY = "h5p_content"
+MODULE_CACHE_KEY = "module_data"
+
+
+@dataclass(frozen=True)
+class PageContentCacheEntry:
+    marker: str
+    content: str
+    base_url: str
+
+
+@dataclass(frozen=True)
+class AssignmentCacheEntry:
+    since: int
+    files: list[dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class QuizCacheEntry:
+    since: int
+    attempts: list[dict[str, Any]]
+    reviews: dict[int, dict[str, Any]]
+
+
+@dataclass
+class CourseModuleCache:
+    pages: dict[int, PageContentCacheEntry] = field(default_factory=dict)
+    assignments: dict[int, AssignmentCacheEntry] = field(default_factory=dict)
+    quizzes: dict[int, QuizCacheEntry] = field(default_factory=dict)
 
 
 def _node_path(ctx: SyncContext, node: Node) -> Path:
@@ -96,6 +125,232 @@ def store_h5p_content(
 ) -> None:
     """Retain extracted H5P content for the next per-course cache write."""
     _h5p_content_cache(ctx, course_node, log)[module_id] = (marker, content)
+
+
+def _module_id(value: Any) -> int | None:
+    try:
+        module_id = int(value)
+    except (TypeError, ValueError):
+        return None
+    return module_id if module_id > 0 else None
+
+
+def _cache_since(value: Any) -> int | None:
+    return (
+        value
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0
+        else None
+    )
+
+
+def _dict_list(value: Any) -> list[dict[str, Any]] | None:
+    if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
+        return None
+    return [dict(item) for item in value]
+
+
+def _page_cache_entries(value: Any) -> dict[int, PageContentCacheEntry]:
+    entries: dict[int, PageContentCacheEntry] = {}
+    if not isinstance(value, dict):
+        return entries
+    for raw_module_id, raw_entry in value.items():
+        module_id = _module_id(raw_module_id)
+        if module_id is None or not isinstance(raw_entry, dict):
+            continue
+        marker = raw_entry.get("marker")
+        content = raw_entry.get("content")
+        base_url = raw_entry.get("url")
+        if (
+            isinstance(marker, str)
+            and marker
+            and isinstance(content, str)
+            and isinstance(base_url, str)
+            and base_url
+        ):
+            entries[module_id] = PageContentCacheEntry(marker, content, base_url)
+    return entries
+
+
+def _assignment_cache_entries(value: Any) -> dict[int, AssignmentCacheEntry]:
+    entries: dict[int, AssignmentCacheEntry] = {}
+    if not isinstance(value, dict):
+        return entries
+    for raw_module_id, raw_entry in value.items():
+        module_id = _module_id(raw_module_id)
+        if module_id is None or not isinstance(raw_entry, dict):
+            continue
+        since = _cache_since(raw_entry.get("since"))
+        files = _dict_list(raw_entry.get("files"))
+        if since is not None and files is not None:
+            entries[module_id] = AssignmentCacheEntry(since, files)
+    return entries
+
+
+def _quiz_reviews(value: Any) -> dict[int, dict[str, Any]] | None:
+    if not isinstance(value, dict):
+        return None
+    reviews: dict[int, dict[str, Any]] = {}
+    for raw_attempt_id, review in value.items():
+        attempt_id = _module_id(raw_attempt_id)
+        if attempt_id is None or not isinstance(review, dict):
+            return None
+        reviews[attempt_id] = dict(review)
+    return reviews
+
+
+def _quiz_cache_entries(value: Any) -> dict[int, QuizCacheEntry]:
+    entries: dict[int, QuizCacheEntry] = {}
+    if not isinstance(value, dict):
+        return entries
+    for raw_module_id, raw_entry in value.items():
+        module_id = _module_id(raw_module_id)
+        if module_id is None or not isinstance(raw_entry, dict):
+            continue
+        since = _cache_since(raw_entry.get("since"))
+        attempts = _dict_list(raw_entry.get("attempts"))
+        reviews = _quiz_reviews(raw_entry.get("reviews"))
+        if since is not None and attempts is not None and reviews is not None:
+            entries[module_id] = QuizCacheEntry(since, attempts, reviews)
+    return entries
+
+
+def _course_module_cache(
+    ctx: SyncContext,
+    course_node: Node,
+    log: logging.Logger,
+) -> CourseModuleCache:
+    course_path = _node_path(ctx, course_node)
+    if course_path in ctx.course_module_caches:
+        return ctx.course_module_caches[course_path]
+
+    payload = _cache_payload(ctx, course_node, log)
+    raw_cache = payload.get(MODULE_CACHE_KEY) if payload else None
+    cache = (
+        CourseModuleCache(
+            pages=_page_cache_entries(raw_cache.get("pages")),
+            assignments=_assignment_cache_entries(raw_cache.get("assignments")),
+            quizzes=_quiz_cache_entries(raw_cache.get("quizzes")),
+        )
+        if isinstance(raw_cache, dict)
+        else CourseModuleCache()
+    )
+
+    ctx.course_module_caches[course_path] = cache
+    return cache
+
+
+def get_page_content(
+    ctx: SyncContext,
+    course_node: Node,
+    module_id: int,
+    marker: str,
+    log: logging.Logger = logger,
+) -> PageContentCacheEntry | None:
+    entry = _course_module_cache(ctx, course_node, log).pages.get(module_id)
+    return entry if entry is not None and entry.marker == marker else None
+
+
+def store_page_content(
+    ctx: SyncContext,
+    course_node: Node,
+    module_id: int,
+    marker: str,
+    content: str,
+    base_url: str,
+    log: logging.Logger = logger,
+) -> None:
+    _course_module_cache(ctx, course_node, log).pages[module_id] = (
+        PageContentCacheEntry(marker, content, base_url)
+    )
+
+
+def get_assignment_cache_entry(
+    ctx: SyncContext,
+    course_node: Node,
+    module_id: int,
+    log: logging.Logger = logger,
+) -> AssignmentCacheEntry | None:
+    return _course_module_cache(ctx, course_node, log).assignments.get(module_id)
+
+
+def store_assignment_cache_entry(
+    ctx: SyncContext,
+    course_node: Node,
+    module_id: int,
+    files: list[dict[str, Any]],
+    log: logging.Logger = logger,
+) -> None:
+    if ctx.moodle_update_watermark is None:
+        return
+    _course_module_cache(ctx, course_node, log).assignments[module_id] = (
+        AssignmentCacheEntry(ctx.moodle_update_watermark, files)
+    )
+
+
+def discard_assignment_cache_entry(
+    ctx: SyncContext,
+    course_node: Node,
+    module_id: int,
+    log: logging.Logger = logger,
+) -> None:
+    _course_module_cache(ctx, course_node, log).assignments.pop(module_id, None)
+
+
+def get_quiz_cache_entry(
+    ctx: SyncContext,
+    course_node: Node,
+    module_id: int,
+    log: logging.Logger = logger,
+) -> QuizCacheEntry | None:
+    return _course_module_cache(ctx, course_node, log).quizzes.get(module_id)
+
+
+def store_quiz_cache_entry(
+    ctx: SyncContext,
+    course_node: Node,
+    module_id: int,
+    attempts: list[dict[str, Any]],
+    reviews: dict[int, dict[str, Any]],
+    log: logging.Logger = logger,
+) -> None:
+    if ctx.moodle_update_watermark is None:
+        return
+    _course_module_cache(ctx, course_node, log).quizzes[module_id] = QuizCacheEntry(
+        ctx.moodle_update_watermark,
+        attempts,
+        reviews,
+    )
+
+
+def _course_module_cache_data(cache: CourseModuleCache) -> dict[str, Any]:
+    data: dict[str, Any] = {}
+    if cache.pages:
+        data["pages"] = {
+            str(module_id): {
+                "marker": entry.marker,
+                "content": entry.content,
+                "url": entry.base_url,
+            }
+            for module_id, entry in sorted(cache.pages.items())
+        }
+    if cache.assignments:
+        data["assignments"] = {
+            str(module_id): {"since": entry.since, "files": entry.files}
+            for module_id, entry in sorted(cache.assignments.items())
+        }
+    if cache.quizzes:
+        data["quizzes"] = {
+            str(module_id): {
+                "since": entry.since,
+                "attempts": entry.attempts,
+                "reviews": {
+                    str(attempt_id): review
+                    for attempt_id, review in sorted(entry.reviews.items())
+                },
+            }
+            for module_id, entry in sorted(cache.quizzes.items())
+        }
+    return data
 
 
 def match_old_cache_child(old_node: Node | None, child: Node) -> Node | None:
@@ -318,6 +573,11 @@ def cache_root_node(
                     str(module_id): {"marker": marker, "content": content}
                     for module_id, (marker, content) in sorted(h5p_content.items())
                 }
+            module_cache = _course_module_cache_data(
+                _course_module_cache(ctx, course_node, log)
+            )
+            if module_cache:
+                payload[MODULE_CACHE_KEY] = module_cache
             write_private_gzip_json(
                 cache_path,
                 payload,

--- a/syncmymoodle/course_cache.py
+++ b/syncmymoodle/course_cache.py
@@ -16,15 +16,18 @@ from syncmymoodle.storage import read_private_gzip_json, write_private_gzip_json
 
 logger = logging.getLogger(__name__)
 COURSE_CACHE_FORMAT = "syncmymoodle.course-cache.v1"
-H5P_CONTENT_CACHE_KEY = "h5p_content"
 MODULE_CACHE_KEY = "module_data"
+CACHED_TEXT_CACHE_KEY = "cached_text"
+H5P_CONTENT_KIND = "h5p"
+PAGE_CONTENT_KIND = "page"
+CACHED_TEXT_KINDS = (H5P_CONTENT_KIND, PAGE_CONTENT_KIND)
 
 
 @dataclass(frozen=True)
-class PageContentCacheEntry:
+class CachedTextEntry:
     marker: str
     content: str
-    base_url: str
+    base_url: str | None = None
 
 
 @dataclass(frozen=True)
@@ -38,93 +41,22 @@ class QuizCacheEntry:
     since: int
     attempts: list[dict[str, Any]]
     reviews: dict[int, dict[str, Any]]
+    timeclose: int
+    refresh_after: int | None
 
 
 @dataclass
-class CourseModuleCache:
-    pages: dict[int, PageContentCacheEntry] = field(default_factory=dict)
+class CourseCacheState:
+    course_root: Node | None = None
+    cached_text: dict[str, dict[int, CachedTextEntry]] = field(
+        default_factory=lambda: {kind: {} for kind in CACHED_TEXT_KINDS}
+    )
     assignments: dict[int, AssignmentCacheEntry] = field(default_factory=dict)
     quizzes: dict[int, QuizCacheEntry] = field(default_factory=dict)
 
 
 def _node_path(ctx: SyncContext, node: Node) -> Path:
     return get_sanitized_node_path(node, Path(ctx.config.sync_directory))
-
-
-def _cache_payload(
-    ctx: SyncContext,
-    course_node: Node,
-    log: logging.Logger,
-) -> dict[str, Any] | None:
-    course_path = _node_path(ctx, course_node)
-    if course_path in ctx.course_cache_payloads:
-        return ctx.course_cache_payloads[course_path]
-
-    cache_path = course_path / COURSE_CACHE_FILENAME
-    payload = (
-        read_private_gzip_json(cache_path, "course cache")
-        if cache_path.exists()
-        else None
-    )
-    if not isinstance(payload, dict):
-        payload = None
-    elif payload.get("format") != COURSE_CACHE_FORMAT:
-        log.warning("Ignoring unsupported course cache format: %s", cache_path)
-        payload = None
-    ctx.course_cache_payloads[course_path] = payload
-    return payload
-
-
-def _h5p_content_cache(
-    ctx: SyncContext,
-    course_node: Node,
-    log: logging.Logger,
-) -> dict[int, tuple[str, str]]:
-    course_path = _node_path(ctx, course_node)
-    if course_path in ctx.h5p_content_caches:
-        return ctx.h5p_content_caches[course_path]
-
-    cache: dict[int, tuple[str, str]] = {}
-    payload = _cache_payload(ctx, course_node, log)
-    cached_items = payload.get(H5P_CONTENT_CACHE_KEY) if payload else None
-    if isinstance(cached_items, dict):
-        for raw_module_id, raw_entry in cached_items.items():
-            try:
-                module_id = int(raw_module_id)
-            except (TypeError, ValueError):
-                continue
-            if not isinstance(raw_entry, dict):
-                continue
-            marker = raw_entry.get("marker")
-            content = raw_entry.get("content")
-            if module_id >= 0 and isinstance(marker, str) and isinstance(content, str):
-                cache[module_id] = (marker, content)
-    ctx.h5p_content_caches[course_path] = cache
-    return cache
-
-
-def get_h5p_content(
-    ctx: SyncContext,
-    course_node: Node,
-    module_id: int,
-    marker: str,
-    log: logging.Logger = logger,
-) -> str | None:
-    """Return cached extracted H5P content when its package is unchanged."""
-    cached = _h5p_content_cache(ctx, course_node, log).get(module_id)
-    return cached[1] if cached is not None and cached[0] == marker else None
-
-
-def store_h5p_content(
-    ctx: SyncContext,
-    course_node: Node,
-    module_id: int,
-    marker: str,
-    content: str,
-    log: logging.Logger = logger,
-) -> None:
-    """Retain extracted H5P content for the next per-course cache write."""
-    _h5p_content_cache(ctx, course_node, log)[module_id] = (marker, content)
 
 
 def _module_id(value: Any) -> int | None:
@@ -149,8 +81,11 @@ def _dict_list(value: Any) -> list[dict[str, Any]] | None:
     return [dict(item) for item in value]
 
 
-def _page_cache_entries(value: Any) -> dict[int, PageContentCacheEntry]:
-    entries: dict[int, PageContentCacheEntry] = {}
+def _cached_text_entries(
+    value: Any,
+    kind: str,
+) -> dict[int, CachedTextEntry]:
+    entries: dict[int, CachedTextEntry] = {}
     if not isinstance(value, dict):
         return entries
     for raw_module_id, raw_entry in value.items():
@@ -160,14 +95,18 @@ def _page_cache_entries(value: Any) -> dict[int, PageContentCacheEntry]:
         marker = raw_entry.get("marker")
         content = raw_entry.get("content")
         base_url = raw_entry.get("url")
+        base_url_valid = isinstance(base_url, str) and bool(base_url)
         if (
             isinstance(marker, str)
             and marker
             and isinstance(content, str)
-            and isinstance(base_url, str)
-            and base_url
+            and (kind != PAGE_CONTENT_KIND or base_url_valid)
         ):
-            entries[module_id] = PageContentCacheEntry(marker, content, base_url)
+            entries[module_id] = CachedTextEntry(
+                marker,
+                content,
+                base_url if base_url_valid else None,
+            )
     return entries
 
 
@@ -209,58 +148,117 @@ def _quiz_cache_entries(value: Any) -> dict[int, QuizCacheEntry]:
         since = _cache_since(raw_entry.get("since"))
         attempts = _dict_list(raw_entry.get("attempts"))
         reviews = _quiz_reviews(raw_entry.get("reviews"))
-        if since is not None and attempts is not None and reviews is not None:
-            entries[module_id] = QuizCacheEntry(since, attempts, reviews)
+        timeclose = _cache_since(raw_entry.get("timeclose"))
+        if "refresh_after" not in raw_entry:
+            continue
+        refresh_after = raw_entry.get("refresh_after")
+        if refresh_after is not None:
+            refresh_after = _cache_since(refresh_after)
+            if refresh_after is None:
+                continue
+        if (
+            since is not None
+            and attempts is not None
+            and reviews is not None
+            and timeclose is not None
+        ):
+            entries[module_id] = QuizCacheEntry(
+                since,
+                attempts,
+                reviews,
+                timeclose,
+                refresh_after,
+            )
     return entries
 
 
-def _course_module_cache(
+def _course_cache_state(
     ctx: SyncContext,
     course_node: Node,
     log: logging.Logger,
-) -> CourseModuleCache:
+) -> CourseCacheState:
+    if course_node in ctx.course_cache_states:
+        return ctx.course_cache_states[course_node]
+
     course_path = _node_path(ctx, course_node)
-    if course_path in ctx.course_module_caches:
-        return ctx.course_module_caches[course_path]
-
-    payload = _cache_payload(ctx, course_node, log)
-    raw_cache = payload.get(MODULE_CACHE_KEY) if payload else None
-    cache = (
-        CourseModuleCache(
-            pages=_page_cache_entries(raw_cache.get("pages")),
-            assignments=_assignment_cache_entries(raw_cache.get("assignments")),
-            quizzes=_quiz_cache_entries(raw_cache.get("quizzes")),
-        )
-        if isinstance(raw_cache, dict)
-        else CourseModuleCache()
+    cache_path = course_path / COURSE_CACHE_FILENAME
+    payload = (
+        read_private_gzip_json(cache_path, "course cache")
+        if cache_path.exists()
+        else None
     )
+    if not isinstance(payload, dict):
+        payload = None
+    elif payload.get("format") != COURSE_CACHE_FORMAT:
+        log.warning("Ignoring unsupported course cache format: %s", cache_path)
+        payload = None
 
-    ctx.course_module_caches[course_path] = cache
-    return cache
+    course_root = None
+    course_data = payload.get("course") if payload else None
+    if isinstance(course_data, dict):
+        try:
+            course_root = node_from_cache_data(course_data)
+        except (TypeError, ValueError):
+            log.warning("Ignoring malformed course cache: %s", cache_path)
+
+    raw_cache = payload.get(MODULE_CACHE_KEY) if payload else None
+    raw_cache = raw_cache if isinstance(raw_cache, dict) else {}
+    raw_cached_text = raw_cache.get(CACHED_TEXT_CACHE_KEY)
+    raw_cached_text = raw_cached_text if isinstance(raw_cached_text, dict) else {}
+    current_user_id = (
+        ctx.moodle_account.user_id if ctx.moodle_account is not None else None
+    )
+    personal_cache_matches = (
+        current_user_id is not None
+        and raw_cache.get("owner_user_id") == current_user_id
+    )
+    state = CourseCacheState(
+        course_root=course_root,
+        cached_text={
+            kind: _cached_text_entries(raw_cached_text.get(kind), kind)
+            for kind in CACHED_TEXT_KINDS
+        },
+        assignments=(
+            _assignment_cache_entries(raw_cache.get("assignments"))
+            if personal_cache_matches
+            else {}
+        ),
+        quizzes=(
+            _quiz_cache_entries(raw_cache.get("quizzes"))
+            if personal_cache_matches
+            else {}
+        ),
+    )
+    ctx.course_cache_states[course_node] = state
+    return state
 
 
-def get_page_content(
+def get_cached_text(
     ctx: SyncContext,
     course_node: Node,
+    kind: str,
     module_id: int,
     marker: str,
     log: logging.Logger = logger,
-) -> PageContentCacheEntry | None:
-    entry = _course_module_cache(ctx, course_node, log).pages.get(module_id)
+) -> CachedTextEntry | None:
+    entry = _course_cache_state(ctx, course_node, log).cached_text[kind].get(module_id)
     return entry if entry is not None and entry.marker == marker else None
 
 
-def store_page_content(
+def store_cached_text(
     ctx: SyncContext,
     course_node: Node,
+    kind: str,
     module_id: int,
     marker: str,
     content: str,
-    base_url: str,
+    base_url: str | None = None,
     log: logging.Logger = logger,
 ) -> None:
-    _course_module_cache(ctx, course_node, log).pages[module_id] = (
-        PageContentCacheEntry(marker, content, base_url)
+    if kind == PAGE_CONTENT_KIND and not base_url:
+        raise ValueError("cached page content requires its base URL")
+    _course_cache_state(ctx, course_node, log).cached_text[kind][module_id] = (
+        CachedTextEntry(marker, content, base_url)
     )
 
 
@@ -270,7 +268,7 @@ def get_assignment_cache_entry(
     module_id: int,
     log: logging.Logger = logger,
 ) -> AssignmentCacheEntry | None:
-    return _course_module_cache(ctx, course_node, log).assignments.get(module_id)
+    return _course_cache_state(ctx, course_node, log).assignments.get(module_id)
 
 
 def store_assignment_cache_entry(
@@ -280,10 +278,11 @@ def store_assignment_cache_entry(
     files: list[dict[str, Any]],
     log: logging.Logger = logger,
 ) -> None:
-    if ctx.moodle_update_watermark is None:
+    since = ctx.moodle_update_watermark
+    if since is None:
         return
-    _course_module_cache(ctx, course_node, log).assignments[module_id] = (
-        AssignmentCacheEntry(ctx.moodle_update_watermark, files)
+    _course_cache_state(ctx, course_node, log).assignments[module_id] = (
+        AssignmentCacheEntry(since, files)
     )
 
 
@@ -293,7 +292,7 @@ def discard_assignment_cache_entry(
     module_id: int,
     log: logging.Logger = logger,
 ) -> None:
-    _course_module_cache(ctx, course_node, log).assignments.pop(module_id, None)
+    _course_cache_state(ctx, course_node, log).assignments.pop(module_id, None)
 
 
 def get_quiz_cache_entry(
@@ -302,7 +301,7 @@ def get_quiz_cache_entry(
     module_id: int,
     log: logging.Logger = logger,
 ) -> QuizCacheEntry | None:
-    return _course_module_cache(ctx, course_node, log).quizzes.get(module_id)
+    return _course_cache_state(ctx, course_node, log).quizzes.get(module_id)
 
 
 def store_quiz_cache_entry(
@@ -311,44 +310,110 @@ def store_quiz_cache_entry(
     module_id: int,
     attempts: list[dict[str, Any]],
     reviews: dict[int, dict[str, Any]],
+    timeclose: int,
+    refresh_after: int | None,
     log: logging.Logger = logger,
 ) -> None:
-    if ctx.moodle_update_watermark is None:
+    since = ctx.moodle_update_watermark
+    if since is None:
         return
-    _course_module_cache(ctx, course_node, log).quizzes[module_id] = QuizCacheEntry(
-        ctx.moodle_update_watermark,
+    _course_cache_state(ctx, course_node, log).quizzes[module_id] = QuizCacheEntry(
+        since,
         attempts,
         reviews,
+        timeclose,
+        refresh_after,
     )
 
 
-def _course_module_cache_data(cache: CourseModuleCache) -> dict[str, Any]:
-    data: dict[str, Any] = {}
-    if cache.pages:
-        data["pages"] = {
-            str(module_id): {
-                "marker": entry.marker,
-                "content": entry.content,
-                "url": entry.base_url,
-            }
-            for module_id, entry in sorted(cache.pages.items())
+def discard_quiz_cache_entry(
+    ctx: SyncContext,
+    course_node: Node,
+    module_id: int,
+    log: logging.Logger = logger,
+) -> None:
+    _course_cache_state(ctx, course_node, log).quizzes.pop(module_id, None)
+
+
+def retain_current_modules(
+    ctx: SyncContext,
+    course_node: Node,
+    modules: list[dict[str, Any]],
+    log: logging.Logger = logger,
+) -> None:
+    """Discard cached data for modules no longer present in the course."""
+    module_ids: dict[str, set[int]] = {
+        "h5pactivity": set(),
+        "page": set(),
+        "assign": set(),
+        "quiz": set(),
+    }
+    for module in modules:
+        module_id = _module_id(module.get("id"))
+        modname = module.get("modname")
+        if module_id is not None and modname in module_ids:
+            module_ids[modname].add(module_id)
+
+    state = _course_cache_state(ctx, course_node, log)
+    caches = (
+        (state.cached_text[H5P_CONTENT_KIND], module_ids["h5pactivity"]),
+        (state.cached_text[PAGE_CONTENT_KIND], module_ids["page"]),
+        (state.assignments, module_ids["assign"]),
+        (state.quizzes, module_ids["quiz"]),
+    )
+    for cache, current_ids in caches:
+        for module_id in cache.keys() - current_ids:
+            del cache[module_id]
+
+
+def _cached_text_data(
+    entries: dict[int, CachedTextEntry],
+    kind: str,
+) -> dict[str, Any]:
+    return {
+        str(module_id): {
+            "marker": entry.marker,
+            "content": entry.content,
+            **({"url": entry.base_url} if kind == PAGE_CONTENT_KIND else {}),
         }
-    if cache.assignments:
+        for module_id, entry in sorted(entries.items())
+    }
+
+
+def _course_module_cache_data(
+    ctx: SyncContext,
+    state: CourseCacheState,
+) -> dict[str, Any]:
+    data: dict[str, Any] = {}
+    cached_text = {
+        kind: _cached_text_data(state.cached_text[kind], kind)
+        for kind in CACHED_TEXT_KINDS
+        if state.cached_text[kind]
+    }
+    if cached_text:
+        data[CACHED_TEXT_CACHE_KEY] = cached_text
+    if state.assignments or state.quizzes:
+        if ctx.moodle_account is None:
+            return data
+        data["owner_user_id"] = ctx.moodle_account.user_id
+    if state.assignments:
         data["assignments"] = {
             str(module_id): {"since": entry.since, "files": entry.files}
-            for module_id, entry in sorted(cache.assignments.items())
+            for module_id, entry in sorted(state.assignments.items())
         }
-    if cache.quizzes:
+    if state.quizzes:
         data["quizzes"] = {
             str(module_id): {
                 "since": entry.since,
                 "attempts": entry.attempts,
+                "timeclose": entry.timeclose,
+                "refresh_after": entry.refresh_after,
                 "reviews": {
                     str(attempt_id): review
                     for attempt_id, review in sorted(entry.reviews.items())
                 },
             }
-            for module_id, entry in sorted(cache.quizzes.items())
+            for module_id, entry in sorted(state.quizzes.items())
         }
     return data
 
@@ -480,28 +545,7 @@ def get_course_cache_root(
     log: logging.Logger = logger,
 ) -> Node | None:
     """Load and return the cached course root for the given course node."""
-    course_path = _node_path(ctx, course_node)
-    if course_path in ctx.course_caches:
-        return ctx.course_caches[course_path]
-
-    payload = _cache_payload(ctx, course_node, log)
-    if payload is None:
-        return None
-    course_data = payload.get("course")
-    if not isinstance(course_data, dict):
-        return None
-
-    try:
-        cached_course_root = node_from_cache_data(course_data)
-    except (TypeError, ValueError):
-        log.warning(
-            "Ignoring malformed course cache: %s",
-            course_path / COURSE_CACHE_FILENAME,
-        )
-        return None
-
-    ctx.course_caches[course_path] = cached_course_root
-    return cached_course_root
+    return _course_cache_state(ctx, course_node, log).course_root
 
 
 def get_old_node_for(
@@ -557,29 +601,15 @@ def cache_root_node(
             if course_node.type != "Course":
                 continue
             course_path = _node_path(ctx, course_node)
-            # Read the previous course cache before overwriting it, so we can
-            # preserve version markers for files that were not downloaded
-            # this run (see node_to_cache_data).
-            old_course_root = get_course_cache_root(ctx, course_node, log)
+            state = _course_cache_state(ctx, course_node, log)
             course_path.mkdir(parents=True, exist_ok=True)
             cache_path = course_path / COURSE_CACHE_FILENAME
             payload: dict[str, Any] = {
                 "format": COURSE_CACHE_FORMAT,
-                "course": node_to_cache_data(ctx, course_node, old_course_root),
+                "course": node_to_cache_data(ctx, course_node, state.course_root),
             }
-            h5p_content = _h5p_content_cache(ctx, course_node, log)
-            if h5p_content:
-                payload[H5P_CONTENT_CACHE_KEY] = {
-                    str(module_id): {"marker": marker, "content": content}
-                    for module_id, (marker, content) in sorted(h5p_content.items())
-                }
-            module_cache = _course_module_cache_data(
-                _course_module_cache(ctx, course_node, log)
-            )
+            module_cache = _course_module_cache_data(ctx, state)
             if module_cache:
                 payload[MODULE_CACHE_KEY] = module_cache
-            write_private_gzip_json(
-                cache_path,
-                payload,
-            )
-            ctx.course_cache_payloads[course_path] = payload
+            write_private_gzip_json(cache_path, payload)
+            state.course_root = node_from_cache_data(payload["course"])

--- a/syncmymoodle/moodle.py
+++ b/syncmymoodle/moodle.py
@@ -35,7 +35,6 @@ MOODLE_MANAGE_TOKEN_URL = f"{MOODLE_URL}user/managetoken.php"
 MOBILE_URL_SCHEME = "syncmymoodle"
 MOODLE_MOBILE_USER_AGENT = "MoodleMobile syncMyMoodle"
 MOODLE_UPDATE_FUNCTION = "core_course_get_updates_since"
-MOODLE_UPDATE_OVERLAP_SECONDS = 5
 
 
 class MobileLaunchError(RuntimeError):
@@ -555,8 +554,10 @@ def _changed_module_ids(instances: Any) -> frozenset[int] | None:
             for update in updates
         ):
             return None
-        if updates:
-            changed.add(module_id)
+        # A returned module instance is itself evidence that Moodle cannot
+        # confirm it unchanged. Some deployments return an empty update list,
+        # so treating that as unchanged would fail open.
+        changed.add(module_id)
     return frozenset(changed)
 
 

--- a/syncmymoodle/moodle.py
+++ b/syncmymoodle/moodle.py
@@ -7,6 +7,7 @@ import secrets
 import sys
 import urllib.parse
 from dataclasses import dataclass
+from email.utils import parsedate_to_datetime
 from enum import Enum
 from typing import Any
 
@@ -33,6 +34,8 @@ MOODLE_MOBILE_LAUNCH_URL = f"{MOODLE_URL}admin/tool/mobile/launch.php"
 MOODLE_MANAGE_TOKEN_URL = f"{MOODLE_URL}user/managetoken.php"
 MOBILE_URL_SCHEME = "syncmymoodle"
 MOODLE_MOBILE_USER_AGENT = "MoodleMobile syncMyMoodle"
+MOODLE_UPDATE_FUNCTION = "core_course_get_updates_since"
+MOODLE_UPDATE_OVERLAP_SECONDS = 5
 
 
 class MobileLaunchError(RuntimeError):
@@ -80,9 +83,14 @@ class MoodleTokenAuth(AuthBase):
                 return request
         else:
             return request
-        query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
-        if not any(key in {"token", "wstoken"} for key, _ in query):
-            query.append(("token", token))
+        query = [
+            (key, value)
+            for key, value in urllib.parse.parse_qsl(
+                parsed.query, keep_blank_values=True
+            )
+            if key.lower() not in {"token", "wstoken"}
+        ]
+        query.append(("token", token))
         request.url = urllib.parse.urlunsplit(
             (
                 parsed.scheme,
@@ -104,6 +112,22 @@ def create_token_session(
     return session
 
 
+def _http_date_timestamp(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = parsedate_to_datetime(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if parsed.tzinfo is None:
+        return None
+    try:
+        timestamp = int(parsed.timestamp())
+    except (OSError, OverflowError, ValueError):
+        return None
+    return timestamp if timestamp >= 0 else None
+
+
 class TokenValidationKind(Enum):
     VALID = "valid"
     INVALID = "invalid"
@@ -115,6 +139,23 @@ class TokenValidation:
     kind: TokenValidationKind
     detail: str | None = None
     site_info: dict[str, Any] | None = None
+    server_time: int | None = None
+
+
+@dataclass(frozen=True)
+class CourseUpdates:
+    """A conservative view of Moodle's per-module update feed."""
+
+    since: int
+    changed_module_ids: frozenset[int]
+    unknown_module_ids: frozenset[int]
+
+    def confirms_unchanged(self, module_id: int, cached_since: int) -> bool:
+        return (
+            cached_since >= self.since
+            and module_id not in self.changed_module_ids
+            and module_id not in self.unknown_module_ids
+        )
 
 
 def mobile_site_signature(passport: str, site: str = MOODLE_URL) -> str:
@@ -298,12 +339,18 @@ def validate_mobile_tokens(
             TokenValidationKind.UNKNOWN,
             f"Moodle token validation returned HTTP {response.status_code}",
         )
-    return validate_mobile_token_payload(payload, tokens)
+    return validate_mobile_token_payload(
+        payload,
+        tokens,
+        server_time=_http_date_timestamp(response.headers.get("Date")),
+    )
 
 
 def validate_mobile_token_payload(
     payload: Any,
     tokens: MoodleTokens,
+    *,
+    server_time: int | None = None,
 ) -> TokenValidation:
     if not isinstance(payload, dict):
         return TokenValidation(TokenValidationKind.UNKNOWN, "unexpected response shape")
@@ -340,7 +387,11 @@ def validate_mobile_token_payload(
             TokenValidationKind.INVALID,
             "token belongs to another Moodle account",
         )
-    return TokenValidation(TokenValidationKind.VALID, site_info=payload)
+    return TokenValidation(
+        TokenValidationKind.VALID,
+        site_info=payload,
+        server_time=server_time,
+    )
 
 
 def _open_moodle_autologin(
@@ -450,6 +501,8 @@ def call_webservice(
     function: str,
     data: dict[str, Any],
     log: logging.Logger = logger,
+    *,
+    warn_on_failure: bool = True,
 ) -> Any:
     request_data = {"wstoken": wstoken, "wsfunction": function, **data}
     try:
@@ -461,17 +514,89 @@ def call_webservice(
         )
         payload = response.json()
     except (requests.RequestException, ValueError) as error:
-        log.warning(
-            "Moodle web service %s failed: %s",
-            function,
-            safe_error_message(error),
-        )
+        if warn_on_failure:
+            log.warning(
+                "Moodle web service %s failed: %s",
+                function,
+                safe_error_message(error),
+            )
         return None
     api_error = api_error_message(payload)
     if api_error is not None:
-        log.warning("Moodle web service %s failed: %s", function, api_error)
+        if warn_on_failure:
+            log.warning("Moodle web service %s failed: %s", function, api_error)
         return None
     return payload
+
+
+def _positive_id(value: Any) -> int | None:
+    return (
+        value
+        if isinstance(value, int) and not isinstance(value, bool) and value > 0
+        else None
+    )
+
+
+def _changed_module_ids(instances: Any) -> frozenset[int] | None:
+    if not isinstance(instances, list):
+        return None
+    changed: set[int] = set()
+    for instance in instances:
+        if not isinstance(instance, dict) or instance.get("contextlevel") != "module":
+            return None
+        module_id = _positive_id(instance.get("id"))
+        updates = instance.get("updates")
+        if module_id is None or not isinstance(updates, list):
+            return None
+        if any(
+            not isinstance(update, dict)
+            or not isinstance(update.get("name"), str)
+            or not update["name"]
+            for update in updates
+        ):
+            return None
+        if updates:
+            changed.add(module_id)
+    return frozenset(changed)
+
+
+def _unknown_module_ids(warnings: Any) -> frozenset[int] | None:
+    if not isinstance(warnings, list):
+        return None
+    unknown: set[int] = set()
+    for warning in warnings:
+        if not isinstance(warning, dict) or warning.get("item") != "module":
+            return None
+        module_id = _positive_id(warning.get("itemid"))
+        if module_id is None:
+            return None
+        unknown.add(module_id)
+    return frozenset(unknown)
+
+
+def get_course_updates_since(
+    session: requests.Session,
+    wstoken: str,
+    course_id: int,
+    since: int,
+    log: logging.Logger = logger,
+) -> CourseUpdates | None:
+    """Return trustworthy module changes, or ``None`` when Moodle cannot tell."""
+    payload = call_webservice(
+        session,
+        wstoken,
+        MOODLE_UPDATE_FUNCTION,
+        {"courseid": course_id, "since": since},
+        log,
+        warn_on_failure=False,
+    )
+    if not isinstance(payload, dict):
+        return None
+    changed = _changed_module_ids(payload.get("instances"))
+    unknown = _unknown_module_ids(payload.get("warnings"))
+    if changed is None or unknown is None:
+        return None
+    return CourseUpdates(since, changed, unknown)
 
 
 def get_ltis_by_course(
@@ -524,15 +649,16 @@ def get_quizzes_by_course(
 
 def get_quiz_attempts(
     session: requests.Session, wstoken: str, quiz_id: int
-) -> list[dict[str, Any]]:
+) -> list[dict[str, Any]] | None:
     payload = call_webservice(
         session,
         wstoken,
         "mod_quiz_get_user_attempts",
         {"quizid": quiz_id, "status": "finished", "includepreviews": 0},
     )
-    attempts = payload.get("attempts") if isinstance(payload, dict) else None
-    return [item for item in attempts or [] if isinstance(item, dict)]
+    if not isinstance(payload, dict) or not isinstance(payload.get("attempts"), list):
+        return None
+    return [item for item in payload["attempts"] if isinstance(item, dict)]
 
 
 def get_quiz_attempt_review(
@@ -776,7 +902,7 @@ def get_assignment_submission_files(
     user_id: Any,
     assignment_id: Any,
     log: logging.Logger = logger,
-) -> list[Any]:
+) -> list[Any] | None:
     payload = call_webservice(
         session,
         wstoken,
@@ -790,7 +916,7 @@ def get_assignment_submission_files(
         log,
     )
     if not isinstance(payload, dict):
-        return []
+        return None
     # Per-assignment errors (e.g. no permission to view the submission) keep
     # their historical behavior of contributing no files. The "or {}" also
     # guards against JSON null values, which .get(key, {}) does not.

--- a/syncmymoodle/sync.py
+++ b/syncmymoodle/sync.py
@@ -12,6 +12,29 @@ logger = logging.getLogger(__name__)
 SLOW_MODULE_SECONDS = 1.0
 
 
+def _has_complete_module_inventory(course_sections: list[object]) -> bool:
+    for section in course_sections:
+        if not isinstance(section, dict):
+            return False
+        modules = section.get("modules")
+        if not isinstance(modules, list):
+            return False
+        for module in modules:
+            if not isinstance(module, dict):
+                return False
+            module_id = module.get("id")
+            module_kind = module.get("modname")
+            if (
+                not isinstance(module_id, int)
+                or isinstance(module_id, bool)
+                or module_id <= 0
+                or not isinstance(module_kind, str)
+                or not module_kind
+            ):
+                return False
+    return True
+
+
 def sync(ctx: SyncContext) -> None:  # noqa: C901 - legacy sync awaiting decomposition
     """Retrieve the file tree for all courses into ``ctx.root_node``."""
     config = ctx.config
@@ -103,17 +126,40 @@ def sync(ctx: SyncContext) -> None:  # noqa: C901 - legacy sync awaiting decompo
                 continue
         courses_to_sync.append((course_name, course_id, semestername))
 
+    semester_nodes: dict[str, Node] = {}
+    prepared_courses: list[tuple[str, int, Node]] = []
+    for course_name, course_id, semestername in courses_to_sync:
+        semester_node = semester_nodes.get(semestername)
+        if semester_node is None:
+            semester_node = cast(
+                Node, root_node.add_child(semestername, None, "Semester")
+            )
+            semester_nodes[semestername] = semester_node
+        course_node = cast(
+            Node, semester_node.add_child(course_name, course_id, "Course")
+        )
+        prepared_courses.append((course_name, int(course_id), course_node))
+
+    # Course paths are cache keys on disk. Resolve all course collisions before
+    # any cache is read or updated so their paths cannot change mid-run.
+    root_node.remove_children_nameclashes()
+
     progress = ctx.output.sync_progress
-    progress.begin_courses(len(courses_to_sync))
+    progress.begin_courses(len(prepared_courses))
     # Syncing all courses that passed the local course filters.
-    for course_index, (course_name, course_id, semestername) in enumerate(
-        courses_to_sync, start=1
+    for course_index, (course_name, course_id, course_node) in enumerate(
+        prepared_courses, start=1
     ):
         ctx.stats.courses += 1
         progress.start_course(course_index, course_name)
         course_sections = moodle_api.get_course(session, wstoken, course_id)
         if course_sections is None:
             ctx.stats.failed += 1
+            semester_node = course_node.parent
+            if semester_node is not None:
+                semester_node.children.remove(course_node)
+                if not semester_node.children:
+                    root_node.children.remove(semester_node)
             progress.finish_course(course_index)
             continue
 
@@ -132,18 +178,6 @@ def sync(ctx: SyncContext) -> None:  # noqa: C901 - legacy sync awaiting decompo
             modules=module_total,
         )
 
-        semester_nodes = [s for s in root_node.children if s.name == semestername]
-        if len(semester_nodes) == 0:
-            semester_node = cast(
-                Node, root_node.add_child(semestername, None, "Semester")
-            )
-        else:
-            semester_node = semester_nodes[0]
-
-        course_node = cast(
-            Node, semester_node.add_child(course_name, course_id, "Course")
-        )
-
         course_modules = [
             module
             for section in course_sections
@@ -151,6 +185,10 @@ def sync(ctx: SyncContext) -> None:  # noqa: C901 - legacy sync awaiting decompo
             for module in section.get("modules", [])
             if isinstance(module, dict)
         ]
+        if _has_complete_module_inventory(course_sections):
+            course_cache.retain_current_modules(
+                ctx, course_node, course_modules, logger
+            )
         module_names = {module.get("modname") for module in course_modules}
 
         cached_update_times: list[int] = []

--- a/syncmymoodle/sync.py
+++ b/syncmymoodle/sync.py
@@ -2,7 +2,7 @@ import logging
 import time
 from typing import cast
 
-from syncmymoodle import filters, sync_handlers
+from syncmymoodle import course_cache, filters, sync_handlers
 from syncmymoodle import moodle as moodle_api
 from syncmymoodle.context import SyncContext
 from syncmymoodle.http_utils import redact_url_secrets
@@ -144,12 +144,54 @@ def sync(ctx: SyncContext) -> None:  # noqa: C901 - legacy sync awaiting decompo
             Node, semester_node.add_child(course_name, course_id, "Course")
         )
 
-        module_names = {
-            module.get("modname")
+        course_modules = [
+            module
             for section in course_sections
             if isinstance(section, dict)
             for module in section.get("modules", [])
-        }
+            if isinstance(module, dict)
+        ]
+        module_names = {module.get("modname") for module in course_modules}
+
+        cached_update_times: list[int] = []
+        for module in course_modules:
+            module_id = module.get("id")
+            if not isinstance(module_id, int) or isinstance(module_id, bool):
+                continue
+            if config.module_assignment and module.get("modname") == "assign":
+                assignment_entry = course_cache.get_assignment_cache_entry(
+                    ctx, course_node, module_id, logger
+                )
+                if assignment_entry is not None:
+                    cached_update_times.append(assignment_entry.since)
+            elif config.quiz_mode != "off" and module.get("modname") == "quiz":
+                quiz_entry = course_cache.get_quiz_cache_entry(
+                    ctx, course_node, module_id, logger
+                )
+                if quiz_entry is not None:
+                    cached_update_times.append(quiz_entry.since)
+
+        course_updates = None
+        if (
+            cached_update_times
+            and moodle_api.MOODLE_UPDATE_FUNCTION in ctx.moodle_functions
+        ):
+            progress.module_status("checking for Moodle updates")
+            course_updates = moodle_api.get_course_updates_since(
+                session,
+                wstoken,
+                int(course_id),
+                min(cached_update_times),
+                logger,
+            )
+            if course_updates is None:
+                ctx.moodle_functions = ctx.moodle_functions - {
+                    moodle_api.MOODLE_UPDATE_FUNCTION
+                }
+                logger.info(
+                    "Moodle incremental update checks are unavailable; using "
+                    "full module queries for this run"
+                )
 
         assignments = None
         if config.module_assignment and ("assign" in module_names):
@@ -207,6 +249,7 @@ def sync(ctx: SyncContext) -> None:  # noqa: C901 - legacy sync awaiting decompo
                 section_node=section_node,
                 assignments_by_cmid=assignments_by_cmid,
                 folders_by_coursemodule=folders_by_coursemodule,
+                course_updates=course_updates,
                 log=logger,
             )
             for module in section["modules"]:

--- a/syncmymoodle/sync_handlers.py
+++ b/syncmymoodle/sync_handlers.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, cast
 
 import requests
 
-from syncmymoodle import filters, moodle_files
+from syncmymoodle import course_cache, filters, moodle_files
 from syncmymoodle import links as links_api
 from syncmymoodle import moodle as moodle_api
 from syncmymoodle import opencast as opencast_api
@@ -55,6 +55,28 @@ def register_handler(handler: Handler) -> Handler:
     """Register a sync module handler so ``handle_module`` dispatches to it."""
     MODULE_HANDLERS.append(handler)
     return handler
+
+
+def _h5p_content_marker(
+    activity: dict[str, Any],
+    package_file: dict[str, Any],
+) -> str | None:
+    # Moodle exposes the package SHA-1 directly; older deployments may only
+    # provide file modification metadata.
+    content_hash = activity.get("contenthash")
+    if isinstance(content_hash, str) and content_hash:
+        return f"contenthash:{content_hash}"
+
+    modified = package_file.get("timemodified", activity.get("timemodified"))
+    if not isinstance(modified, int) or isinstance(modified, bool) or modified < 0:
+        return None
+    size = package_file.get("filesize")
+    size_marker = (
+        str(size)
+        if isinstance(size, int) and not isinstance(size, bool) and size >= 0
+        else "unknown"
+    )
+    return f"timemodified:{modified}:filesize:{size_marker}"
 
 
 def _opencast_series_episodes(
@@ -445,21 +467,60 @@ def handle_embedded_link_module(  # noqa: C901 - legacy handler awaiting decompo
         package_files = activity.get("package") if activity else None
         if isinstance(package_files, dict):
             package_files = [package_files]
-        package_url = next(
+        package_file = next(
             (
-                item.get("fileurl")
+                item
                 for item in package_files or []
-                if isinstance(item, dict) and item.get("fileurl")
+                if isinstance(item, dict) and isinstance(item.get("fileurl"), str)
             ),
             None,
         )
-        if isinstance(package_url, str):
-            module_context.status("downloading H5P package")
-            content = _read_h5p_content(
-                ctx.require_session(), package_url, module["id"], log
+        if isinstance(activity, dict) and isinstance(package_file, dict):
+            package_url = package_file["fileurl"]
+            assert isinstance(package_url, str)
+            module_id = module["id"]
+            cache_module_id = (
+                module_id
+                if isinstance(module_id, int) and not isinstance(module_id, bool)
+                else None
             )
+            marker = _h5p_content_marker(activity, package_file)
+            content = (
+                course_cache.get_h5p_content(
+                    ctx,
+                    module_context.course_node,
+                    cache_module_id,
+                    marker,
+                    log,
+                )
+                if cache_module_id is not None and marker is not None
+                else None
+            )
+            from_cache = content is not None
+            if content is None:
+                module_context.status("downloading H5P package")
+                content = _read_h5p_content(
+                    ctx.require_session(), package_url, module_id, log
+                )
+                if (
+                    content is not None
+                    and cache_module_id is not None
+                    and marker is not None
+                ):
+                    course_cache.store_h5p_content(
+                        ctx,
+                        module_context.course_node,
+                        cache_module_id,
+                        marker,
+                        content,
+                        log,
+                    )
             if content is not None:
-                module_context.status("scanning H5P content")
+                module_context.status(
+                    "scanning cached H5P content"
+                    if from_cache
+                    else "scanning H5P content"
+                )
                 links_api.scan_for_links(
                     ctx,
                     content,

--- a/syncmymoodle/sync_handlers.py
+++ b/syncmymoodle/sync_handlers.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 H5P_PACKAGE_MAX_BYTES = 2 * 1024**3
 H5P_PACKAGE_MEMORY_BYTES = 16 * 1024**2
 H5P_CONTENT_MAX_BYTES = 10 * 1024 * 1024
+QUIZ_IMMEDIATE_REVIEW_SECONDS = 2 * 60
 
 
 @dataclass
@@ -46,6 +47,12 @@ class ModuleContext:
         self.ctx.output.sync_progress.module_status(message)
 
 
+@dataclass(frozen=True)
+class QuizCacheTiming:
+    timeclose: int
+    refresh_after: int | None
+
+
 Handler = Callable[[ModuleContext, dict[str, Any]], None]
 
 # Handlers register themselves here via @register_handler and run, per module,
@@ -60,46 +67,30 @@ def register_handler(handler: Handler) -> Handler:
     return handler
 
 
-def _h5p_content_marker(
-    activity: dict[str, Any],
-    package_file: dict[str, Any],
+def _content_marker(
+    metadata: dict[str, Any],
+    file_metadata: dict[str, Any],
+    *,
+    url: str | None = None,
 ) -> str | None:
-    # Moodle exposes the package SHA-1 directly; older deployments may only
-    # provide file modification metadata.
-    content_hash = activity.get("contenthash")
+    content_hash = metadata.get("contenthash")
+    if not isinstance(content_hash, str) or not content_hash:
+        content_hash = file_metadata.get("contenthash")
     if isinstance(content_hash, str) and content_hash:
-        return f"contenthash:{content_hash}"
+        marker = f"contenthash:{content_hash}"
+    else:
+        modified = file_metadata.get("timemodified", metadata.get("timemodified"))
+        if not isinstance(modified, int) or isinstance(modified, bool) or modified < 0:
+            return None
+        size = file_metadata.get("filesize")
+        size_marker = (
+            str(size)
+            if isinstance(size, int) and not isinstance(size, bool) and size >= 0
+            else "unknown"
+        )
+        marker = f"timemodified:{modified}:filesize:{size_marker}"
 
-    modified = package_file.get("timemodified", activity.get("timemodified"))
-    if not isinstance(modified, int) or isinstance(modified, bool) or modified < 0:
-        return None
-    size = package_file.get("filesize")
-    size_marker = (
-        str(size)
-        if isinstance(size, int) and not isinstance(size, bool) and size >= 0
-        else "unknown"
-    )
-    return f"timemodified:{modified}:filesize:{size_marker}"
-
-
-def _page_content_marker(content: dict[str, Any]) -> str | None:
-    file_url = content.get("fileurl")
-    if not isinstance(file_url, str) or not file_url:
-        return None
-    content_hash = content.get("contenthash")
-    if isinstance(content_hash, str) and content_hash:
-        return f"contenthash:{content_hash}:url:{file_url}"
-
-    modified = content.get("timemodified")
-    if not isinstance(modified, int) or isinstance(modified, bool) or modified < 0:
-        return None
-    size = content.get("filesize")
-    size_marker = (
-        str(size)
-        if isinstance(size, int) and not isinstance(size, bool) and size >= 0
-        else "unknown"
-    )
-    return f"timemodified:{modified}:filesize:{size_marker}:url:{file_url}"
+    return f"{marker}:url:{url}" if url is not None else marker
 
 
 def _page_response_cacheable(response: Any, requested_url: str) -> bool:
@@ -497,7 +488,9 @@ def handle_embedded_link_module(  # noqa: C901 - legacy handler awaiting decompo
             (
                 content
                 for content in module.get("contents") or []
-                if content.get("filename") == "index.html" and content.get("fileurl")
+                if content.get("filename") == "index.html"
+                and isinstance(content.get("fileurl"), str)
+                and content["fileurl"]
             ),
             None,
         )
@@ -515,14 +508,19 @@ def handle_embedded_link_module(  # noqa: C901 - legacy handler awaiting decompo
                 else None
             )
             marker = (
-                _page_content_marker(index_content)
+                _content_marker(
+                    index_content,
+                    index_content,
+                    url=index_content["fileurl"],
+                )
                 if index_content is not None
                 else None
             )
             cached = (
-                course_cache.get_page_content(
+                course_cache.get_cached_text(
                     ctx,
                     module_context.course_node,
+                    course_cache.PAGE_CONTENT_KIND,
                     cache_module_id,
                     marker,
                     log,
@@ -536,7 +534,7 @@ def handle_embedded_link_module(  # noqa: C901 - legacy handler awaiting decompo
             if cached is not None:
                 module_context.status("scanning cached page")
                 page_content = cached.content
-                page_base_url = cached.base_url
+                page_base_url = cached.base_url or html_url
             else:
                 module_context.status("fetching page")
                 try:
@@ -604,9 +602,10 @@ def handle_embedded_link_module(  # noqa: C901 - legacy handler awaiting decompo
                         module_title=module["name"],
                     )
                 if cache_module_id is not None and marker is not None and cacheable:
-                    course_cache.store_page_content(
+                    course_cache.store_cached_text(
                         ctx,
                         module_context.course_node,
+                        course_cache.PAGE_CONTENT_KIND,
                         cache_module_id,
                         marker,
                         page_content,
@@ -643,11 +642,12 @@ def handle_embedded_link_module(  # noqa: C901 - legacy handler awaiting decompo
                 if isinstance(module_id, int) and not isinstance(module_id, bool)
                 else None
             )
-            marker = _h5p_content_marker(activity, package_file)
-            content = (
-                course_cache.get_h5p_content(
+            marker = _content_marker(activity, package_file)
+            cached = (
+                course_cache.get_cached_text(
                     ctx,
                     module_context.course_node,
+                    course_cache.H5P_CONTENT_KIND,
                     cache_module_id,
                     marker,
                     log,
@@ -655,7 +655,8 @@ def handle_embedded_link_module(  # noqa: C901 - legacy handler awaiting decompo
                 if cache_module_id is not None and marker is not None
                 else None
             )
-            from_cache = content is not None
+            content = cached.content if cached is not None else None
+            from_cache = cached is not None
             if content is None:
                 module_context.status("downloading H5P package")
                 content = _read_h5p_content(
@@ -666,13 +667,14 @@ def handle_embedded_link_module(  # noqa: C901 - legacy handler awaiting decompo
                     and cache_module_id is not None
                     and marker is not None
                 ):
-                    course_cache.store_h5p_content(
+                    course_cache.store_cached_text(
                         ctx,
                         module_context.course_node,
+                        course_cache.H5P_CONTENT_KIND,
                         cache_module_id,
                         marker,
                         content,
-                        log,
+                        log=log,
                     )
             if content is not None:
                 module_context.status(
@@ -824,18 +826,65 @@ def _quiz_review_html(name: str, review: dict[str, Any]) -> str:
     )
 
 
+def _quiz_cache_timing(
+    attempts: list[dict[str, Any]],
+    quiz: dict[str, Any] | None,
+    server_time: int | None,
+) -> QuizCacheTiming | None:
+    """Return cache timing metadata, or ``None`` when it cannot be trusted."""
+    if quiz is None or server_time is None:
+        return None
+    timeclose = quiz.get("timeclose")
+    if not isinstance(timeclose, int) or isinstance(timeclose, bool) or timeclose < 0:
+        return None
+
+    boundaries = [timeclose] if timeclose > server_time else []
+    for attempt in attempts:
+        attempt_id = attempt.get("id")
+        timefinish = attempt.get("timefinish")
+        if (
+            not isinstance(attempt_id, int)
+            or isinstance(attempt_id, bool)
+            or attempt_id <= 0
+            or not isinstance(timefinish, int)
+            or isinstance(timefinish, bool)
+            or timefinish <= 0
+        ):
+            return None
+        immediate_review_end = timefinish + QUIZ_IMMEDIATE_REVIEW_SECONDS
+        if immediate_review_end > server_time:
+            boundaries.append(immediate_review_end)
+    return QuizCacheTiming(timeclose, min(boundaries, default=None))
+
+
 def _cached_quiz_data(
     module_context: ModuleContext,
     module_id: int,
-) -> tuple[list[dict[str, Any]], dict[int, dict[str, Any]]] | None:
+    quiz: dict[str, Any] | None,
+) -> (
+    tuple[
+        list[dict[str, Any]],
+        dict[int, dict[str, Any]],
+        QuizCacheTiming,
+    ]
+    | None
+):
     cached = course_cache.get_quiz_cache_entry(
         module_context.ctx,
         module_context.course_node,
         module_id,
         module_context.log,
     )
+    timing = _quiz_cache_timing(
+        cached.attempts if cached is not None else [],
+        quiz,
+        module_context.ctx.moodle_server_time,
+    )
     if (
         cached is None
+        or timing is None
+        or timing.timeclose != cached.timeclose
+        or timing.refresh_after != cached.refresh_after
         or module_context.course_updates is None
         or not module_context.course_updates.confirms_unchanged(module_id, cached.since)
     ):
@@ -848,7 +897,7 @@ def _cached_quiz_data(
     }
     if not valid_attempt_ids.issubset(cached.reviews):
         return None
-    return cached.attempts, cached.reviews
+    return cached.attempts, cached.reviews, timing
 
 
 def _load_quiz_data(
@@ -867,7 +916,12 @@ def _load_quiz_data(
     complete = True
     for index, attempt in enumerate(attempts, 1):
         attempt_id = attempt.get("id")
-        if not isinstance(attempt_id, int) or isinstance(attempt_id, bool):
+        if (
+            not isinstance(attempt_id, int)
+            or isinstance(attempt_id, bool)
+            or attempt_id <= 0
+        ):
+            complete = False
             continue
         module_context.status(f"loading quiz attempt {index}/{len(attempts)}")
         review = moodle_api.get_quiz_attempt_review(
@@ -915,40 +969,56 @@ def handle_quiz_module(
         return
 
     module_id = module.get("id")
-    quiz_id = module.get("instance")
     if not isinstance(module_id, int) or isinstance(module_id, bool):
         return
-    if not isinstance(quiz_id, int) or isinstance(quiz_id, bool):
-        module_context.status("loading quiz activity")
-        instance = module_instance(
-            ctx,
-            module,
-            module_context.course_id,
-            ctx.quiz_instance_cache,
-            moodle_api.get_quizzes_by_course,
-        )
-        quiz_id = instance.get("id") if instance else None
+
+    # Effective quiz closing times include user/group overrides and determine
+    # when Moodle changes which review fields are visible.
+    module_context.status("loading quiz activity")
+    instance = module_instance(
+        ctx,
+        module,
+        module_context.course_id,
+        ctx.quiz_instance_cache,
+        moodle_api.get_quizzes_by_course,
+    )
+    quiz_id = instance.get("id") if instance else module.get("instance")
     if not isinstance(quiz_id, int) or isinstance(quiz_id, bool):
         return
-    cached_data = _cached_quiz_data(module_context, module_id)
+    cached_data = _cached_quiz_data(module_context, module_id, instance)
+    timing: QuizCacheTiming | None
     if cached_data is not None:
         module_context.status("scanning cached quiz attempts")
-        attempts, reviews = cached_data
+        attempts, reviews, timing = cached_data
         complete = True
     else:
         loaded = _load_quiz_data(module_context, quiz_id)
         if loaded is None:
             return
         attempts, reviews, complete = loaded
+        timing = _quiz_cache_timing(
+            attempts,
+            instance,
+            ctx.moodle_server_time,
+        )
 
     _add_quiz_nodes(ctx, section_node, module["name"], attempts, reviews)
-    if complete:
+    if complete and timing is not None:
         course_cache.store_quiz_cache_entry(
             ctx,
             module_context.course_node,
             module_id,
             attempts,
             reviews,
+            timing.timeclose,
+            timing.refresh_after,
+            module_context.log,
+        )
+    else:
+        course_cache.discard_quiz_cache_entry(
+            ctx,
+            module_context.course_node,
+            module_id,
             module_context.log,
         )
 

--- a/syncmymoodle/sync_handlers.py
+++ b/syncmymoodle/sync_handlers.py
@@ -16,7 +16,9 @@ from syncmymoodle import opencast as opencast_api
 from syncmymoodle.constants import HTTP_TIMEOUT_SECONDS, MOODLE_URL
 from syncmymoodle.context import SyncContext
 from syncmymoodle.http_utils import (
+    HTML_CONTENT_TYPES,
     content_length,
+    content_type_without_parameters,
     copy_capped_body,
     parse_html,
     safe_request_error,
@@ -37,6 +39,7 @@ class ModuleContext:
     section_node: Node
     assignments_by_cmid: Any
     folders_by_coursemodule: Any
+    course_updates: moodle_api.CourseUpdates | None = None
     log: logging.Logger = logger
 
     def status(self, message: str) -> None:
@@ -77,6 +80,49 @@ def _h5p_content_marker(
         else "unknown"
     )
     return f"timemodified:{modified}:filesize:{size_marker}"
+
+
+def _page_content_marker(content: dict[str, Any]) -> str | None:
+    file_url = content.get("fileurl")
+    if not isinstance(file_url, str) or not file_url:
+        return None
+    content_hash = content.get("contenthash")
+    if isinstance(content_hash, str) and content_hash:
+        return f"contenthash:{content_hash}:url:{file_url}"
+
+    modified = content.get("timemodified")
+    if not isinstance(modified, int) or isinstance(modified, bool) or modified < 0:
+        return None
+    size = content.get("filesize")
+    size_marker = (
+        str(size)
+        if isinstance(size, int) and not isinstance(size, bool) and size >= 0
+        else "unknown"
+    )
+    return f"timemodified:{modified}:filesize:{size_marker}:url:{file_url}"
+
+
+def _page_response_cacheable(response: Any, requested_url: str) -> bool:
+    content_type = content_type_without_parameters(response)
+    if content_type and content_type not in HTML_CONTENT_TYPES:
+        return False
+
+    requested = urllib.parse.urlsplit(requested_url)
+    final = urllib.parse.urlsplit(response.url or requested_url)
+
+    def moodle_file_path(path: str) -> str:
+        prefix = "/webservice/pluginfile.php/"
+        return (
+            f"/pluginfile.php/{path.removeprefix(prefix)}"
+            if path.startswith(prefix)
+            else path
+        )
+
+    return (
+        requested.scheme.lower() == final.scheme.lower()
+        and requested.netloc.lower() == final.netloc.lower()
+        and moodle_file_path(requested.path) == moodle_file_path(final.path)
+    )
 
 
 def _opencast_series_episodes(
@@ -221,6 +267,61 @@ def module_instance(
     return cache.get(module_id)
 
 
+def _assignment_submission_files(
+    module_context: ModuleContext,
+    module_id: int,
+    assignment_id: Any,
+    *,
+    allow_cache: bool,
+) -> list[dict[str, Any]] | None:
+    ctx = module_context.ctx
+    cached = course_cache.get_assignment_cache_entry(
+        ctx, module_context.course_node, module_id, module_context.log
+    )
+    if (
+        allow_cache
+        and cached is not None
+        and module_context.course_updates is not None
+        and module_context.course_updates.confirms_unchanged(module_id, cached.since)
+    ):
+        module_context.status("scanning cached assignment submissions")
+        return cached.files
+
+    account = ctx.require_moodle_account()
+    module_context.status("loading assignment submissions")
+    fetched = moodle_api.get_assignment_submission_files(
+        ctx.require_session(),
+        account.wstoken,
+        account.user_id,
+        assignment_id,
+    )
+    if fetched is None:
+        return None
+    return [item for item in fetched if isinstance(item, dict)]
+
+
+def _add_assignment_file_nodes(
+    ctx: SyncContext,
+    assignment_node: Node,
+    files: list[Any],
+) -> None:
+    for item in files:
+        if not isinstance(item, dict):
+            continue
+        if filters.should_skip_url(ctx, item.get("fileurl"), "assignment file"):
+            continue
+        moodle_files.add_moodle_file_node(
+            assignment_node,
+            item.get("filepath", "/"),
+            item["filename"],
+            item["fileurl"],
+            "Assignment File",
+            item["fileurl"],
+            timemodified=item.get("timemodified"),
+            remote_size=item.get("filesize"),
+        )
+
+
 @register_handler
 def handle_assignment_module(
     module_context: ModuleContext,
@@ -237,6 +338,9 @@ def handle_assignment_module(
         if not ass:
             return
         assignment_id = ass["id"]
+        module_id = module["id"]
+        if not isinstance(module_id, int) or isinstance(module_id, bool):
+            return
         assignment_name = module["name"]
         assignment_node = section_node.add_child(
             assignment_name, assignment_id, "Assignment"
@@ -255,26 +359,36 @@ def handle_assignment_module(
                 module_title=assignment_name,
             )
 
-        account = ctx.require_moodle_account()
-        module_context.status("loading assignment submissions")
-        ass = ass["introattachments"] + moodle_api.get_assignment_submission_files(
-            ctx.require_session(),
-            account.wstoken,
-            account.user_id,
+        # Moodle's update callback checks the current user's submission row,
+        # while a team submission can be changed through the shared group row.
+        cache_allowed = not bool(ass.get("teamsubmission"))
+        submission_files = _assignment_submission_files(
+            module_context,
+            module_id,
             assignment_id,
+            allow_cache=cache_allowed,
         )
-        for c in ass:
-            if filters.should_skip_url(ctx, c.get("fileurl"), "assignment file"):
-                continue
-            moodle_files.add_moodle_file_node(
-                assignment_node,
-                c.get("filepath", "/"),
-                c["filename"],
-                c["fileurl"],
-                "Assignment File",
-                c["fileurl"],
-                timemodified=c.get("timemodified"),
-                remote_size=c.get("filesize"),
+        if submission_files is None:
+            return
+
+        intro_attachments = ass.get("introattachments") or []
+        _add_assignment_file_nodes(
+            ctx, assignment_node, [*intro_attachments, *submission_files]
+        )
+        if cache_allowed:
+            course_cache.store_assignment_cache_entry(
+                ctx,
+                module_context.course_node,
+                module_id,
+                submission_files,
+                module_context.log,
+            )
+        else:
+            course_cache.discard_assignment_cache_entry(
+                ctx,
+                module_context.course_node,
+                module_id,
+                module_context.log,
             )
 
 
@@ -394,37 +508,72 @@ def handle_embedded_link_module(  # noqa: C901 - legacy handler awaiting decompo
         )
         scan_page_links = not filters.should_skip_url(ctx, html_url, "page link")
         if opencast_enabled or scan_page_links:
-            module_context.status("fetching page")
-            try:
-                response = ctx.require_session().get(
-                    html_url,
-                    timeout=HTTP_TIMEOUT_SECONDS,
+            module_id = module["id"]
+            cache_module_id = (
+                module_id
+                if isinstance(module_id, int) and not isinstance(module_id, bool)
+                else None
+            )
+            marker = (
+                _page_content_marker(index_content)
+                if index_content is not None
+                else None
+            )
+            cached = (
+                course_cache.get_page_content(
+                    ctx,
+                    module_context.course_node,
+                    cache_module_id,
+                    marker,
+                    log,
                 )
-            except requests.RequestException as error:
-                log.warning(
-                    "Failed to fetch page module %s: %s",
-                    module["id"],
-                    safe_request_error(error),
-                )
-                ctx.stats.failed += 1
-                response = None
-            if response is not None and not (200 <= response.status_code < 300):
-                log.warning(
-                    "Page module %s returned status %s",
-                    module["id"],
-                    response.status_code,
-                )
-                ctx.stats.failed += 1
-                response = None
-            if response is not None:
+                if cache_module_id is not None and marker is not None
+                else None
+            )
+            page_content: str | None = None
+            page_base_url = html_url
+            cacheable = cached is not None
+            if cached is not None:
+                module_context.status("scanning cached page")
+                page_content = cached.content
+                page_base_url = cached.base_url
+            else:
+                module_context.status("fetching page")
+                try:
+                    response = ctx.require_session().get(
+                        html_url,
+                        timeout=HTTP_TIMEOUT_SECONDS,
+                    )
+                except requests.RequestException as error:
+                    log.warning(
+                        "Failed to fetch page module %s: %s",
+                        module_id,
+                        safe_request_error(error),
+                    )
+                    ctx.stats.failed += 1
+                    response = None
+                if response is not None and not (200 <= response.status_code < 300):
+                    log.warning(
+                        "Page module %s returned status %s",
+                        module_id,
+                        response.status_code,
+                    )
+                    ctx.stats.failed += 1
+                    response = None
+                if response is not None:
+                    page_content = response.text
+                    page_base_url = response.url or html_url
+                    cacheable = _page_response_cacheable(response, html_url)
+
+            if page_content is not None:
                 if opencast_enabled:
-                    html = parse_html(response.text)
+                    html = parse_html(page_content)
                     for iframe in html.find_all("iframe"):
                         iframe_src_value = iframe.get("src")
                         if not iframe_src_value:
                             continue
                         iframe_src = urllib.parse.urljoin(
-                            response.url or html_url,
+                            page_base_url,
                             cast(str, iframe_src_value),
                         )
                         vid_id = opencast_api.extract_episode_id(iframe_src)
@@ -448,11 +597,21 @@ def handle_embedded_link_module(  # noqa: C901 - legacy handler awaiting decompo
                     module_context.status("scanning page links")
                     links_api.scan_html_text_for_links(
                         ctx,
-                        response.text,
-                        response.url or html_url,
+                        page_content,
+                        page_base_url,
                         section_node,
                         course_id,
                         module_title=module["name"],
+                    )
+                if cache_module_id is not None and marker is not None and cacheable:
+                    course_cache.store_page_content(
+                        ctx,
+                        module_context.course_node,
+                        cache_module_id,
+                        marker,
+                        page_content,
+                        page_base_url,
+                        log,
                     )
     # "Interactive" h5p videos
     elif module["modname"] == "h5pactivity":
@@ -639,6 +798,110 @@ def handle_opencast_lti_module(  # noqa: C901 - legacy handler awaiting decompos
             )
 
 
+def _quiz_review_html(name: str, review: dict[str, Any]) -> str:
+    parts: list[str] = []
+    grade = review.get("grade")
+    if grade not in (None, ""):
+        parts.append(
+            '<section class="quiz-grade"><h2>Grade</h2><p>'
+            f"{html.escape(str(grade))}</p></section>"
+        )
+    parts.extend(
+        str(question.get("html") or "")
+        for question in review.get("questions") or []
+        if isinstance(question, dict)
+    )
+    for item in review.get("additionaldata") or []:
+        if not isinstance(item, dict):
+            continue
+        title = item.get("title")
+        if title not in (None, ""):
+            parts.append(f"<h2>{html.escape(str(title))}</h2>")
+        parts.append(str(item.get("content") or ""))
+    return (
+        "<!doctype html><html><head><title>"
+        f"{html.escape(name)}</title></head><body>{''.join(parts)}</body></html>"
+    )
+
+
+def _cached_quiz_data(
+    module_context: ModuleContext,
+    module_id: int,
+) -> tuple[list[dict[str, Any]], dict[int, dict[str, Any]]] | None:
+    cached = course_cache.get_quiz_cache_entry(
+        module_context.ctx,
+        module_context.course_node,
+        module_id,
+        module_context.log,
+    )
+    if (
+        cached is None
+        or module_context.course_updates is None
+        or not module_context.course_updates.confirms_unchanged(module_id, cached.since)
+    ):
+        return None
+    valid_attempt_ids = {
+        attempt_id
+        for attempt in cached.attempts
+        if isinstance((attempt_id := attempt.get("id")), int)
+        and not isinstance(attempt_id, bool)
+    }
+    if not valid_attempt_ids.issubset(cached.reviews):
+        return None
+    return cached.attempts, cached.reviews
+
+
+def _load_quiz_data(
+    module_context: ModuleContext,
+    quiz_id: int,
+) -> tuple[list[dict[str, Any]], dict[int, dict[str, Any]], bool] | None:
+    ctx = module_context.ctx
+    module_context.status("loading quiz attempts")
+    attempts = moodle_api.get_quiz_attempts(
+        ctx.require_session(), ctx.require_moodle_account().wstoken, quiz_id
+    )
+    if attempts is None:
+        return None
+
+    reviews: dict[int, dict[str, Any]] = {}
+    complete = True
+    for index, attempt in enumerate(attempts, 1):
+        attempt_id = attempt.get("id")
+        if not isinstance(attempt_id, int) or isinstance(attempt_id, bool):
+            continue
+        module_context.status(f"loading quiz attempt {index}/{len(attempts)}")
+        review = moodle_api.get_quiz_attempt_review(
+            ctx.require_session(),
+            ctx.require_moodle_account().wstoken,
+            attempt_id,
+        )
+        if review is None:
+            complete = False
+        else:
+            reviews[attempt_id] = review
+    return attempts, reviews, complete
+
+
+def _add_quiz_nodes(
+    ctx: SyncContext,
+    section_node: Node,
+    module_name: str,
+    attempts: list[dict[str, Any]],
+    reviews: dict[int, dict[str, Any]],
+) -> None:
+    for index, attempt in enumerate(attempts, 1):
+        attempt_id = attempt.get("id")
+        if not isinstance(attempt_id, int) or isinstance(attempt_id, bool):
+            continue
+        review = reviews.get(attempt_id)
+        if review is None:
+            continue
+        name = f"{module_name}, Versuch {index}"
+        review_url = f"{MOODLE_URL}mod/quiz/review.php?attempt={attempt_id}"
+        ctx.quiz_review_cache[review_url] = _quiz_review_html(name, review)
+        section_node.add_child(name, attempt_id, "Quiz", url=review_url)
+
+
 @register_handler
 def handle_quiz_module(
     module_context: ModuleContext,
@@ -651,62 +914,42 @@ def handle_quiz_module(
     if module["modname"] != "quiz" or ctx.config.quiz_mode == "off":
         return
 
-    module_context.status("loading quiz activity")
-    instance = module_instance(
-        ctx,
-        module,
-        module_context.course_id,
-        ctx.quiz_instance_cache,
-        moodle_api.get_quizzes_by_course,
-    )
-    quiz_id = instance.get("id") if instance else module.get("instance")
-    if not isinstance(quiz_id, int):
+    module_id = module.get("id")
+    quiz_id = module.get("instance")
+    if not isinstance(module_id, int) or isinstance(module_id, bool):
         return
-    module_context.status("loading quiz attempts")
-    attempts = moodle_api.get_quiz_attempts(
-        ctx.require_session(), ctx.require_moodle_account().wstoken, quiz_id
-    )
-    for index, attempt in enumerate(attempts, 1):
-        attempt_id = attempt.get("id")
-        if not isinstance(attempt_id, int):
-            continue
-        module_context.status(f"loading quiz attempt {index}/{len(attempts)}")
-        review = moodle_api.get_quiz_attempt_review(
-            ctx.require_session(), ctx.require_moodle_account().wstoken, attempt_id
+    if not isinstance(quiz_id, int) or isinstance(quiz_id, bool):
+        module_context.status("loading quiz activity")
+        instance = module_instance(
+            ctx,
+            module,
+            module_context.course_id,
+            ctx.quiz_instance_cache,
+            moodle_api.get_quizzes_by_course,
         )
-        if review is None:
-            continue
-        parts: list[str] = []
-        grade = review.get("grade")
-        if grade not in (None, ""):
-            parts.append(
-                '<section class="quiz-grade"><h2>Grade</h2><p>'
-                f"{html.escape(str(grade))}</p></section>"
-            )
-        parts.extend(
-            str(question.get("html") or "")
-            for question in review.get("questions") or []
-            if isinstance(question, dict)
-        )
-        for item in review.get("additionaldata") or []:
-            if not isinstance(item, dict):
-                continue
-            title = item.get("title")
-            if title not in (None, ""):
-                parts.append(f"<h2>{html.escape(str(title))}</h2>")
-            parts.append(str(item.get("content") or ""))
-        body = "".join(parts)
-        name = f"{module['name']}, Versuch {index}"
-        review_url = f"{MOODLE_URL}mod/quiz/review.php?attempt={attempt_id}"
-        ctx.quiz_review_cache[review_url] = (
-            "<!doctype html><html><head><title>"
-            f"{html.escape(name)}</title></head><body>{body}</body></html>"
-        )
-        section_node.add_child(
-            name,
-            attempt_id,
-            "Quiz",
-            url=review_url,
+        quiz_id = instance.get("id") if instance else None
+    if not isinstance(quiz_id, int) or isinstance(quiz_id, bool):
+        return
+    cached_data = _cached_quiz_data(module_context, module_id)
+    if cached_data is not None:
+        module_context.status("scanning cached quiz attempts")
+        attempts, reviews = cached_data
+        complete = True
+    else:
+        loaded = _load_quiz_data(module_context, quiz_id)
+        if loaded is None:
+            return
+        attempts, reviews, complete = loaded
+
+    _add_quiz_nodes(ctx, section_node, module["name"], attempts, reviews)
+    if complete:
+        course_cache.store_quiz_cache_entry(
+            ctx,
+            module_context.course_node,
+            module_id,
+            attempts,
+            reviews,
+            module_context.log,
         )
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -205,6 +205,10 @@ def install_moodle_fixtures(
         lambda session, wstoken, course_id: [],
     )
     monkeypatch.setattr(
+        "syncmymoodle.moodle.get_quizzes_by_course",
+        lambda session, wstoken, course_id: [],
+    )
+    monkeypatch.setattr(
         "syncmymoodle.moodle.get_ltis_by_course",
         lambda session, wstoken, course_id: [],
     )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -208,10 +208,6 @@ def install_moodle_fixtures(
         "syncmymoodle.moodle.get_ltis_by_course",
         lambda session, wstoken, course_id: [],
     )
-    monkeypatch.setattr(
-        "syncmymoodle.moodle.get_quizzes_by_course",
-        lambda session, wstoken, course_id: [],
-    )
     # The assignment handler fetches submission files via the moodle module
     # directly, so stub it there (leak-safe via monkeypatch).
     monkeypatch.setattr(

--- a/tests/test_auth_flow.py
+++ b/tests/test_auth_flow.py
@@ -58,7 +58,9 @@ def valid(tokens: MoodleTokens) -> cli.moodle_api.TokenValidation:
             "username": tokens.username,
             "siteurl": "https://moodle.rwth-aachen.de/",
             "userprivateaccesskey": "download-key",
+            "functions": [{"name": cli.moodle_api.MOODLE_UPDATE_FUNCTION}],
         },
+        server_time=1_000,
     )
 
 
@@ -942,6 +944,8 @@ def test_normal_sync_uses_valid_stored_token_without_sso(monkeypatch):
     assert calls == ["sync", "download", "cache"]
     assert ctx.session is token_session
     assert ctx.moodle_account == MoodleAccount(stored)
+    assert ctx.moodle_functions == frozenset({cli.moodle_api.MOODLE_UPDATE_FUNCTION})
+    assert ctx.moodle_update_watermark == 995
     assert store.writes == []
 
 

--- a/tests/test_course_cache_safety.py
+++ b/tests/test_course_cache_safety.py
@@ -72,3 +72,187 @@ def test_malformed_nested_course_cache_is_ignored(tmp_path, caplog):
 
     assert course_cache.get_course_cache_root(context, course_node) is None
     assert "Ignoring malformed course cache" in caplog.text
+
+
+def test_cached_module_data_survives_course_name_disambiguation(tmp_path):
+    def colliding_courses(context):
+        root = Node("", -1, "Root", None)
+        semester = root.add_child("26ss", None, "Semester")
+        first = semester.add_child("Same Course", 301, "Course")
+        second = semester.add_child("Same Course", 302, "Course")
+        context.root_node = root
+        return root, first, second
+
+    context = make_context({"paths.sync_directory": str(tmp_path)})
+    root, first, second = colliding_courses(context)
+    course_cache.store_cached_text(
+        context,
+        first,
+        course_cache.H5P_CONTENT_KIND,
+        11,
+        "marker-1",
+        "first",
+    )
+    course_cache.store_cached_text(
+        context,
+        second,
+        course_cache.H5P_CONTENT_KIND,
+        22,
+        "marker-2",
+        "second",
+    )
+
+    root.remove_children_nameclashes()
+    course_cache.cache_root_node(context)
+
+    loaded = make_context({"paths.sync_directory": str(tmp_path)})
+    loaded_root, loaded_first, loaded_second = colliding_courses(loaded)
+    loaded_root.remove_children_nameclashes()
+
+    assert (
+        course_cache.get_cached_text(
+            loaded,
+            loaded_first,
+            course_cache.H5P_CONTENT_KIND,
+            11,
+            "marker-1",
+        ).content
+        == "first"
+    )
+    assert (
+        course_cache.get_cached_text(
+            loaded,
+            loaded_second,
+            course_cache.H5P_CONTENT_KIND,
+            22,
+            "marker-2",
+        ).content
+        == "second"
+    )
+
+
+def test_sync_prunes_cache_entries_for_removed_modules(tmp_path, monkeypatch):
+    config = {"paths.sync_directory": str(tmp_path)}
+    seeded = make_context(config)
+    seeded.moodle_server_time = 100
+    seeded.root_node, course_node = course_tree()
+    course_cache.store_cached_text(
+        seeded,
+        course_node,
+        course_cache.H5P_CONTENT_KIND,
+        11,
+        "h5p-marker",
+        "h5p content",
+    )
+    course_cache.store_cached_text(
+        seeded,
+        course_node,
+        course_cache.PAGE_CONTENT_KIND,
+        12,
+        "page-marker",
+        "page content",
+        "https://example.test/page",
+    )
+    course_cache.store_assignment_cache_entry(seeded, course_node, 13, [])
+    course_cache.store_quiz_cache_entry(
+        seeded,
+        course_node,
+        14,
+        [{"id": 15, "timefinish": 1}],
+        {15: {"questions": []}},
+        0,
+        None,
+    )
+    course_cache.cache_root_node(seeded)
+
+    monkeypatch.setattr(
+        moodle,
+        "get_all_courses",
+        lambda session, wstoken, user_id: [
+            {"id": 301, "shortname": "Download Course", "idnumber": "26ss"}
+        ],
+    )
+    monkeypatch.setattr(
+        moodle,
+        "get_course",
+        lambda session, wstoken, course_id: [
+            {"id": 401, "name": "General", "modules": []}
+        ],
+    )
+    current = make_context(config)
+    current.session = FakeSession()
+
+    sync.sync(current)
+    course_cache.cache_root_node(current)
+
+    loaded = make_context(config)
+    _, loaded_course = course_tree()
+    assert (
+        course_cache.get_cached_text(
+            loaded,
+            loaded_course,
+            course_cache.H5P_CONTENT_KIND,
+            11,
+            "h5p-marker",
+        )
+        is None
+    )
+    assert (
+        course_cache.get_cached_text(
+            loaded,
+            loaded_course,
+            course_cache.PAGE_CONTENT_KIND,
+            12,
+            "page-marker",
+        )
+        is None
+    )
+    assert course_cache.get_assignment_cache_entry(loaded, loaded_course, 13) is None
+    assert course_cache.get_quiz_cache_entry(loaded, loaded_course, 14) is None
+
+
+def test_malformed_module_inventory_does_not_prune_cache(tmp_path, monkeypatch):
+    config = {"paths.sync_directory": str(tmp_path)}
+    seeded = make_context(config)
+    seeded.root_node, course_node = course_tree()
+    course_cache.store_cached_text(
+        seeded,
+        course_node,
+        course_cache.H5P_CONTENT_KIND,
+        11,
+        "h5p-marker",
+        "h5p content",
+    )
+    course_cache.cache_root_node(seeded)
+
+    monkeypatch.setattr(
+        moodle,
+        "get_all_courses",
+        lambda session, wstoken, user_id: [
+            {"id": 301, "shortname": "Download Course", "idnumber": "26ss"}
+        ],
+    )
+    monkeypatch.setattr(
+        moodle,
+        "get_course",
+        lambda session, wstoken, course_id: [
+            {"id": 401, "name": "General", "modules": [{"name": "broken"}]}
+        ],
+    )
+    current = make_context(config)
+    current.session = FakeSession()
+
+    sync.sync(current)
+    course_cache.cache_root_node(current)
+
+    loaded = make_context(config)
+    _, loaded_course = course_tree()
+    entry = course_cache.get_cached_text(
+        loaded,
+        loaded_course,
+        course_cache.H5P_CONTENT_KIND,
+        11,
+        "h5p-marker",
+    )
+    assert entry is not None
+    assert entry.content == "h5p content"

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -112,6 +112,79 @@ def test_get_assignment_skips_course_on_api_error(caplog):
     assert "invalidtoken" in caplog.text
 
 
+def test_course_updates_distinguish_changed_unknown_and_unchanged_modules():
+    session = FakeSession()
+
+    def update_response(url, kwargs):
+        assert kwargs["data"]["courseid"] == 101
+        assert kwargs["data"]["since"] == 500
+        return FakeResponse(
+            json_payload={
+                "instances": [
+                    {
+                        "contextlevel": "module",
+                        "id": 42,
+                        "updates": [{"name": "submissions", "itemids": [7]}],
+                    }
+                ],
+                "warnings": [
+                    {
+                        "item": "module",
+                        "itemid": 99,
+                        "warningcode": "missingcallback",
+                        "message": "unsupported",
+                    }
+                ],
+            }
+        )
+
+    session.add("POST", MOODLE_REST_URL, update_response)
+
+    updates = moodle.get_course_updates_since(session, "token", 101, 500)
+
+    assert updates is not None
+    assert updates.confirms_unchanged(42, 500) is False
+    assert updates.confirms_unchanged(99, 500) is False
+    assert updates.confirms_unchanged(43, 500) is True
+    assert updates.confirms_unchanged(43, 499) is False
+
+
+def test_course_updates_fail_closed_on_non_module_warning():
+    session = FakeSession()
+    session.add(
+        "POST",
+        MOODLE_REST_URL,
+        FakeResponse(
+            json_payload={
+                "instances": [],
+                "warnings": [{"item": "course", "itemid": 101}],
+            }
+        ),
+    )
+
+    assert moodle.get_course_updates_since(session, "token", 101, 500) is None
+
+
+def test_course_update_api_failure_is_silent_optional_cache_miss(caplog):
+    session = FakeSession()
+    session.add(
+        "POST",
+        MOODLE_REST_URL,
+        FakeResponse(
+            json_payload={
+                "exception": "TypeError",
+                "message": (
+                    "array_keys(): Argument #1 ($array) must be of type array, "
+                    "mysqli_native_moodle_recordset given"
+                ),
+            }
+        ),
+    )
+
+    assert moodle.get_course_updates_since(session, "token", 101, 500) is None
+    assert "array_keys" not in caplog.text
+
+
 def test_get_folders_skips_course_on_api_error(caplog):
     assert moodle.get_folders_by_courses(_error_session(), "token", 101) == []
     assert "invalidtoken" in caplog.text
@@ -165,6 +238,13 @@ def test_submission_response_is_not_logged(caplog):
     assert moodle.get_assignment_submission_files(session, "token", 1, 2) == []
 
     assert "private-assignment-response" not in caplog.text
+
+
+def test_submission_api_error_is_not_cached_as_an_empty_submission(caplog):
+    assert (
+        moodle.get_assignment_submission_files(_error_session(), "token", 1, 2) is None
+    )
+    assert "invalidtoken" in caplog.text
 
 
 def test_equivalent_moodle_folder_entities_share_one_raw_node():

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -125,7 +125,12 @@ def test_course_updates_distinguish_changed_unknown_and_unchanged_modules():
                         "contextlevel": "module",
                         "id": 42,
                         "updates": [{"name": "submissions", "itemids": [7]}],
-                    }
+                    },
+                    {
+                        "contextlevel": "module",
+                        "id": 44,
+                        "updates": [],
+                    },
                 ],
                 "warnings": [
                     {
@@ -144,6 +149,7 @@ def test_course_updates_distinguish_changed_unknown_and_unchanged_modules():
 
     assert updates is not None
     assert updates.confirms_unchanged(42, 500) is False
+    assert updates.confirms_unchanged(44, 500) is False
     assert updates.confirms_unchanged(99, 500) is False
     assert updates.confirms_unchanged(43, 500) is True
     assert updates.confirms_unchanged(43, 499) is False

--- a/tests/test_moodle_auth.py
+++ b/tests/test_moodle_auth.py
@@ -1,5 +1,6 @@
 import base64
 import hashlib
+from datetime import UTC, datetime
 
 import pytest
 import requests
@@ -95,12 +96,14 @@ def test_acquire_mobile_tokens_requires_browser_account_identity():
     assert session.count("GET", moodle.MOODLE_MOBILE_LAUNCH_URL) == 0
 
 
-def validation_session(payload, status_code=200):
+def validation_session(payload, status_code=200, headers=None):
     session = FakeSession()
     session.add(
         "POST",
         moodle.MOODLE_REST_URL,
-        FakeResponse(status_code=status_code, json_payload=payload),
+        FakeResponse(
+            status_code=status_code, json_payload=payload, headers=headers or {}
+        ),
     )
     return session
 
@@ -129,6 +132,24 @@ def test_token_validation_returns_site_info_for_matching_account():
 
     assert result.kind is moodle.TokenValidationKind.VALID
     assert result.site_info == payload
+
+
+def test_token_validation_records_moodle_server_time():
+    payload = {
+        "userid": 123,
+        "username": "opaque-id",
+        "siteurl": MOODLE_URL.rstrip("/"),
+    }
+
+    result = moodle.validate_mobile_tokens(
+        bound_tokens(),
+        session=validation_session(
+            payload,
+            headers={"Date": "Tue, 14 Jul 2026 12:00:00 GMT"},
+        ),
+    )
+
+    assert result.server_time == int(datetime(2026, 7, 14, 12, tzinfo=UTC).timestamp())
 
 
 def test_token_validation_distinguishes_revocation_from_server_failure():
@@ -334,6 +355,23 @@ def test_token_session_uses_user_private_key_for_tokenpluginfile_urls():
     assert request.url == (
         f"{MOODLE_URL}tokenpluginfile.php/42/question/questiontext/file.png"
         "?token=download-key"
+    )
+
+
+def test_token_session_replaces_stale_cached_file_tokens():
+    request = requests.Request(
+        "GET",
+        (
+            f"{MOODLE_URL}webservice/pluginfile.php/42/mod_resource/content/1/file.pdf"
+            "?forced=1&token=old-token"
+        ),
+    ).prepare()
+
+    moodle.MoodleTokenAuth("current-token")(request)
+
+    assert request.url == (
+        f"{MOODLE_URL}webservice/pluginfile.php/42/mod_resource/content/1/file.pdf"
+        "?forced=1&token=current-token"
     )
 
 

--- a/tests/test_quiz.py
+++ b/tests/test_quiz.py
@@ -115,11 +115,6 @@ def test_quiz_api_review_preserves_grade_and_feedback_titles(monkeypatch, tmp_pa
     )
     monkeypatch.setattr(
         sync_handlers.moodle_api,
-        "get_quizzes_by_course",
-        lambda session, wstoken, course_id: [{"coursemodule": 42, "id": 7}],
-    )
-    monkeypatch.setattr(
-        sync_handlers.moodle_api,
         "get_quiz_attempts",
         lambda session, wstoken, quiz_id: [{"id": 5}],
     )
@@ -159,11 +154,6 @@ def test_quiz_node_keeps_remote_name_until_path_materialization(monkeypatch):
         section_node,
         {},
         {},
-    )
-    monkeypatch.setattr(
-        sync_handlers.moodle_api,
-        "get_quizzes_by_course",
-        lambda session, wstoken, course_id: [{"coursemodule": 42, "id": 7}],
     )
     monkeypatch.setattr(
         sync_handlers.moodle_api,

--- a/tests/test_quiz.py
+++ b/tests/test_quiz.py
@@ -94,7 +94,18 @@ def quiz_node():
     return node
 
 
+def install_quiz_activity(monkeypatch):
+    monkeypatch.setattr(
+        sync_handlers.moodle_api,
+        "get_quizzes_by_course",
+        lambda session, wstoken, course_id: [
+            {"coursemodule": 42, "id": 7, "timeclose": 0}
+        ],
+    )
+
+
 def test_quiz_api_review_preserves_grade_and_feedback_titles(monkeypatch, tmp_path):
+    install_quiz_activity(monkeypatch)
     ctx = make_context(
         {
             "paths.sync_directory": str(tmp_path),
@@ -142,6 +153,7 @@ def test_quiz_api_review_preserves_grade_and_feedback_titles(monkeypatch, tmp_pa
 
 
 def test_quiz_node_keeps_remote_name_until_path_materialization(monkeypatch):
+    install_quiz_activity(monkeypatch)
     ctx = make_context({"modules.quiz": "html"})
     ctx.session = FakeSession()
     course_node = Node("Course", 1, "Course", None)

--- a/tests/test_sync_fixtures.py
+++ b/tests/test_sync_fixtures.py
@@ -14,6 +14,8 @@ from syncmymoodle import (
     sync_handlers,
 )
 from syncmymoodle.constants import HTTP_TIMEOUT_SECONDS
+from syncmymoodle.context import MoodleAccount
+from syncmymoodle.moodle_tokens import MoodleTokens
 from syncmymoodle.node import Node
 
 from .helpers import (
@@ -445,7 +447,7 @@ def test_update_feed_reuses_and_refreshes_assignment_and_quiz_data(
 
     def quiz_attempts(session, wstoken, quiz_id):
         calls["attempts"] += 1
-        return [{"id": 5}]
+        return [{"id": 5, "timefinish": 1}]
 
     def quiz_review(session, wstoken, attempt_id):
         calls["review"] += 1
@@ -459,8 +461,15 @@ def test_update_feed_reuses_and_refreshes_assignment_and_quiz_data(
     monkeypatch.setattr(moodle, "get_quiz_attempts", quiz_attempts)
     monkeypatch.setattr(moodle, "get_quiz_attempt_review", quiz_review)
     monkeypatch.setattr(moodle, "get_course_updates_since", course_updates)
+    monkeypatch.setattr(
+        moodle,
+        "get_quizzes_by_course",
+        lambda session, wstoken, course_id: [
+            {"coursemodule": 43, "id": 8, "timeclose": 10_000}
+        ],
+    )
 
-    def run_at(watermark):
+    def run_at(watermark, user_id=10001):
         context = make_context(
             {
                 "paths.sync_directory": str(tmp_path),
@@ -468,17 +477,25 @@ def test_update_feed_reuses_and_refreshes_assignment_and_quiz_data(
                 "modules.quiz": "html",
             }
         )
+        context.moodle_account = MoodleAccount(
+            MoodleTokens(
+                "fake-user",
+                "fake-webservice-token",
+                "fake-private-token",
+                moodle_user_id=user_id,
+            )
+        )
         context.session = FakeSession()
         context.moodle_functions = frozenset({moodle.MOODLE_UPDATE_FUNCTION})
-        context.moodle_update_watermark = watermark
+        context.moodle_server_time = watermark + 5
         sync.sync(context)
         return context
 
-    first = run_at(100)
+    first = run_at(200)
     course_cache.cache_root_node(first)
-    second = run_at(200)
+    second = run_at(300)
 
-    assert update_calls == [100]
+    assert update_calls == [200]
     assert calls == {"submission": 1, "attempts": 1, "review": 1}
     node_at_path(
         second.root_node,
@@ -494,12 +511,20 @@ def test_update_feed_reuses_and_refreshes_assignment_and_quiz_data(
     assert "Review v1" in second.quiz_review_cache[review_url]
     course_cache.cache_root_node(second)
 
+    # Assignment submissions and quiz attempts are private to the Moodle user.
+    # A second account using the same sync directory must not reuse them.
+    other_user = run_at(350, user_id=20002)
+
+    assert update_calls == [200]
+    assert calls == {"submission": 2, "attempts": 2, "review": 2}
+    assert "Review v1" in other_user.quiz_review_cache[review_url]
+
     state["version"] = 2
     state["changed"] = frozenset({42, 43})
-    third = run_at(300)
+    third = run_at(400)
 
-    assert update_calls == [100, 200]
-    assert calls == {"submission": 2, "attempts": 2, "review": 2}
+    assert update_calls == [200, 300]
+    assert calls == {"submission": 3, "attempts": 3, "review": 3}
     node_at_path(
         third.root_node,
         [
@@ -518,10 +543,10 @@ def test_update_feed_reuses_and_refreshes_assignment_and_quiz_data(
     assignments["assignments"][0]["teamsubmission"] = 1
     state["version"] = 3
     state["changed"] = frozenset()
-    team_run = run_at(400)
+    team_run = run_at(500)
 
-    assert update_calls == [100, 200, 300]
-    assert calls == {"submission": 3, "attempts": 2, "review": 2}
+    assert update_calls == [200, 300, 400]
+    assert calls == {"submission": 4, "attempts": 3, "review": 3}
     node_at_path(
         team_run.root_node,
         [
@@ -532,6 +557,84 @@ def test_update_feed_reuses_and_refreshes_assignment_and_quiz_data(
             "feedback-v3.pdf",
         ],
     )
+
+
+def test_quiz_cache_refreshes_at_review_phase_boundary(monkeypatch, tmp_path):
+    calls = {"attempts": 0, "review": 0}
+    quiz_state = {"timeclose": 0}
+
+    monkeypatch.setattr(
+        moodle,
+        "get_quizzes_by_course",
+        lambda session, wstoken, course_id: [
+            {"coursemodule": 43, "id": 8, "timeclose": quiz_state["timeclose"]}
+        ],
+    )
+
+    def quiz_attempts(session, wstoken, quiz_id):
+        calls["attempts"] += 1
+        return [{"id": 5, "timefinish": 50}]
+
+    def quiz_review(session, wstoken, attempt_id):
+        calls["review"] += 1
+        return {"questions": [{"html": f"<p>Review {calls['review']}</p>"}]}
+
+    monkeypatch.setattr(moodle, "get_quiz_attempts", quiz_attempts)
+    monkeypatch.setattr(moodle, "get_quiz_attempt_review", quiz_review)
+
+    def run_at(server_time, updates):
+        context = make_context(
+            {
+                "paths.sync_directory": str(tmp_path),
+                "modules.quiz": "html",
+            }
+        )
+        context.session = FakeSession()
+        context.moodle_server_time = server_time
+        root = Node("", -1, "Root", None)
+        semester = root.add_child("26ss", None, "Semester")
+        course_node = semester.add_child("Cached Course", 901, "Course")
+        section_node = course_node.add_child("General", 902, "Section")
+        context.root_node = root
+        module_context = sync_handlers.ModuleContext(
+            context,
+            901,
+            course_node,
+            section_node,
+            {},
+            {},
+            course_updates=updates,
+        )
+        sync_handlers.handle_quiz_module(
+            module_context,
+            {"id": 43, "instance": 8, "modname": "quiz", "name": "Quiz"},
+        )
+        return context
+
+    first = run_at(100, None)
+    course_cache.cache_root_node(first)
+
+    unchanged = moodle.CourseUpdates(95, frozenset(), frozenset())
+    before_boundary = run_at(160, unchanged)
+    review_url = "https://moodle.rwth-aachen.de/mod/quiz/review.php?attempt=5"
+
+    assert calls == {"attempts": 1, "review": 1}
+    assert "Review 1" in before_boundary.quiz_review_cache[review_url]
+
+    at_boundary = run_at(170, unchanged)
+
+    assert calls == {"attempts": 2, "review": 2}
+    assert "Review 2" in at_boundary.quiz_review_cache[review_url]
+
+    course_cache.cache_root_node(at_boundary)
+    quiz_state["timeclose"] = 160
+    after_override_change = run_at(
+        180,
+        moodle.CourseUpdates(165, frozenset(), frozenset()),
+    )
+
+    assert calls == {"attempts": 3, "review": 3}
+    assert "Review 3" in after_override_change.quiz_review_cache[review_url]
 
 
 def test_failed_update_feed_is_tried_only_once_per_run(monkeypatch, caplog):

--- a/tests/test_sync_fixtures.py
+++ b/tests/test_sync_fixtures.py
@@ -4,7 +4,15 @@ import zipfile
 
 import requests
 
-from syncmymoodle import course_cache, links, opencast, sciebo, sync, sync_handlers
+from syncmymoodle import (
+    course_cache,
+    links,
+    moodle,
+    opencast,
+    sciebo,
+    sync,
+    sync_handlers,
+)
 from syncmymoodle.constants import HTTP_TIMEOUT_SECONDS
 from syncmymoodle.node import Node
 
@@ -22,6 +30,9 @@ from .helpers import (
 
 H5P_PACKAGE_URL = "https://moodle.rwth-aachen.de/pluginfile.php/activity.h5p"
 PAGE_URL = "https://moodle.rwth-aachen.de/mod/page/view.php?id=123"
+PAGE_CONTENT_URL = (
+    "https://moodle.rwth-aachen.de/pluginfile.php/1/mod_page/content/315/index.html"
+)
 
 
 def run_page_handler(response):
@@ -144,6 +155,48 @@ def run_cached_h5p_handler(
         module_context,
         {"id": 317, "modname": "h5pactivity", "name": "Interactive video"},
     )
+
+    return ctx, section_node, session
+
+
+def run_cached_page_handler(tmp_path, timemodified, response=None):
+    ctx = make_context(
+        {
+            "paths.sync_directory": str(tmp_path),
+            "links.youtube": True,
+            "links.opencast": False,
+            "links.sciebo": False,
+        }
+    )
+    session = FakeSession()
+    if response is not None:
+        session.add("GET", PAGE_CONTENT_URL, response)
+    ctx.session = session
+    root = Node("", -1, "Root", None)
+    semester_node = root.add_child("26ss", None, "Semester")
+    assert semester_node is not None
+    course_node = semester_node.add_child("Course", 1, "Course")
+    assert course_node is not None
+    section_node = course_node.add_child("Section", 2, "Section")
+    assert section_node is not None
+    ctx.root_node = root
+    module_context = sync_handlers.ModuleContext(
+        ctx, 1, course_node, section_node, {}, {}
+    )
+    module = {
+        "id": 315,
+        "modname": "page",
+        "name": "Page",
+        "contents": [
+            {
+                "filename": "index.html",
+                "fileurl": PAGE_CONTENT_URL,
+                "timemodified": timemodified,
+            }
+        ],
+    }
+
+    sync_handlers.handle_embedded_link_module(module_context, module)
 
     return ctx, section_node, session
 
@@ -291,6 +344,249 @@ def test_h5p_without_a_revision_marker_is_downloaded_each_run(monkeypatch, tmp_p
 
     assert first_session.count("GET", H5P_PACKAGE_URL) == 1
     assert second_session.count("GET", H5P_PACKAGE_URL) == 1
+
+
+def test_page_content_cache_reuses_unchanged_and_refreshes_changed_pages(tmp_path):
+    first_url = "https://www.youtube.com/watch?v=abcdefghijk"
+    first, first_section, first_session = run_cached_page_handler(
+        tmp_path,
+        100,
+        FakeResponse(text=f'<a href="{first_url}">first</a>'),
+    )
+    course_cache.cache_root_node(first)
+
+    cached, cached_section, cached_session = run_cached_page_handler(tmp_path, 100)
+    course_cache.cache_root_node(cached)
+
+    assert first_session.count("GET", PAGE_CONTENT_URL) == 1
+    assert cached_session.count("GET", PAGE_CONTENT_URL) == 0
+    assert [child.url for child in first_section.children] == [first_url]
+    assert [child.url for child in cached_section.children] == [first_url]
+
+    changed_url = "https://www.youtube.com/watch?v=zyxwvutsrqp"
+    _, changed_section, changed_session = run_cached_page_handler(
+        tmp_path,
+        101,
+        FakeResponse(text=f'<a href="{changed_url}">changed</a>'),
+    )
+
+    assert changed_session.count("GET", PAGE_CONTENT_URL) == 1
+    assert [child.url for child in changed_section.children] == [changed_url]
+
+
+def test_page_without_revision_marker_is_fetched_each_run(tmp_path):
+    page = FakeResponse(
+        text='<a href="https://www.youtube.com/watch?v=abcdefghijk">video</a>'
+    )
+    first, _, first_session = run_cached_page_handler(tmp_path, None, page)
+    course_cache.cache_root_node(first)
+
+    _, _, second_session = run_cached_page_handler(tmp_path, None, page)
+
+    assert first_session.count("GET", PAGE_CONTENT_URL) == 1
+    assert second_session.count("GET", PAGE_CONTENT_URL) == 1
+
+
+def test_update_feed_reuses_and_refreshes_assignment_and_quiz_data(
+    monkeypatch, tmp_path
+):
+    courses = [
+        {
+            "id": 901,
+            "shortname": "Cached Course",
+            "idnumber": "26ss-course",
+        }
+    ]
+    course = [
+        {
+            "id": 902,
+            "name": "General",
+            "modules": [
+                {"id": 42, "instance": 7, "modname": "assign", "name": "Assignment"},
+                {"id": 43, "instance": 8, "modname": "quiz", "name": "Quiz"},
+            ],
+        }
+    ]
+    assignments = {
+        "assignments": [
+            {
+                "id": 7,
+                "cmid": 42,
+                "intro": "",
+                "introattachments": [],
+                "teamsubmission": 0,
+            }
+        ]
+    }
+    install_moodle_fixtures(
+        monkeypatch,
+        courses,
+        {901: course},
+        {901: assignments},
+    )
+    state = {"version": 1, "changed": frozenset()}
+    calls = {"submission": 0, "attempts": 0, "review": 0}
+    update_calls = []
+
+    def submission_files(session, wstoken, user_id, assignment_id):
+        calls["submission"] += 1
+        version = state["version"]
+        return [
+            {
+                "filename": f"feedback-v{version}.pdf",
+                "filepath": "/",
+                "fileurl": (
+                    "https://moodle.rwth-aachen.de/pluginfile.php/1/"
+                    f"mod_assign/feedback/feedback-v{version}.pdf"
+                ),
+                "timemodified": 100 + int(version),
+            }
+        ]
+
+    def quiz_attempts(session, wstoken, quiz_id):
+        calls["attempts"] += 1
+        return [{"id": 5}]
+
+    def quiz_review(session, wstoken, attempt_id):
+        calls["review"] += 1
+        return {"questions": [{"html": f"<p>Review v{state['version']}</p>"}]}
+
+    def course_updates(session, wstoken, course_id, since, log):
+        update_calls.append(since)
+        return moodle.CourseUpdates(since, state["changed"], frozenset())
+
+    monkeypatch.setattr(moodle, "get_assignment_submission_files", submission_files)
+    monkeypatch.setattr(moodle, "get_quiz_attempts", quiz_attempts)
+    monkeypatch.setattr(moodle, "get_quiz_attempt_review", quiz_review)
+    monkeypatch.setattr(moodle, "get_course_updates_since", course_updates)
+
+    def run_at(watermark):
+        context = make_context(
+            {
+                "paths.sync_directory": str(tmp_path),
+                "modules.assignment": True,
+                "modules.quiz": "html",
+            }
+        )
+        context.session = FakeSession()
+        context.moodle_functions = frozenset({moodle.MOODLE_UPDATE_FUNCTION})
+        context.moodle_update_watermark = watermark
+        sync.sync(context)
+        return context
+
+    first = run_at(100)
+    course_cache.cache_root_node(first)
+    second = run_at(200)
+
+    assert update_calls == [100]
+    assert calls == {"submission": 1, "attempts": 1, "review": 1}
+    node_at_path(
+        second.root_node,
+        [
+            "26ss",
+            "Cached Course",
+            "General",
+            "Assignment",
+            "feedback-v1.pdf",
+        ],
+    )
+    review_url = "https://moodle.rwth-aachen.de/mod/quiz/review.php?attempt=5"
+    assert "Review v1" in second.quiz_review_cache[review_url]
+    course_cache.cache_root_node(second)
+
+    state["version"] = 2
+    state["changed"] = frozenset({42, 43})
+    third = run_at(300)
+
+    assert update_calls == [100, 200]
+    assert calls == {"submission": 2, "attempts": 2, "review": 2}
+    node_at_path(
+        third.root_node,
+        [
+            "26ss",
+            "Cached Course",
+            "General",
+            "Assignment",
+            "feedback-v2.pdf",
+        ],
+    )
+    assert "Review v2" in third.quiz_review_cache[review_url]
+
+    # Moodle's update callback does not reliably cover a teammate changing the
+    # shared group submission, so those assignments must keep using live data.
+    course_cache.cache_root_node(third)
+    assignments["assignments"][0]["teamsubmission"] = 1
+    state["version"] = 3
+    state["changed"] = frozenset()
+    team_run = run_at(400)
+
+    assert update_calls == [100, 200, 300]
+    assert calls == {"submission": 3, "attempts": 2, "review": 2}
+    node_at_path(
+        team_run.root_node,
+        [
+            "26ss",
+            "Cached Course",
+            "General",
+            "Assignment",
+            "feedback-v3.pdf",
+        ],
+    )
+
+
+def test_failed_update_feed_is_tried_only_once_per_run(monkeypatch, caplog):
+    courses = [
+        {"id": 901, "shortname": "First", "idnumber": "26ss-first"},
+        {"id": 902, "shortname": "Second", "idnumber": "26ss-second"},
+    ]
+    course_contents = {
+        course_id: [
+            {
+                "id": 1000 + course_id,
+                "name": "General",
+                "modules": [
+                    {
+                        "id": course_id,
+                        "instance": course_id,
+                        "modname": "assign",
+                        "name": "Assignment",
+                    }
+                ],
+            }
+        ]
+        for course_id in (901, 902)
+    }
+    install_moodle_fixtures(monkeypatch, courses, course_contents)
+    monkeypatch.setattr(
+        course_cache,
+        "get_assignment_cache_entry",
+        lambda ctx, course_node, module_id, log: course_cache.AssignmentCacheEntry(
+            100, []
+        ),
+    )
+    update_calls = []
+
+    def failed_update(session, wstoken, course_id, since, log):
+        update_calls.append(course_id)
+        return None
+
+    monkeypatch.setattr(moodle, "get_course_updates_since", failed_update)
+    context = make_context({"modules.assignment": True})
+    context.session = FakeSession()
+    context.moodle_functions = frozenset({moodle.MOODLE_UPDATE_FUNCTION})
+    caplog.set_level(logging.INFO, logger="syncmymoodle.sync")
+
+    sync.sync(context)
+
+    assert update_calls == [901]
+    assert moodle.MOODLE_UPDATE_FUNCTION not in context.moodle_functions
+    assert (
+        caplog.messages.count(
+            "Moodle incremental update checks are unavailable; using full module "
+            "queries for this run"
+        )
+        == 1
+    )
 
 
 def test_nested_moodle_folder_paths_are_preserved(monkeypatch):

--- a/tests/test_sync_fixtures.py
+++ b/tests/test_sync_fixtures.py
@@ -4,7 +4,7 @@ import zipfile
 
 import requests
 
-from syncmymoodle import links, opencast, sciebo, sync, sync_handlers
+from syncmymoodle import course_cache, links, opencast, sciebo, sync, sync_handlers
 from syncmymoodle.constants import HTTP_TIMEOUT_SECONDS
 from syncmymoodle.node import Node
 
@@ -66,6 +66,13 @@ def test_page_http_failure_is_counted(caplog):
     assert "Page module 123 returned status 503" in caplog.text
 
 
+def h5p_package(content: str) -> bytes:
+    package = io.BytesIO()
+    with zipfile.ZipFile(package, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("content/content.json", content)
+    return package.getvalue()
+
+
 def run_h5p_handler(monkeypatch, response):
     ctx = make_context()
     session = FakeSession()
@@ -94,6 +101,51 @@ def run_h5p_handler(monkeypatch, response):
     )
 
     return section_node
+
+
+def run_cached_h5p_handler(
+    monkeypatch,
+    tmp_path,
+    content_hash,
+    response=None,
+    *,
+    timemodified=None,
+):
+    ctx = make_context({"paths.sync_directory": str(tmp_path)})
+    session = FakeSession()
+    if response is not None:
+        session.add("GET", H5P_PACKAGE_URL, response)
+    ctx.session = session
+    monkeypatch.setattr(
+        sync_handlers.moodle_api,
+        "get_h5pactivities_by_course",
+        lambda session, wstoken, course_id: [
+            {
+                "coursemodule": 317,
+                "contenthash": content_hash,
+                "timemodified": timemodified,
+                "package": [{"fileurl": H5P_PACKAGE_URL}],
+            }
+        ],
+    )
+    root = Node("", -1, "Root", None)
+    semester_node = root.add_child("26ss", None, "Semester")
+    assert semester_node is not None
+    course_node = semester_node.add_child("Course", 1, "Course")
+    assert course_node is not None
+    section_node = course_node.add_child("Section", 2, "Section")
+    assert section_node is not None
+    ctx.root_node = root
+    module_context = sync_handlers.ModuleContext(
+        ctx, 1, course_node, section_node, {}, {}
+    )
+
+    sync_handlers.handle_embedded_link_module(
+        module_context,
+        {"id": 317, "modname": "h5pactivity", "name": "Interactive video"},
+    )
+
+    return ctx, section_node, session
 
 
 def test_h5p_package_download_is_streamed_and_capped(monkeypatch, caplog):
@@ -149,6 +201,96 @@ def test_large_h5p_package_is_spooled_and_inspected(monkeypatch):
     assert section_node.children[0].url == (
         "https://www.youtube.com/watch?v=abcdefghijk"
     )
+
+
+def test_h5p_content_cache_reuses_unchanged_and_refreshes_changed_packages(
+    monkeypatch, tmp_path
+):
+    first_url = "https://www.youtube.com/watch?v=abcdefghijk"
+    first, first_section, first_session = run_cached_h5p_handler(
+        monkeypatch,
+        tmp_path,
+        "a" * 40,
+        FakeResponse(content=h5p_package(first_url)),
+    )
+    course_cache.cache_root_node(first)
+
+    _, cached_section, cached_session = run_cached_h5p_handler(
+        monkeypatch,
+        tmp_path,
+        "a" * 40,
+    )
+
+    assert first_session.count("GET", H5P_PACKAGE_URL) == 1
+    assert cached_session.count("GET", H5P_PACKAGE_URL) == 0
+    assert [child.url for child in first_section.children] == [first_url]
+    assert [child.url for child in cached_section.children] == [first_url]
+
+    changed_url = "https://www.youtube.com/watch?v=zyxwvutsrqp"
+    changed, changed_section, changed_session = run_cached_h5p_handler(
+        monkeypatch,
+        tmp_path,
+        "b" * 40,
+        FakeResponse(content=h5p_package(changed_url)),
+    )
+    course_cache.cache_root_node(changed)
+
+    assert changed_session.count("GET", H5P_PACKAGE_URL) == 1
+    assert [child.url for child in changed_section.children] == [changed_url]
+
+    _, refreshed_section, refreshed_session = run_cached_h5p_handler(
+        monkeypatch,
+        tmp_path,
+        "b" * 40,
+    )
+
+    assert refreshed_session.count("GET", H5P_PACKAGE_URL) == 0
+    assert [child.url for child in refreshed_section.children] == [changed_url]
+
+
+def test_h5p_timestamp_marker_is_used_when_content_hash_is_missing(
+    monkeypatch, tmp_path
+):
+    video_url = "https://www.youtube.com/watch?v=abcdefghijk"
+    first, _, _ = run_cached_h5p_handler(
+        monkeypatch,
+        tmp_path,
+        None,
+        FakeResponse(content=h5p_package(video_url)),
+        timemodified=1234,
+    )
+    course_cache.cache_root_node(first)
+
+    _, cached_section, cached_session = run_cached_h5p_handler(
+        monkeypatch,
+        tmp_path,
+        None,
+        timemodified=1234,
+    )
+
+    assert cached_session.count("GET", H5P_PACKAGE_URL) == 0
+    assert [child.url for child in cached_section.children] == [video_url]
+
+
+def test_h5p_without_a_revision_marker_is_downloaded_each_run(monkeypatch, tmp_path):
+    video_url = "https://www.youtube.com/watch?v=abcdefghijk"
+    first, _, first_session = run_cached_h5p_handler(
+        monkeypatch,
+        tmp_path,
+        None,
+        FakeResponse(content=h5p_package(video_url)),
+    )
+    course_cache.cache_root_node(first)
+
+    _, _, second_session = run_cached_h5p_handler(
+        monkeypatch,
+        tmp_path,
+        None,
+        FakeResponse(content=h5p_package(video_url)),
+    )
+
+    assert first_session.count("GET", H5P_PACKAGE_URL) == 1
+    assert second_session.count("GET", H5P_PACKAGE_URL) == 1
 
 
 def test_nested_moodle_folder_paths_are_preserved(monkeypatch):


### PR DESCRIPTION
Reduce repeat-sync time by caching derived page, assignment, and quiz data and using Moodle’s update metadata to avoid unnecessary API requests.

The cache invalidates conservatively and falls back to full queries whenever Moodle cannot reliably report changes, preserving existing sync behavior.
 
Also: No longer re-download h5p archives during every sync, drastically reducing sync time for certain courses.