### PR TITLE
Avoid repeated requests during sync

### DIFF
--- a/syncmymoodle/context.py
+++ b/syncmymoodle/context.py
@@ -17,7 +17,10 @@ from syncmymoodle.output import TerminalOutput, get_output
 if TYPE_CHECKING:
     from syncmymoodle.course_cache import CourseCacheState
     from syncmymoodle.emedia import EmediaVideo
-    from syncmymoodle.opencast import OpencastTrack
+    from syncmymoodle.opencast import (
+        OpencastEpisode,
+        OpencastMetadataState,
+    )
 
 
 # Retain a small overlap so a change committed at the integer-second token
@@ -83,6 +86,19 @@ class FilteredItem:
     reason: str
 
 
+@dataclass(frozen=True)
+class LinkedResourceCacheEntry:
+    """Revalidation metadata and optional HTML for one followed link."""
+
+    final_url: str
+    content_type: str
+    html: str | None = None
+    etag: str | None = None
+    last_modified: str | None = None
+    fresh_until: float | None = None
+    remote_size: int | None = None
+
+
 @dataclass
 class SyncContext:
     config: Config
@@ -113,10 +129,17 @@ class SyncContext:
     # None negatively caches a share that already failed during this run.
     sciebo_link_cache: dict[str, Node | None] = field(default_factory=dict)
     service_outages: ServiceOutageTracker = field(default_factory=ServiceOutageTracker)
-    opencast_episode_auth_cache: set[tuple[Any, str]] = field(default_factory=set)
-    opencast_track_cache: dict[str, tuple[OpencastTrack, ...]] = field(
+    opencast_course_auth_cache: set[tuple[str, str]] = field(default_factory=set)
+    opencast_episode_cache: dict[tuple[str | None, str], OpencastEpisode] = field(
         default_factory=dict
     )
+    opencast_seen_episodes: set[tuple[str, str]] = field(default_factory=set)
+    opencast_metadata_states: dict[tuple[str | None, str], OpencastMetadataState] = (
+        field(default_factory=dict)
+    )
+    opencast_series_cache: dict[
+        tuple[str | None, str], tuple[tuple[str, str], ...] | None
+    ] = field(default_factory=dict)
     emedia_video_cache: dict[int, EmediaVideo | None] = field(default_factory=dict)
     emedia_revision_cache: dict[str, str] = field(default_factory=dict)
     emedia_output_suffix: str | None = None
@@ -126,6 +149,13 @@ class SyncContext:
     lti_instance_cache: dict[int, dict[str, Any]] = field(default_factory=dict)
     h5p_activity_cache: dict[int, dict[str, Any]] = field(default_factory=dict)
     quiz_instance_cache: dict[int, dict[str, Any]] = field(default_factory=dict)
+    linked_resources_by_course: dict[str, dict[str, LinkedResourceCacheEntry]] = field(
+        default_factory=dict
+    )
+    linked_resource_results: dict[str, LinkedResourceCacheEntry | None] = field(
+        default_factory=dict
+    )
+    seen_linked_resources: set[tuple[str, str]] = field(default_factory=set)
 
     def __post_init__(self) -> None:
         self.auth = AuthState.from_config(self.config)

--- a/syncmymoodle/course_cache.py
+++ b/syncmymoodle/course_cache.py
@@ -1,11 +1,13 @@
 import logging
+import math
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from syncmymoodle import links
+from syncmymoodle import links, opencast
 from syncmymoodle.constants import COURSE_CACHE_FILENAME
-from syncmymoodle.context import SyncContext
+from syncmymoodle.context import LinkedResourceCacheEntry, SyncContext
+from syncmymoodle.http_utils import HTML_CONTENT_TYPES, normalized_http_origin
 from syncmymoodle.node import (
     NAME_CLASH_ID_UNSET,
     DownloadStatus,
@@ -18,6 +20,10 @@ logger = logging.getLogger(__name__)
 COURSE_CACHE_FORMAT = "syncmymoodle.course-cache.v1"
 MODULE_CACHE_KEY = "module_data"
 CACHED_TEXT_CACHE_KEY = "cached_text"
+OPENCAST_EPISODES_CACHE_KEY = "opencast_episodes"
+OPENCAST_EPISODES_CACHE_FORMAT = "syncmymoodle.opencast-episodes.v1"
+LINKED_RESOURCES_CACHE_KEY = "linked_resources"
+LINKED_RESOURCES_CACHE_FORMAT = "syncmymoodle.linked-resources.v1"
 H5P_CONTENT_KIND = "h5p"
 PAGE_CONTENT_KIND = "page"
 CACHED_TEXT_KINDS = (H5P_CONTENT_KIND, PAGE_CONTENT_KIND)
@@ -53,6 +59,9 @@ class CourseCacheState:
     )
     assignments: dict[int, AssignmentCacheEntry] = field(default_factory=dict)
     quizzes: dict[int, QuizCacheEntry] = field(default_factory=dict)
+    opencast_episodes: dict[str, opencast.OpencastEpisode] = field(default_factory=dict)
+    linked_resources: dict[str, LinkedResourceCacheEntry] = field(default_factory=dict)
+    complete_module_inventory: bool = False
 
 
 def _node_path(ctx: SyncContext, node: Node) -> Path:
@@ -172,6 +181,114 @@ def _quiz_cache_entries(value: Any) -> dict[int, QuizCacheEntry]:
     return entries
 
 
+def _opencast_episode_entries(
+    value: Any,
+) -> dict[str, opencast.OpencastEpisode]:
+    entries: dict[str, opencast.OpencastEpisode] = {}
+    if (
+        not isinstance(value, dict)
+        or value.get("format") != OPENCAST_EPISODES_CACHE_FORMAT
+        or not isinstance(value.get("episodes"), dict)
+    ):
+        return entries
+    for episode_id, raw_episode in value["episodes"].items():
+        if not isinstance(episode_id, str) or not episode_id:
+            continue
+        episode = opencast.episode_from_cache_data(raw_episode)
+        if episode is not None:
+            entries[episode_id] = episode
+    return entries
+
+
+def _linked_resource_entries(value: Any) -> dict[str, LinkedResourceCacheEntry]:
+    entries: dict[str, LinkedResourceCacheEntry] = {}
+    if (
+        not isinstance(value, dict)
+        or value.get("format") != LINKED_RESOURCES_CACHE_FORMAT
+        or not isinstance(value.get("resources"), dict)
+    ):
+        return entries
+    for requested_url, raw_entry in value["resources"].items():
+        if (
+            not isinstance(requested_url, str)
+            or normalized_http_origin(requested_url) is None
+        ):
+            continue
+        if not isinstance(raw_entry, dict):
+            continue
+        final_url = raw_entry.get("final_url")
+        content_type = raw_entry.get("content_type")
+        html = raw_entry.get("html")
+        etag = raw_entry.get("etag")
+        last_modified = raw_entry.get("last_modified")
+        fresh_until = raw_entry.get("fresh_until")
+        remote_size = raw_entry.get("remote_size")
+        if (
+            not isinstance(final_url, str)
+            or normalized_http_origin(final_url) is None
+            or not isinstance(content_type, str)
+            or not content_type
+            or (html is not None and not isinstance(html, str))
+            or ((content_type in HTML_CONTENT_TYPES) != isinstance(html, str))
+            or (etag is not None and (not isinstance(etag, str) or not etag))
+            or (
+                last_modified is not None
+                and (not isinstance(last_modified, str) or not last_modified)
+            )
+            or (
+                fresh_until is not None
+                and (
+                    not isinstance(fresh_until, (int, float))
+                    or isinstance(fresh_until, bool)
+                    or not math.isfinite(fresh_until)
+                    or fresh_until < 0
+                )
+            )
+            or (
+                remote_size is not None
+                and (
+                    not isinstance(remote_size, int)
+                    or isinstance(remote_size, bool)
+                    or remote_size < 0
+                )
+            )
+        ):
+            continue
+        entries[requested_url] = LinkedResourceCacheEntry(
+            final_url,
+            content_type,
+            html,
+            etag,
+            last_modified,
+            float(fresh_until) if fresh_until is not None else None,
+            remote_size,
+        )
+    return entries
+
+
+def _course_linked_resources(
+    ctx: SyncContext,
+    course_id: int | None,
+    raw_cache: dict[str, Any],
+    personal_cache_matches: bool,
+) -> dict[str, LinkedResourceCacheEntry]:
+    linked_resources = (
+        _linked_resource_entries(raw_cache.get(LINKED_RESOURCES_CACHE_KEY))
+        if personal_cache_matches
+        else {}
+    )
+    if course_id is None:
+        return linked_resources
+    course_key = str(course_id)
+    runtime_resources = ctx.linked_resources_by_course.get(course_key)
+    if runtime_resources is None:
+        ctx.linked_resources_by_course[course_key] = linked_resources
+        return linked_resources
+    for requested_url, entry in linked_resources.items():
+        runtime_resources.setdefault(requested_url, entry)
+    return runtime_resources
+
+
 def _course_cache_state(
     ctx: SyncContext,
     course_node: Node,
@@ -212,6 +329,13 @@ def _course_cache_state(
         current_user_id is not None
         and raw_cache.get("owner_user_id") == current_user_id
     )
+    course_id = _module_id(course_node.id)
+    linked_resources = _course_linked_resources(
+        ctx,
+        course_id,
+        raw_cache,
+        personal_cache_matches,
+    )
     state = CourseCacheState(
         course_root=course_root,
         cached_text={
@@ -228,7 +352,19 @@ def _course_cache_state(
             if personal_cache_matches
             else {}
         ),
+        opencast_episodes=(
+            _opencast_episode_entries(raw_cache.get(OPENCAST_EPISODES_CACHE_KEY))
+            if personal_cache_matches
+            else {}
+        ),
+        linked_resources=linked_resources,
     )
+    if course_id is not None:
+        for episode_id, episode in state.opencast_episodes.items():
+            ctx.opencast_episode_cache.setdefault(
+                (str(course_id), episode_id),
+                episode,
+            )
     ctx.course_cache_states[course_node] = state
     return state
 
@@ -355,6 +491,7 @@ def retain_current_modules(
             module_ids[modname].add(module_id)
 
     state = _course_cache_state(ctx, course_node, log)
+    state.complete_module_inventory = True
     caches = (
         (state.cached_text[H5P_CONTENT_KIND], module_ids["h5pactivity"]),
         (state.cached_text[PAGE_CONTENT_KIND], module_ids["page"]),
@@ -380,11 +517,80 @@ def _cached_text_data(
     }
 
 
+def _opencast_episodes_data(
+    entries: dict[str, opencast.OpencastEpisode],
+) -> dict[str, Any]:
+    return {
+        "format": OPENCAST_EPISODES_CACHE_FORMAT,
+        "episodes": {
+            episode_id: opencast.episode_cache_data(episode)
+            for episode_id, episode in sorted(entries.items())
+        },
+    }
+
+
+def _linked_resources_data(
+    entries: dict[str, LinkedResourceCacheEntry],
+) -> dict[str, Any]:
+    return {
+        "format": LINKED_RESOURCES_CACHE_FORMAT,
+        "resources": {
+            requested_url: {
+                "final_url": entry.final_url,
+                "content_type": entry.content_type,
+                **({"html": entry.html} if entry.html is not None else {}),
+                **({"etag": entry.etag} if entry.etag is not None else {}),
+                **(
+                    {"last_modified": entry.last_modified}
+                    if entry.last_modified is not None
+                    else {}
+                ),
+                **(
+                    {"fresh_until": entry.fresh_until}
+                    if entry.fresh_until is not None
+                    else {}
+                ),
+                **(
+                    {"remote_size": entry.remote_size}
+                    if entry.remote_size is not None
+                    else {}
+                ),
+            }
+            for requested_url, entry in sorted(entries.items())
+        },
+    }
+
+
 def _course_module_cache_data(
     ctx: SyncContext,
     state: CourseCacheState,
+    course_node: Node,
 ) -> dict[str, Any]:
     data: dict[str, Any] = {}
+    course_id = _module_id(course_node.id)
+    if course_id is not None:
+        course_key = str(course_id)
+        state.opencast_episodes = {
+            episode_id: episode
+            for (
+                cached_course_id,
+                episode_id,
+            ), episode in ctx.opencast_episode_cache.items()
+            if cached_course_id == course_key
+            and (course_key, episode_id) in ctx.opencast_seen_episodes
+        }
+        if state.complete_module_inventory:
+            seen_urls = {
+                requested_url
+                for seen_course, requested_url in ctx.seen_linked_resources
+                if seen_course == course_key
+            }
+            state.linked_resources = {
+                requested_url: entry
+                for requested_url, entry in state.linked_resources.items()
+                if requested_url in seen_urls
+            }
+            ctx.linked_resources_by_course[course_key] = state.linked_resources
     cached_text = {
         kind: _cached_text_data(state.cached_text[kind], kind)
         for kind in CACHED_TEXT_KINDS
@@ -392,7 +598,12 @@ def _course_module_cache_data(
     }
     if cached_text:
         data[CACHED_TEXT_CACHE_KEY] = cached_text
-    if state.assignments or state.quizzes:
+    if (
+        state.assignments
+        or state.quizzes
+        or state.opencast_episodes
+        or state.linked_resources
+    ):
         if ctx.moodle_account is None:
             return data
         data["owner_user_id"] = ctx.moodle_account.user_id
@@ -415,6 +626,14 @@ def _course_module_cache_data(
             }
             for module_id, entry in sorted(state.quizzes.items())
         }
+    if state.opencast_episodes:
+        data[OPENCAST_EPISODES_CACHE_KEY] = _opencast_episodes_data(
+            state.opencast_episodes
+        )
+    if state.linked_resources:
+        data[LINKED_RESOURCES_CACHE_KEY] = _linked_resources_data(
+            state.linked_resources
+        )
     return data
 
 
@@ -608,7 +827,7 @@ def cache_root_node(
                 "format": COURSE_CACHE_FORMAT,
                 "course": node_to_cache_data(ctx, course_node, state.course_root),
             }
-            module_cache = _course_module_cache_data(ctx, state)
+            module_cache = _course_module_cache_data(ctx, state, course_node)
             if module_cache:
                 payload[MODULE_CACHE_KEY] = module_cache
             write_private_gzip_json(cache_path, payload)

--- a/syncmymoodle/downloader.py
+++ b/syncmymoodle/downloader.py
@@ -14,7 +14,7 @@ from typing import Any
 import requests
 import yt_dlp
 
-from syncmymoodle import course_cache, filters, links, pathing, quiz
+from syncmymoodle import course_cache, filters, links, opencast, pathing, quiz
 from syncmymoodle.constants import (
     DEFAULT_BLOCK_SIZE,
     HASH_ALGOS_BY_LENGTH,
@@ -294,6 +294,12 @@ def conditional_get_confirms_unchanged(
     download_origin = normalized_http_origin(node.url)
     if download_origin and ctx.service_outages.should_skip(download_origin):
         return False
+    if node.type == "Opencast":
+        if ctx.config.dry_run:
+            return False
+        authorized, _ = authorize_opencast_download(ctx, node, log)
+        if not authorized:
+            return False
 
     headers: dict[str, str] = {"If-None-Match": old_etag}
     if node.download_headers:
@@ -584,6 +590,13 @@ def download_violates_size_limits(
     return record_size_limit_filter(ctx, str(downloadpath), total_size, "size")
 
 
+def _opencast_course_node(node: Node) -> Node | None:
+    try:
+        return course_cache.get_course_node(node)
+    except Exception:
+        return None
+
+
 def planned_download_action(
     ctx: SyncContext,
     node: Node,
@@ -594,6 +607,22 @@ def planned_download_action(
     early_outcome = should_skip_before_decision(ctx, node, downloadpath)
     if early_outcome is not None:
         return early_outcome
+    if node.type == "Opencast":
+        course_node = _opencast_course_node(node)
+        course_id = course_node.id if course_node is not None else None
+        if opencast.episode_metadata_is_stale(
+            ctx,
+            course_id,
+            str(node.id or ""),
+        ):
+            if downloadpath.exists() and not ctx.config.update_files:
+                return UNCHANGED_DOWNLOAD
+            log.warning(
+                "Skipping Opencast download %s because its metadata could not be "
+                "refreshed",
+                downloadpath,
+            )
+            return FAILED_DOWNLOAD
     if known_remote_size_violates_limit(ctx, node, downloadpath):
         return HANDLED_DOWNLOAD
 
@@ -861,6 +890,32 @@ def _classify_download_response(
     return failure_kind
 
 
+def authorize_opencast_download(
+    ctx: SyncContext,
+    node: Node,
+    log: logging.Logger,
+) -> tuple[bool, Any]:
+    course_node = _opencast_course_node(node)
+    if course_node is None:
+        log.warning("Cannot authorize Opencast download outside a course")
+        return False, None
+    episode_id = str(node.id or "")
+    if not episode_id:
+        log.warning("Cannot authorize Opencast download without an episode id")
+        return False, course_node.id
+    if not opencast.course_is_authorized(ctx, course_node.id):
+        ctx.output.action("Authorizing", course_node.name, "Opencast")
+    return (
+        opencast.authorize_course_for_episode(
+            ctx,
+            course_node.id,
+            episode_id,
+            log,
+        ),
+        course_node.id,
+    )
+
+
 def download_file(
     ctx: SyncContext,
     node: Node,
@@ -882,8 +937,16 @@ def download_file(
         return action_or_outcome
     action = action_or_outcome
 
-    if ctx.config.dry_run and not size_limits_configured(ctx):
+    if ctx.config.dry_run and (
+        node.type == "Opencast" or not size_limits_configured(ctx)
+    ):
         return report_planned_download(ctx, downloadpath, node.type)
+
+    opencast_course_id: Any = None
+    if node.type == "Opencast":
+        authorized, opencast_course_id = authorize_opencast_download(ctx, node, log)
+        if not authorized:
+            return FAILED_DOWNLOAD
 
     transfer = None if ctx.config.dry_run else prepare_transfer_plan(node, downloadpath)
     headers = (
@@ -918,7 +981,7 @@ def download_file(
         )
         if failure_kind is HttpFailureKind.TRANSIENT:
             return FAILED_DOWNLOAD
-        return process_download_response(
+        outcome = process_download_response(
             ctx,
             node,
             response,
@@ -927,6 +990,20 @@ def download_file(
             action,
             log,
         )
+        if (
+            node.type == "Opencast"
+            and not outcome.is_handled
+            and (
+                response.status_code in {401, 403, 404, 410}
+                or content_type_without_parameters(response) in HTML_CONTENT_TYPES
+            )
+        ):
+            opencast.invalidate_episode(
+                ctx,
+                opencast_course_id,
+                str(node.id or ""),
+            )
+        return outcome
 
 
 def download_all_files(

--- a/syncmymoodle/http_utils.py
+++ b/syncmymoodle/http_utils.py
@@ -19,7 +19,14 @@ from syncmymoodle.constants import DEFAULT_BLOCK_SIZE
 HTML_CONTENT_TYPES = frozenset({"text/html", "application/xhtml+xml"})
 _REDIRECT_STATUS_CODES = frozenset({301, 302, 303, 307, 308})
 _SENSITIVE_REDIRECT_HEADERS = frozenset(
-    {"authorization", "cookie", "proxy-authorization", "requesttoken"}
+    {
+        "authorization",
+        "cookie",
+        "if-modified-since",
+        "if-none-match",
+        "proxy-authorization",
+        "requesttoken",
+    }
 )
 _SENSITIVE_QUERY_PARAMETER_NAMES = frozenset(
     {

--- a/syncmymoodle/links.py
+++ b/syncmymoodle/links.py
@@ -1,5 +1,7 @@
 import logging
+import time
 import urllib.parse
+from collections.abc import Callable
 from contextlib import closing
 from typing import Any, cast
 
@@ -18,7 +20,7 @@ from syncmymoodle.constants import (
     YOUTUBE_LINK_RE,
     YOUTUBE_WATCH_URL,
 )
-from syncmymoodle.context import SyncContext
+from syncmymoodle.context import LinkedResourceCacheEntry, SyncContext
 from syncmymoodle.http_utils import (
     HTML_CONTENT_TYPES,
     HttpFailureKind,
@@ -37,6 +39,361 @@ from syncmymoodle.http_utils import (
 from syncmymoodle.node import Node, RemoteMarkerKind
 
 logger = logging.getLogger(__name__)
+
+
+def _response_header(response: Any, name: str) -> str | None:
+    for header_name, value in response.headers.items():
+        if str(header_name).lower() == name.lower() and value:
+            return str(value)
+    return None
+
+
+def _cache_policy(response: Any) -> tuple[bool, float | None]:
+    directives: dict[str, str | None] = {}
+    for directive in (_response_header(response, "Cache-Control") or "").split(","):
+        name, separator, value = directive.strip().partition("=")
+        name = name.strip().lower()
+        if name:
+            directives[name] = value.strip().strip('"') if separator else None
+    if "no-store" in directives:
+        return False, None
+    if "no-cache" in directives or "max-age" not in directives:
+        return True, None
+    try:
+        max_age = int(directives["max-age"] or "")
+        age = max(0, int(_response_header(response, "Age") or "0"))
+    except ValueError:
+        return True, None
+    if max_age < 0:
+        return True, None
+    return True, time.time() + max(0, max_age - age)
+
+
+def _response_cache_entry(
+    response: Any,
+    html: str | None,
+) -> tuple[LinkedResourceCacheEntry, bool]:
+    cacheable, fresh_until = _cache_policy(response)
+    content_type = content_type_without_parameters(response)
+    if not content_type:
+        content_type = "text/html" if html is not None else "application/octet-stream"
+    return (
+        LinkedResourceCacheEntry(
+            final_url=str(response.url),
+            content_type=content_type,
+            html=html,
+            etag=_response_header(response, "ETag"),
+            last_modified=_response_header(response, "Last-Modified"),
+            fresh_until=fresh_until,
+            remote_size=content_length(response),
+        ),
+        cacheable,
+    )
+
+
+def _revalidated_cache_entry(
+    cached: LinkedResourceCacheEntry,
+    response: Any,
+) -> tuple[LinkedResourceCacheEntry, bool]:
+    cacheable, fresh_until = _cache_policy(response)
+    remote_size = content_length(response)
+    return (
+        LinkedResourceCacheEntry(
+            final_url=cached.final_url,
+            content_type=cached.content_type,
+            html=cached.html,
+            etag=_response_header(response, "ETag") or cached.etag,
+            last_modified=(
+                _response_header(response, "Last-Modified") or cached.last_modified
+            ),
+            fresh_until=fresh_until,
+            remote_size=(
+                remote_size if remote_size is not None else cached.remote_size
+            ),
+        ),
+        cacheable,
+    )
+
+
+def _conditional_headers(cached: LinkedResourceCacheEntry | None) -> dict[str, str]:
+    if cached is None:
+        return {}
+    headers = {}
+    if cached.etag:
+        headers["If-None-Match"] = cached.etag
+    if cached.last_modified:
+        headers["If-Modified-Since"] = cached.last_modified
+    return headers
+
+
+def _head_linked_resource(
+    ctx: SyncContext,
+    url: str,
+    cached: LinkedResourceCacheEntry | None,
+    url_allowed: Callable[[str], bool],
+) -> tuple[LinkedResourceCacheEntry | None, str, str | None, bool]:
+    headers = _conditional_headers(cached)
+    conditional = bool(headers)
+    while True:
+        response = request_following_safe_redirects(
+            ctx.require_session(),
+            "HEAD",
+            url,
+            url_allowed,
+            headers=headers,
+            timeout=HTTP_TIMEOUT_SECONDS,
+        )
+        with closing(response):
+            final_url = str(response.url or url)
+            request_origin = normalized_http_origin(final_url)
+            if (
+                response.status_code == 304
+                and conditional
+                and cached is not None
+                and final_url == cached.final_url
+            ):
+                entry, cacheable = _revalidated_cache_entry(cached, response)
+                return entry, final_url, request_origin, cacheable
+            if response.status_code == 304 and conditional:
+                headers = {}
+                conditional = False
+                continue
+            content_type = content_type_without_parameters(response)
+            if (
+                200 <= response.status_code < 300
+                and content_type
+                and content_type not in HTML_CONTENT_TYPES
+            ):
+                entry, cacheable = _response_cache_entry(response, None)
+                return entry, final_url, request_origin, cacheable
+            return None, final_url, request_origin, True
+
+
+def _get_linked_resource(
+    ctx: SyncContext,
+    url: str,
+    cached: LinkedResourceCacheEntry | None,
+    url_allowed: Callable[[str], bool],
+    request_origin: str | None,
+    log: logging.Logger,
+) -> tuple[LinkedResourceCacheEntry | None, bool]:
+    headers = _conditional_headers(cached)
+    conditional = bool(headers)
+    while True:
+        response = request_following_safe_redirects(
+            ctx.require_session(),
+            "GET",
+            url,
+            url_allowed,
+            headers=headers,
+            stream=True,
+            timeout=HTTP_TIMEOUT_SECONDS,
+        )
+        with closing(response):
+            final_url = str(response.url or url)
+            response_origin = normalized_http_origin(final_url) or request_origin
+            if request_origin and response_origin != request_origin:
+                ctx.service_outages.record_available(request_origin)
+            if (
+                response.status_code == 304
+                and conditional
+                and cached is not None
+                and final_url == cached.final_url
+            ):
+                if response_origin:
+                    ctx.service_outages.record_available(response_origin)
+                return _revalidated_cache_entry(cached, response)
+            if response.status_code == 304 and conditional:
+                headers = {}
+                conditional = False
+                continue
+
+            failure_kind = classify_http_failure(response.status_code)
+            if failure_kind is not None:
+                if response_origin:
+                    record_service_failure(
+                        ctx.service_outages,
+                        response_origin,
+                        f"Link origin {response_origin}",
+                        failure_kind,
+                        f"GET {redact_url_secrets(final_url)} returned HTTP "
+                        f"{response.status_code}",
+                        log,
+                    )
+                return None, True
+
+            if response_origin:
+                ctx.service_outages.record_available(response_origin)
+            content_type = content_type_without_parameters(response)
+            html = (
+                None
+                if content_type and content_type not in HTML_CONTENT_TYPES
+                else response.text
+            )
+            return _response_cache_entry(response, html)
+
+
+def _fresh_cached_resource(
+    ctx: SyncContext,
+    cached: LinkedResourceCacheEntry | None,
+) -> tuple[bool, LinkedResourceCacheEntry | None]:
+    if (
+        cached is None
+        or cached.fresh_until is None
+        or time.time() >= cached.fresh_until
+    ):
+        return False, None
+    if filters.should_skip_url(ctx, cached.final_url, "cached linked resource"):
+        return True, None
+    return True, cached
+
+
+def _handle_link_request_error(
+    ctx: SyncContext,
+    url: str,
+    request_origin: str | None,
+    error: requests.RequestException,
+    log: logging.Logger,
+) -> tuple[None, bool]:
+    reason = (
+        f"request for {redact_url_secrets(url)} failed: {safe_request_error(error)}"
+    )
+    failure_kind = classify_request_failure(error)
+    if request_origin:
+        record_service_failure(
+            ctx.service_outages,
+            request_origin,
+            f"Link origin {request_origin}",
+            failure_kind,
+            reason,
+            log,
+        )
+    if failure_kind is not HttpFailureKind.TRANSIENT and not isinstance(
+        error, filters.FilteredRequestError
+    ):
+        log.warning("Skipping link request: %s", reason)
+    return None, True
+
+
+def _resolve_linked_resource(
+    ctx: SyncContext,
+    url: str,
+    cached: LinkedResourceCacheEntry | None,
+    log: logging.Logger,
+) -> tuple[LinkedResourceCacheEntry | None, bool]:
+    link_origin = normalized_http_origin(url)
+    request_origin = link_origin
+    use_cached, fresh_resource = _fresh_cached_resource(ctx, cached)
+    if use_cached:
+        return fresh_resource, True
+    if link_origin and ctx.service_outages.should_skip(link_origin):
+        return None, True
+
+    def url_allowed(candidate: str) -> bool:
+        return filters.require_url_allowed(ctx, candidate, "redirected link")
+
+    try:
+        if cached is not None and cached.html is not None and ctx.config.follow_links:
+            ctx.output.sync_progress.module_status("revalidating linked page")
+            return _get_linked_resource(
+                ctx,
+                url,
+                cached,
+                url_allowed,
+                request_origin,
+                log,
+            )
+
+        ctx.output.sync_progress.module_status("checking linked resource")
+        resource, final_url, final_origin, cacheable = _head_linked_resource(
+            ctx,
+            url,
+            cached,
+            url_allowed,
+        )
+        request_origin = final_origin or request_origin
+        if resource is not None:
+            if request_origin:
+                ctx.service_outages.record_available(request_origin)
+            return resource, cacheable
+
+        if not ctx.config.follow_links or (
+            request_origin and ctx.service_outages.should_skip(request_origin)
+        ):
+            return None, True
+        ctx.output.sync_progress.module_status("loading linked page")
+        return _get_linked_resource(
+            ctx,
+            final_url,
+            None,
+            url_allowed,
+            request_origin,
+            log,
+        )
+    except requests.RequestException as error:
+        return _handle_link_request_error(ctx, url, request_origin, error, log)
+
+
+def _known_provider_link(url: str) -> bool:
+    return bool(
+        YOUTUBE_LINK_RE.match(url)
+        or OPENCAST_LINK_RE.match(url)
+        or SCIEBO_LINK_RE.match(url)
+        or EMEDIA_LINK_RE.match(url)
+    )
+
+
+def _scan_single_link(
+    ctx: SyncContext,
+    url: str,
+    parent_node: Node,
+    course_id: Any,
+    module_title: Any,
+    log: logging.Logger,
+) -> bool:
+    """Resolve one generic link and return whether it is a direct file."""
+    if filters.should_skip_url(ctx, url, "link"):
+        return False
+    course_key = str(course_id)
+    cache = ctx.linked_resources_by_course.setdefault(course_key, {})
+    ctx.seen_linked_resources.add((course_key, url))
+    if url in ctx.linked_resource_results:
+        resource = ctx.linked_resource_results[url]
+        if resource is not None:
+            cache[url] = resource
+    else:
+        resource, cacheable = _resolve_linked_resource(ctx, url, cache.get(url), log)
+        if cacheable:
+            if resource is not None:
+                cache[url] = resource
+            ctx.linked_resource_results[url] = resource
+        else:
+            cache.pop(url, None)
+
+    if resource is None:
+        return False
+    if resource.html is None:
+        parent_node.add_child(
+            filename_from_url(resource.final_url),
+            None,
+            f"Linked file [{resource.content_type}]",
+            url=resource.final_url,
+            etag=resource.etag,
+            etag_kind=(RemoteMarkerKind.OPAQUE if resource.etag else None),
+            remote_size=resource.remote_size,
+        )
+        return True
+    if ctx.config.follow_links:
+        scan_html_text_for_links(
+            ctx,
+            resource.html,
+            resource.final_url,
+            parent_node,
+            course_id,
+            module_title=module_title,
+            log=log,
+        )
+    return False
 
 
 def youtube_video_id(link: str) -> str | None:
@@ -96,6 +453,7 @@ def scan_html_text_for_links(
         course_id,
         module_title=module_title,
         single=False,
+        log=log,
     )
 
 
@@ -109,141 +467,17 @@ def scan_for_links(  # noqa: C901 - legacy parser awaiting decomposition
     log: logging.Logger = logger,
 ) -> None:
     # A single link is supplied and the contents of it are checked
-    link_origin = normalized_http_origin(text) if single else None
-    is_sciebo_share = (
-        ctx.config.link_source_enabled("sciebo")
-        and SCIEBO_LINK_RE.fullmatch(text.split("?", 1)[0].split("#", 1)[0].rstrip("/"))
-        is not None
-    )
-    is_emedia_video = (
-        ctx.config.link_source_enabled("emedia")
-        and emedia_api.extract_video_id(text) is not None
-    )
-    origin_is_unavailable = bool(
-        link_origin and ctx.service_outages.should_skip(link_origin)
-    )
-    request_origin = link_origin
-    if (
-        single
-        and not is_sciebo_share
-        and not is_emedia_video
-        and not origin_is_unavailable
-    ):
-        try:
-            text = text.replace("webservice/pluginfile.php", "pluginfile.php")
-            if filters.should_skip_url(ctx, text, "link"):
-                return
-
-            ctx.output.sync_progress.module_status("checking linked resource")
-
-            def url_allowed(url: str) -> bool:
-                return filters.require_url_allowed(
-                    ctx,
-                    url,
-                    "redirected link",
-                )
-
-            response = request_following_safe_redirects(
-                ctx.require_session(),
-                "HEAD",
-                text,
-                url_allowed,
-                timeout=HTTP_TIMEOUT_SECONDS,
-            )
-            with closing(response):
-                final_url = response.url or text
-                request_origin = normalized_http_origin(final_url) or link_origin
-                content_type = content_type_without_parameters(response)
-                if "youtube.com" in text or "youtu.be" in text:
-                    # workaround for youtube providing bad headers when using HEAD
-                    pass
-                elif (
-                    200 <= response.status_code < 300
-                    and content_type
-                    and content_type not in HTML_CONTENT_TYPES
-                ):
-                    if request_origin:
-                        ctx.service_outages.record_available(request_origin)
-                    # non html links, assume the filename is in the path
-                    filename = filename_from_url(final_url)
-                    parent_node.add_child(
-                        filename,
-                        None,
-                        f"Linked file [{content_type}]",
-                        url=final_url,
-                        etag=response.headers.get("ETag"),
-                        etag_kind=(
-                            RemoteMarkerKind.OPAQUE
-                            if response.headers.get("ETag")
-                            else None
-                        ),
-                        remote_size=content_length(response),
-                    )
-                    # instantly return as it was a direct link
-                    return
-            target_is_unavailable = bool(
-                request_origin and ctx.service_outages.should_skip(request_origin)
-            )
-            if ctx.config.follow_links and not target_is_unavailable:
-                ctx.output.sync_progress.module_status("loading linked page")
-                response = request_following_safe_redirects(
-                    ctx.require_session(),
-                    "GET",
-                    final_url,
-                    url_allowed,
-                    timeout=HTTP_TIMEOUT_SECONDS,
-                )
-                with closing(response):
-                    response_origin = (
-                        normalized_http_origin(response.url or final_url)
-                        or request_origin
-                    )
-                    if request_origin and response_origin != request_origin:
-                        ctx.service_outages.record_available(request_origin)
-                    request_origin = response_origin
-                    failure_kind = classify_http_failure(response.status_code)
-                    if failure_kind is None:
-                        if request_origin:
-                            ctx.service_outages.record_available(request_origin)
-                        scan_html_text_for_links(
-                            ctx,
-                            response.text,
-                            response.url or final_url,
-                            parent_node,
-                            course_id,
-                            module_title=module_title,
-                        )
-                    else:
-                        if request_origin:
-                            assert failure_kind is not None
-                            record_service_failure(
-                                ctx.service_outages,
-                                request_origin,
-                                f"Link origin {request_origin}",
-                                failure_kind,
-                                f"GET {redact_url_secrets(response.url or final_url)} "
-                                f"returned HTTP {response.status_code}",
-                                log,
-                            )
-        except requests.RequestException as error:
-            reason = (
-                f"request for {redact_url_secrets(text)} failed: "
-                f"{safe_request_error(error)}"
-            )
-            failure_kind = classify_request_failure(error)
-            if request_origin:
-                record_service_failure(
-                    ctx.service_outages,
-                    request_origin,
-                    f"Link origin {request_origin}",
-                    failure_kind,
-                    reason,
-                    log,
-                )
-            if failure_kind is not HttpFailureKind.TRANSIENT and not isinstance(
-                error, filters.FilteredRequestError
-            ):
-                log.warning("Skipping link request: %s", reason)
+    if single:
+        text = text.replace("webservice/pluginfile.php", "pluginfile.php")
+        if not _known_provider_link(text) and _scan_single_link(
+            ctx,
+            text,
+            parent_node,
+            course_id,
+            module_title,
+            log,
+        ):
+            return
     if not ctx.config.follow_links:
         return
 
@@ -278,16 +512,13 @@ def scan_for_links(  # noqa: C901 - legacy parser awaiting decomposition
             if not vid_id:
                 log.warning(f"Opencast: could not extract episode id from url {vid}")
                 continue
-            ctx.output.sync_progress.module_status("authenticating Opencast video")
-            if not opencast_api.authenticate_episode(ctx, course_id, vid_id, log):
-                continue
-            ctx.output.sync_progress.module_status("resolving Opencast video")
             opencast_api.add_episode_nodes(
                 ctx,
                 parent_node,
                 module_title,
                 vid_id,
                 log,
+                course_id=course_id,
             )
 
     # VEIRA videos on the separate emedia Medizin Moodle service

--- a/syncmymoodle/moodle.py
+++ b/syncmymoodle/moodle.py
@@ -34,7 +34,7 @@ MOODLE_MOBILE_LAUNCH_URL = f"{MOODLE_URL}admin/tool/mobile/launch.php"
 MOODLE_MANAGE_TOKEN_URL = f"{MOODLE_URL}user/managetoken.php"
 MOBILE_URL_SCHEME = "syncmymoodle"
 MOODLE_MOBILE_USER_AGENT = "MoodleMobile syncMyMoodle"
-MOODLE_UPDATE_FUNCTION = "core_course_get_updates_since"
+MOODLE_UPDATE_FUNCTION = "core_course_check_updates"
 
 
 class MobileLaunchError(RuntimeError):
@@ -145,13 +145,15 @@ class TokenValidation:
 class CourseUpdates:
     """A conservative view of Moodle's per-module update feed."""
 
-    since: int
+    checked_since_by_module: dict[int, int]
     changed_module_ids: frozenset[int]
     unknown_module_ids: frozenset[int]
 
     def confirms_unchanged(self, module_id: int, cached_since: int) -> bool:
+        checked_since = self.checked_since_by_module.get(module_id)
         return (
-            cached_since >= self.since
+            checked_since is not None
+            and cached_since >= checked_since
             and module_id not in self.changed_module_ids
             and module_id not in self.unknown_module_ids
         )
@@ -575,19 +577,25 @@ def _unknown_module_ids(warnings: Any) -> frozenset[int] | None:
     return frozenset(unknown)
 
 
-def get_course_updates_since(
+def check_course_updates(
     session: requests.Session,
     wstoken: str,
     course_id: int,
-    since: int,
+    module_since: dict[int, int],
     log: logging.Logger = logger,
 ) -> CourseUpdates | None:
     """Return trustworthy module changes, or ``None`` when Moodle cannot tell."""
+    request_data: dict[str, Any] = {"courseid": course_id}
+    for index, (module_id, since) in enumerate(module_since.items()):
+        prefix = f"tocheck[{index}]"
+        request_data[f"{prefix}[contextlevel]"] = "module"
+        request_data[f"{prefix}[id]"] = module_id
+        request_data[f"{prefix}[since]"] = since
     payload = call_webservice(
         session,
         wstoken,
         MOODLE_UPDATE_FUNCTION,
-        {"courseid": course_id, "since": since},
+        request_data,
         log,
         warn_on_failure=False,
     )
@@ -597,7 +605,10 @@ def get_course_updates_since(
     unknown = _unknown_module_ids(payload.get("warnings"))
     if changed is None or unknown is None:
         return None
-    return CourseUpdates(since, changed, unknown)
+    requested = frozenset(module_since)
+    if not changed <= requested or not unknown <= requested:
+        return None
+    return CourseUpdates(dict(module_since), changed, unknown)
 
 
 def get_ltis_by_course(

--- a/syncmymoodle/opencast.py
+++ b/syncmymoodle/opencast.py
@@ -3,6 +3,7 @@ import logging
 import re
 import urllib.parse
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Iterator, cast
 
 import requests
@@ -20,6 +21,7 @@ from syncmymoodle.context import BrowserSessionUnavailable, SyncContext
 from syncmymoodle.http_utils import (
     HttpFailureKind,
     classify_http_failure,
+    normalized_http_origin,
     parse_html,
     record_service_failure,
     redact_url_secrets,
@@ -31,6 +33,7 @@ logger = logging.getLogger(__name__)
 
 OPENCAST_LTI_URL = f"{OPENCAST_URL}/lti"
 OPENCAST_SEARCH_URL = f"{OPENCAST_URL}/search/episode.json"
+OPENCAST_SERIES_PAGE_SIZE = 100
 
 
 @dataclass(frozen=True)
@@ -55,6 +58,23 @@ class OpencastTrack:
         return RemoteMarkerKind.CONTENT_HASH if self.checksum else None
 
 
+@dataclass(frozen=True)
+class OpencastEpisode:
+    """Last known tracks plus the remote scope used to refresh them."""
+
+    tracks: tuple[OpencastTrack, ...]
+    series_id: str | None = None
+
+
+class OpencastMetadataState(Enum):
+    """Authoritative state for this run; no entry means not validated yet."""
+
+    # FRESH also represents an authoritative response with no usable track.
+    FRESH = "fresh"
+    # STALE metadata may preserve local files but must not drive a transfer.
+    STALE = "stale"
+
+
 def _track_node_name(
     name: Any,
     track: OpencastTrack,
@@ -77,8 +97,15 @@ def add_episode_nodes(
     name: Any,
     episode_id: str,
     log: logging.Logger = logger,
+    *,
+    course_id: Any = None,
 ) -> None:
-    tracks = resolve_tracks_from_episode(ctx, episode_id, log)
+    tracks = resolve_tracks_from_episode(
+        ctx,
+        episode_id,
+        log,
+        course_id=course_id,
+    )
     if tracks is None:
         return
 
@@ -166,6 +193,7 @@ def submit_lti_form(
     log: logging.Logger = logger,
     *,
     endpoint: str = OPENCAST_LTI_URL,
+    course_id: Any = None,
 ) -> bool:
     if ctx.service_outages.should_skip(OPENCAST_URL):
         return False
@@ -197,6 +225,7 @@ def submit_lti_form(
         return False
 
     ctx.service_outages.record_available(OPENCAST_URL)
+    record_course_authorized(ctx, endpoint, course_id)
     return True
 
 
@@ -238,7 +267,44 @@ def fetch_lti_form_data(
     return engage_data
 
 
-def authenticate_episode(
+def _course_id_key(course_id: Any) -> str | None:
+    if course_id is None or isinstance(course_id, bool):
+        return None
+    try:
+        parsed = int(course_id)
+    except (TypeError, ValueError):
+        return None
+    return str(parsed) if parsed > 0 else None
+
+
+def _course_auth_key(endpoint: str, course_id: Any) -> tuple[str, str] | None:
+    origin = normalized_http_origin(endpoint)
+    course_key = _course_id_key(course_id)
+    return (
+        (origin, course_key) if origin is not None and course_key is not None else None
+    )
+
+
+def record_course_authorized(
+    ctx: SyncContext,
+    endpoint: str,
+    course_id: Any,
+) -> None:
+    cache_key = _course_auth_key(endpoint, course_id)
+    if cache_key is not None:
+        ctx.opencast_course_auth_cache.add(cache_key)
+
+
+def course_is_authorized(
+    ctx: SyncContext,
+    course_id: Any,
+    endpoint: str = OPENCAST_URL,
+) -> bool:
+    cache_key = _course_auth_key(endpoint, course_id)
+    return cache_key is not None and cache_key in ctx.opencast_course_auth_cache
+
+
+def authorize_course_for_episode(
     ctx: SyncContext,
     course_id: Any,
     episode_id: str,
@@ -246,6 +312,8 @@ def authenticate_episode(
 ) -> bool:
     if ctx.service_outages.should_skip(OPENCAST_URL):
         return False
+    if course_is_authorized(ctx, course_id):
+        return True
     try:
         ctx.require_browser_session()
     except BrowserSessionUnavailable as error:
@@ -256,10 +324,6 @@ def authenticate_episode(
     if not ctx.browser_session_key:
         log.warning("Opencast: cannot launch episode without Moodle sesskey")
         return False
-
-    cache_key = (course_id, episode_id)
-    if cache_key in ctx.opencast_episode_auth_cache:
-        return True
 
     params = urllib.parse.urlencode(
         {
@@ -274,9 +338,8 @@ def authenticate_episode(
     engage_data = fetch_lti_form_data(ctx, info_url, context, log)
     if engage_data is None:
         return False
-    if not submit_lti_form(ctx, engage_data, context, log):
+    if not submit_lti_form(ctx, engage_data, context, log, course_id=course_id):
         return False
-    ctx.opencast_episode_auth_cache.add(cache_key)
     return True
 
 
@@ -362,6 +425,107 @@ def optional_int(value: Any) -> int | None:
         return None
 
 
+def _validated_checksum(
+    checksum_type: Any,
+    checksum_value: Any,
+) -> tuple[str | None, str | None]:
+    if not isinstance(checksum_value, str) or not checksum_value.strip():
+        return None, None
+    checksum = checksum_value.strip().lower()
+    parsed_type = (
+        checksum_type.strip().lower()
+        if isinstance(checksum_type, str) and checksum_type.strip()
+        else infer_checksum_type(checksum)
+    )
+    expected_length = CHECKSUM_LENGTHS_BY_ALGO.get(parsed_type) if parsed_type else None
+    if (
+        expected_length is None
+        or len(checksum) != expected_length
+        or re.fullmatch(r"[0-9a-f]+", checksum) is None
+    ):
+        return None, None
+    return parsed_type, checksum
+
+
+def track_cache_data(track: OpencastTrack) -> dict[str, Any]:
+    return {
+        "url": track.url,
+        **(
+            {
+                "checksum_type": track.checksum_type,
+                "checksum": track.checksum,
+            }
+            if track.checksum_type is not None and track.checksum is not None
+            else {}
+        ),
+        **({"size": track.size} if track.size is not None else {}),
+        **({"duration": track.duration} if track.duration is not None else {}),
+        **({"flavor_type": track.flavor_type} if track.flavor_type is not None else {}),
+    }
+
+
+def track_from_cache_data(value: Any) -> OpencastTrack | None:
+    if not isinstance(value, dict):
+        return None
+    url = value.get("url")
+    if not isinstance(url, str) or not url:
+        return None
+
+    checksum = value.get("checksum")
+    checksum_type = value.get("checksum_type")
+    if checksum is None and checksum_type is None:
+        parsed_checksum = None
+        parsed_checksum_type = None
+    else:
+        parsed_checksum_type, parsed_checksum = _validated_checksum(
+            checksum_type,
+            checksum,
+        )
+        if parsed_checksum is None:
+            return None
+
+    flavor = value.get("flavor_type")
+    if flavor is not None and (not isinstance(flavor, str) or not flavor):
+        return None
+    return OpencastTrack(
+        url=url,
+        checksum_type=parsed_checksum_type,
+        checksum=parsed_checksum,
+        size=optional_int(value.get("size")),
+        duration=optional_int(value.get("duration")),
+        flavor_type=flavor,
+    )
+
+
+def episode_cache_data(episode: OpencastEpisode) -> dict[str, Any]:
+    return {
+        "tracks": [track_cache_data(track) for track in episode.tracks],
+        **({"series_id": episode.series_id} if episode.series_id is not None else {}),
+    }
+
+
+def episode_from_cache_data(value: Any) -> OpencastEpisode | None:
+    if not isinstance(value, dict) or not isinstance(value.get("tracks"), list):
+        return None
+    raw_tracks = value["tracks"]
+    tracks = tuple(
+        track
+        for raw_track in raw_tracks
+        if (track := track_from_cache_data(raw_track)) is not None
+    )
+    if not tracks or len(tracks) != len(raw_tracks):
+        return None
+    series_id = value.get("series_id")
+    if series_id is not None and (
+        not isinstance(series_id, str) or not series_id.strip()
+    ):
+        return None
+    return OpencastEpisode(
+        tracks,
+        series_id.strip() if isinstance(series_id, str) else None,
+    )
+
+
 def infer_checksum_type(checksum: str) -> str | None:
     for checksum_type, expected_length in CHECKSUM_LENGTHS_BY_ALGO.items():
         if len(checksum) == expected_length:
@@ -386,21 +550,7 @@ def extract_checksum(track: dict[str, Any]) -> tuple[str | None, str | None]:
     elif isinstance(checksum_data, str):
         checksum_value = checksum_data.strip()
 
-    if not checksum_value:
-        return None, None
-
-    checksum = checksum_value.lower()
-    checksum_type = checksum_type or infer_checksum_type(checksum)
-    expected_length = (
-        CHECKSUM_LENGTHS_BY_ALGO.get(checksum_type) if checksum_type else None
-    )
-    if expected_length is None:
-        return None, None
-    if len(checksum) != expected_length:
-        return None, None
-    if not re.fullmatch(r"[0-9a-f]+", checksum):
-        return None, None
-    return checksum_type, checksum
+    return _validated_checksum(checksum_type, checksum_value)
 
 
 def opencast_track_from_api(track: dict[str, Any]) -> OpencastTrack | None:
@@ -432,12 +582,18 @@ def opencast_track_from_api(track: dict[str, Any]) -> OpencastTrack | None:
     )
 
 
+def _mediapackage(entry: Any) -> dict[str, Any] | None:
+    if not isinstance(entry, dict) or not isinstance(entry.get("mediapackage"), dict):
+        return None
+    return cast(dict[str, Any], entry["mediapackage"])
+
+
 def _episode_track_data(entries: list[Any]) -> Iterator[dict[str, Any]]:
     for entry in entries:
-        if not isinstance(entry, dict):
+        mediapackage = _mediapackage(entry)
+        if mediapackage is None:
             continue
-        mediapackage = entry.get("mediapackage")
-        media = mediapackage.get("media") if isinstance(mediapackage, dict) else None
+        media = mediapackage.get("media")
         track_data = media.get("track") if isinstance(media, dict) else None
         if isinstance(track_data, dict):
             yield track_data
@@ -445,21 +601,84 @@ def _episode_track_data(entries: list[Any]) -> Iterator[dict[str, Any]]:
             yield from (track for track in track_data if isinstance(track, dict))
 
 
-def resolve_tracks_from_episode(
-    ctx: SyncContext,
+def _episode_cache_key(
+    course_id: Any,
     episode_id: str,
-    log: logging.Logger = logger,
-) -> tuple[OpencastTrack, ...] | None:
-    if episode_id in ctx.opencast_track_cache:
-        return ctx.opencast_track_cache[episode_id]
+) -> tuple[str | None, str]:
+    return _course_id_key(course_id), episode_id
 
-    episode_url = f"{OPENCAST_SEARCH_URL}?id={episode_id}"
+
+def _series_cache_key(
+    course_id: Any,
+    series_id: str,
+) -> tuple[str | None, str]:
+    return _course_id_key(course_id), series_id
+
+
+def _cached_episode(
+    ctx: SyncContext,
+    course_id: Any,
+    episode_id: str,
+) -> OpencastEpisode | None:
+    cache_key = _episode_cache_key(course_id, episode_id)
+    if cache_key[0] is not None:
+        ctx.opencast_seen_episodes.add((cache_key[0], episode_id))
+    return ctx.opencast_episode_cache.get(cache_key)
+
+
+def store_episode(
+    ctx: SyncContext,
+    course_id: Any,
+    episode_id: str,
+    episode: OpencastEpisode,
+    *,
+    state: OpencastMetadataState | None = OpencastMetadataState.FRESH,
+    seen: bool = True,
+) -> None:
+    """Store an episode, leaving it unvalidated when ``state`` is ``None``."""
+    cache_key = _episode_cache_key(course_id, episode_id)
+    ctx.opencast_episode_cache[cache_key] = episode
+    if state is None:
+        ctx.opencast_metadata_states.pop(cache_key, None)
+    else:
+        ctx.opencast_metadata_states[cache_key] = state
+    if seen and cache_key[0] is not None:
+        ctx.opencast_seen_episodes.add((cache_key[0], episode_id))
+
+
+def invalidate_episode(
+    ctx: SyncContext,
+    course_id: Any,
+    episode_id: str,
+    *,
+    state: OpencastMetadataState | None = None,
+) -> None:
+    """Drop cached tracks and optionally record a terminal state for this run."""
+    cache_key = _episode_cache_key(course_id, episode_id)
+    ctx.opencast_episode_cache.pop(cache_key, None)
+    if state is not None:
+        ctx.opencast_metadata_states[cache_key] = state
+    else:
+        ctx.opencast_metadata_states.pop(cache_key, None)
+    if cache_key[0] is not None:
+        ctx.opencast_seen_episodes.discard((cache_key[0], episode_id))
+
+
+def episode_metadata_is_stale(
+    ctx: SyncContext,
+    course_id: Any,
+    episode_id: str,
+) -> bool:
+    return (
+        ctx.opencast_metadata_states.get(_episode_cache_key(course_id, episode_id))
+        is OpencastMetadataState.STALE
+    )
+
+
+def tracks_from_entries(entries: list[Any]) -> tuple[OpencastTrack, ...]:
     selected: dict[
         tuple[str, str], tuple[tuple[int, int, int, str], OpencastTrack]
     ] = {}
-    entries = fetch_result_list(ctx, episode_url, f"episode {episode_id}", log)
-    if entries is None:
-        return None
     for track_data in _episode_track_data(entries):
         track = opencast_track_from_api(track_data)
         if track is None:
@@ -483,12 +702,288 @@ def resolve_tracks_from_episode(
         if current is None or quality > current[0]:
             selected[track_key] = (quality, track)
 
-    if not selected:
+    return tuple(selected[track_key][1] for track_key in sorted(selected))
+
+
+def _series_id_from_entries(
+    entries: list[Any],
+    fallback: str | None = None,
+) -> str | None:
+    for entry in entries:
+        mediapackage = _mediapackage(entry)
+        series_id = mediapackage.get("series") if mediapackage is not None else None
+        if isinstance(series_id, str) and series_id.strip():
+            return series_id.strip()
+    return fallback
+
+
+def _entries_include_media(entries: list[Any]) -> bool:
+    return any(
+        (mediapackage := _mediapackage(entry)) is not None and "media" in mediapackage
+        for entry in entries
+    )
+
+
+def _cache_episode_entries(
+    ctx: SyncContext,
+    course_id: Any,
+    episode_id: str,
+    entries: list[Any],
+    *,
+    series_id: str | None = None,
+    seen: bool = True,
+) -> bool:
+    if not _entries_include_media(entries):
+        cache_key = _episode_cache_key(course_id, episode_id)
+        ctx.opencast_metadata_states.pop(cache_key, None)
+        cached = ctx.opencast_episode_cache.get(cache_key)
+        if cached is not None and cached.series_id is None and series_id is not None:
+            store_episode(
+                ctx,
+                course_id,
+                episode_id,
+                OpencastEpisode(cached.tracks, series_id),
+                state=None,
+                seen=seen,
+            )
+        return False
+
+    tracks = tracks_from_entries(entries)
+    if not tracks:
+        invalidate_episode(
+            ctx,
+            course_id,
+            episode_id,
+            state=OpencastMetadataState.FRESH,
+        )
+        return False
+    store_episode(
+        ctx,
+        course_id,
+        episode_id,
+        OpencastEpisode(
+            tracks,
+            _series_id_from_entries(entries, series_id),
+        ),
+        seen=seen,
+    )
+    return True
+
+
+def _new_series_entries(
+    series_id: str,
+    page: list[Any],
+    seen_episode_ids: set[str],
+    log: logging.Logger,
+) -> list[tuple[str, str, Any]]:
+    entries: list[tuple[str, str, Any]] = []
+    for entry in page:
+        mediapackage = _mediapackage(entry)
+        if mediapackage is None:
+            log.warning(
+                "Opencast: series %s contains episode without id",
+                series_id,
+            )
+            continue
+        episode_id = mediapackage.get("id")
+        if not isinstance(episode_id, str) or not episode_id:
+            log.warning(
+                "Opencast: series %s contains episode without id",
+                series_id,
+            )
+            continue
+        if episode_id in seen_episode_ids:
+            continue
+        seen_episode_ids.add(episode_id)
+        raw_title = mediapackage.get("title")
+        title = raw_title if isinstance(raw_title, str) and raw_title else episode_id
+        entries.append((episode_id, title, entry))
+    return entries
+
+
+def _cache_series_entries(
+    ctx: SyncContext,
+    course_id: Any,
+    series_id: str,
+    entries: list[tuple[str, str, Any]],
+    complete: bool,
+) -> None:
+    episode_ids = {episode_id for episode_id, _, _ in entries}
+    for episode_id, _, entry in entries:
+        _cache_episode_entries(
+            ctx,
+            course_id,
+            episode_id,
+            [entry],
+            series_id=series_id,
+            seen=False,
+        )
+
+    if not complete:
+        return
+    cache_key = _series_cache_key(course_id, series_id)
+    for episode_key, episode in list(ctx.opencast_episode_cache.items()):
+        if (
+            episode_key[0] == cache_key[0]
+            and episode.series_id == series_id
+            and episode_key[1] not in episode_ids
+        ):
+            invalidate_episode(
+                ctx,
+                episode_key[0],
+                episode_key[1],
+                state=OpencastMetadataState.FRESH,
+            )
+
+
+def list_series_episodes(
+    ctx: SyncContext,
+    series_id: str,
+    log: logging.Logger = logger,
+    course_id: Any = None,
+) -> tuple[tuple[str, str], ...] | None:
+    """Fetch a series once per course and cache all usable episode metadata."""
+    cache_key = _series_cache_key(course_id, series_id)
+    if cache_key in ctx.opencast_series_cache:
+        return ctx.opencast_series_cache[cache_key]
+
+    entries: list[tuple[str, str, Any]] = []
+    seen_episode_ids: set[str] = set()
+    offset = 0
+    complete = False
+    can_prove_complete = True
+    while True:
+        ctx.output.sync_progress.module_status(
+            f"listing Opencast episodes ({len(entries)} found)"
+        )
+        query = urllib.parse.urlencode(
+            {
+                "limit": OPENCAST_SERIES_PAGE_SIZE,
+                "offset": offset,
+                "sid": series_id,
+            }
+        )
+        page = fetch_result_list(
+            ctx,
+            f"{OPENCAST_SEARCH_URL}?{query}",
+            f"series {series_id}",
+            log,
+        )
+        if page is None:
+            _cache_series_entries(ctx, course_id, series_id, entries, False)
+            ctx.opencast_series_cache[cache_key] = None
+            return None
+
+        new_entries = _new_series_entries(series_id, page, seen_episode_ids, log)
+        can_prove_complete &= len(new_entries) == len(page)
+        if page and not new_entries:
+            log.warning(
+                "Opencast: series %s made no pagination progress at offset %s; "
+                "stopping",
+                series_id,
+                offset,
+            )
+            break
+        entries.extend(new_entries)
+        if len(page) < OPENCAST_SERIES_PAGE_SIZE:
+            complete = can_prove_complete
+            break
+        offset += OPENCAST_SERIES_PAGE_SIZE
+
+    _cache_series_entries(ctx, course_id, series_id, entries, complete)
+    result = tuple((episode_id, title) for episode_id, title, _ in entries)
+    ctx.opencast_series_cache[cache_key] = result
+    return result
+
+
+def _authorize_episode_refresh(
+    ctx: SyncContext,
+    course_id: Any,
+    episode_id: str,
+    log: logging.Logger,
+) -> bool:
+    if course_id is None:
+        return True
+    if not course_is_authorized(ctx, course_id):
+        ctx.output.sync_progress.module_status("authorizing Opencast course")
+    return authorize_course_for_episode(ctx, course_id, episode_id, log)
+
+
+def _stale_episode(
+    ctx: SyncContext,
+    course_id: Any,
+    episode_id: str,
+    cached: OpencastEpisode | None,
+    log: logging.Logger,
+) -> OpencastEpisode | None:
+    cache_key = _episode_cache_key(course_id, episode_id)
+    if ctx.opencast_metadata_states.get(cache_key) is OpencastMetadataState.STALE:
+        return cached
+    ctx.opencast_metadata_states[cache_key] = OpencastMetadataState.STALE
+    if cached is not None:
+        log.warning(
+            "Opencast: could not refresh metadata for %s; cached metadata will "
+            "only be used to preserve existing files",
+            episode_id,
+        )
+    return cached
+
+
+def _refresh_episode(
+    ctx: SyncContext,
+    course_id: Any,
+    episode_id: str,
+    cached: OpencastEpisode | None,
+    log: logging.Logger,
+) -> OpencastEpisode | None:
+    ctx.output.sync_progress.module_status("resolving Opencast video")
+    entries = fetch_result_list(
+        ctx,
+        f"{OPENCAST_SEARCH_URL}?id={episode_id}",
+        f"episode {episode_id}",
+        log,
+    )
+    if entries is None:
+        return _stale_episode(ctx, course_id, episode_id, cached, log)
+    if not entries:
+        invalidate_episode(
+            ctx,
+            course_id,
+            episode_id,
+            state=OpencastMetadataState.FRESH,
+        )
         log.warning("Opencast: no downloadable mp4 track found for %s", episode_id)
         return None
+    if not _entries_include_media(entries):
+        log.warning("Opencast: metadata for %s did not include media", episode_id)
+        return _stale_episode(ctx, course_id, episode_id, cached, log)
+    if not _cache_episode_entries(ctx, course_id, episode_id, entries):
+        log.warning("Opencast: no downloadable mp4 track found for %s", episode_id)
+        return None
+    return _cached_episode(ctx, course_id, episode_id)
 
-    # Select the best plain MP4 rendition per known logical flavor and keep
-    # untyped tracks distinct. Sorting makes node order independent of the API.
-    tracks = tuple(selected[track_key][1] for track_key in sorted(selected))
-    ctx.opencast_track_cache[episode_id] = tracks
-    return tracks
+
+def resolve_tracks_from_episode(
+    ctx: SyncContext,
+    episode_id: str,
+    log: logging.Logger = logger,
+    *,
+    course_id: Any = None,
+) -> tuple[OpencastTrack, ...] | None:
+    """Return tracks after one authoritative refresh for their mutable scope."""
+    cache_key = _episode_cache_key(course_id, episode_id)
+    cached = _cached_episode(ctx, course_id, episode_id)
+    if cache_key in ctx.opencast_metadata_states:
+        return cached.tracks if cached is not None else None
+    if not _authorize_episode_refresh(ctx, course_id, episode_id, log):
+        stale = _stale_episode(ctx, course_id, episode_id, cached, log)
+        return stale.tracks if stale is not None else None
+
+    if cached is not None and cached.series_id is not None:
+        list_series_episodes(ctx, cached.series_id, log, course_id)
+        cached = _cached_episode(ctx, course_id, episode_id)
+        if cache_key in ctx.opencast_metadata_states:
+            return cached.tracks if cached is not None else None
+
+    refreshed = _refresh_episode(ctx, course_id, episode_id, cached, log)
+    return refreshed.tracks if refreshed is not None else None

--- a/syncmymoodle/sync.py
+++ b/syncmymoodle/sync.py
@@ -191,7 +191,7 @@ def sync(ctx: SyncContext) -> None:  # noqa: C901 - legacy sync awaiting decompo
             )
         module_names = {module.get("modname") for module in course_modules}
 
-        cached_update_times: list[int] = []
+        cached_module_updates: dict[int, int] = {}
         for module in course_modules:
             module_id = module.get("id")
             if not isinstance(module_id, int) or isinstance(module_id, bool):
@@ -201,34 +201,32 @@ def sync(ctx: SyncContext) -> None:  # noqa: C901 - legacy sync awaiting decompo
                     ctx, course_node, module_id, logger
                 )
                 if assignment_entry is not None:
-                    cached_update_times.append(assignment_entry.since)
+                    cached_module_updates[module_id] = assignment_entry.since
             elif config.quiz_mode != "off" and module.get("modname") == "quiz":
                 quiz_entry = course_cache.get_quiz_cache_entry(
                     ctx, course_node, module_id, logger
                 )
                 if quiz_entry is not None:
-                    cached_update_times.append(quiz_entry.since)
+                    cached_module_updates[module_id] = quiz_entry.since
 
         course_updates = None
         if (
-            cached_update_times
+            cached_module_updates
             and moodle_api.MOODLE_UPDATE_FUNCTION in ctx.moodle_functions
         ):
             progress.module_status("checking for Moodle updates")
-            course_updates = moodle_api.get_course_updates_since(
+            course_updates = moodle_api.check_course_updates(
                 session,
                 wstoken,
                 int(course_id),
-                min(cached_update_times),
+                cached_module_updates,
                 logger,
             )
             if course_updates is None:
-                ctx.moodle_functions = ctx.moodle_functions - {
-                    moodle_api.MOODLE_UPDATE_FUNCTION
-                }
                 logger.info(
-                    "Moodle incremental update checks are unavailable; using "
-                    "full module queries for this run"
+                    "Moodle incremental update check failed for %s; using "
+                    "full module queries for this course",
+                    course_name,
                 )
 
         assignments = None

--- a/syncmymoodle/sync_handlers.py
+++ b/syncmymoodle/sync_handlers.py
@@ -64,7 +64,6 @@ Handler = Callable[[ModuleContext, dict[str, Any]], None]
 # Handlers register themselves here via @register_handler and run, per module,
 # in registration (definition) order.
 MODULE_HANDLERS: list[Handler] = []
-OPENCAST_SERIES_PAGE_SIZE = 100
 
 
 def register_handler(handler: Handler) -> Handler:
@@ -120,73 +119,6 @@ def _page_response_cacheable(response: Any, requested_url: str) -> bool:
         and requested.netloc.lower() == final.netloc.lower()
         and moodle_file_path(requested.path) == moodle_file_path(final.path)
     )
-
-
-def _opencast_series_episodes(
-    ctx: SyncContext,
-    series_id: str,
-    log: logging.Logger,
-) -> list[tuple[str, str]] | None:
-    episodes: list[tuple[str, str]] = []
-    seen_episode_ids: set[str] = set()
-    offset = 0
-    while True:
-        ctx.output.sync_progress.module_status(
-            f"listing Opencast episodes ({len(episodes)} found)"
-        )
-        query = urllib.parse.urlencode(
-            {
-                "limit": OPENCAST_SERIES_PAGE_SIZE,
-                "offset": offset,
-                "sid": series_id,
-            }
-        )
-        page = opencast_api.fetch_result_list(
-            ctx,
-            f"{opencast_api.OPENCAST_SEARCH_URL}?{query}",
-            f"series {series_id}",
-            log,
-        )
-        if page is None:
-            return None
-        new_episodes: list[tuple[str, str]] = []
-        for episode in page:
-            mediapackage = (
-                episode.get("mediapackage") if isinstance(episode, dict) else None
-            )
-            if not isinstance(mediapackage, dict):
-                log.warning(
-                    "Opencast: series %s contains episode without id",
-                    series_id,
-                )
-                continue
-            episode_id = mediapackage.get("id")
-            if not isinstance(episode_id, str) or not episode_id:
-                log.warning(
-                    "Opencast: series %s contains episode without id",
-                    series_id,
-                )
-                continue
-            if episode_id in seen_episode_ids:
-                continue
-            seen_episode_ids.add(episode_id)
-            raw_title = mediapackage.get("title")
-            title = (
-                raw_title if isinstance(raw_title, str) and raw_title else episode_id
-            )
-            new_episodes.append((episode_id, title))
-        if page and not new_episodes:
-            log.warning(
-                "Opencast: series %s made no pagination progress at offset %s; "
-                "stopping",
-                series_id,
-                offset,
-            )
-            return episodes
-        episodes.extend(new_episodes)
-        if len(page) < OPENCAST_SERIES_PAGE_SIZE:
-            return episodes
-        offset += OPENCAST_SERIES_PAGE_SIZE
 
 
 class _H5PRangeUnavailable(Exception):
@@ -746,18 +678,13 @@ def handle_embedded_link_module(  # noqa: C901 - legacy handler awaiting decompo
                         vid_id = opencast_api.extract_episode_id(iframe_src)
                         if not vid_id:
                             continue
-                        module_context.status("authenticating embedded Opencast video")
-                        if not opencast_api.authenticate_episode(
-                            ctx, course_id, vid_id, log
-                        ):
-                            continue
-                        module_context.status("resolving embedded Opencast video")
                         opencast_api.add_episode_nodes(
                             ctx,
                             section_node,
                             module["name"],
                             vid_id,
                             log,
+                            course_id=course_id,
                         )
 
                 if scan_page_links:
@@ -923,17 +850,28 @@ def handle_opencast_lti_module(  # noqa: C901 - legacy handler awaiting decompos
         # Found an Opencast "series" page
         series_id = engage_series_id
 
-        module_context.status("authenticating Opencast series")
-        if not opencast_api.submit_lti_form(
+        if not opencast_api.course_is_authorized(
             ctx,
-            engage_data,
-            f"LTI series module {module['id']}",
-            log,
-            endpoint=endpoint,
+            module_context.course_id,
+            endpoint,
         ):
-            return
+            module_context.status("authorizing Opencast course")
+            if not opencast_api.submit_lti_form(
+                ctx,
+                engage_data,
+                f"LTI series module {module['id']}",
+                log,
+                endpoint=endpoint,
+                course_id=module_context.course_id,
+            ):
+                return
 
-        episodes = _opencast_series_episodes(ctx, series_id, log)
+        episodes = opencast_api.list_series_episodes(
+            ctx,
+            series_id,
+            log,
+            module_context.course_id,
+        )
         if episodes is None:
             return
         series_node = cast(Node, course_node.add_child(name, series_id, "Section"))
@@ -946,6 +884,7 @@ def handle_opencast_lti_module(  # noqa: C901 - legacy handler awaiting decompos
                 episode_title,
                 episode_id,
                 log,
+                course_id=module_context.course_id,
             )
     else:
         if not engage_single_id:
@@ -954,22 +893,28 @@ def handle_opencast_lti_module(  # noqa: C901 - legacy handler awaiting decompos
                 module["id"],
             )
         else:
-            module_context.status("authenticating Opencast video")
-            if not opencast_api.submit_lti_form(
+            if not opencast_api.course_is_authorized(
                 ctx,
-                engage_data,
-                f"LTI module {module['id']}",
-                log,
-                endpoint=endpoint,
+                module_context.course_id,
+                endpoint,
             ):
-                return
-            module_context.status("resolving Opencast video")
+                module_context.status("authorizing Opencast course")
+                if not opencast_api.submit_lti_form(
+                    ctx,
+                    engage_data,
+                    f"LTI module {module['id']}",
+                    log,
+                    endpoint=endpoint,
+                    course_id=module_context.course_id,
+                ):
+                    return
             opencast_api.add_episode_nodes(
                 ctx,
                 section_node,
                 name,
                 engage_single_id,
                 log,
+                course_id=module_context.course_id,
             )
 
 

--- a/tests/test_course_cache_safety.py
+++ b/tests/test_course_cache_safety.py
@@ -1,4 +1,4 @@
-from syncmymoodle import course_cache, moodle, sync
+from syncmymoodle import course_cache, moodle, opencast, sync
 from syncmymoodle.constants import COURSE_CACHE_FILENAME
 from syncmymoodle.node import Node
 from syncmymoodle.storage import write_private_gzip_json
@@ -129,6 +129,83 @@ def test_cached_module_data_survives_course_name_disambiguation(tmp_path):
         ).content
         == "second"
     )
+
+
+def test_persisted_opencast_series_refreshes_in_one_request(tmp_path, monkeypatch):
+    config = {"paths.sync_directory": str(tmp_path)}
+    seeded = make_context(config)
+    seeded.root_node, course_node = course_tree()
+    series_id = "series-1111-2222"
+    episode_ids = (
+        "11111111-2222-4333-8444-555555555555",
+        "66666666-7777-4888-8999-000000000000",
+    )
+    for episode_id in episode_ids:
+        opencast.store_episode(
+            seeded,
+            course_node.id,
+            episode_id,
+            opencast.OpencastEpisode(
+                (
+                    opencast.OpencastTrack(
+                        f"https://video.example.test/{episode_id}.mp4"
+                    ),
+                ),
+                series_id,
+            ),
+        )
+    course_cache.cache_root_node(seeded)
+
+    loaded = make_context(config)
+    _, loaded_course = course_tree()
+    course_cache.get_course_cache_root(loaded, loaded_course)
+    requested_urls = []
+
+    monkeypatch.setattr(
+        opencast,
+        "authorize_course_for_episode",
+        lambda *args, **kwargs: True,
+    )
+
+    def fetch_result_list(ctx, url, context, log):
+        requested_urls.append(url)
+        return [
+            {
+                "mediapackage": {
+                    "id": episode_id,
+                    "series": series_id,
+                    "title": episode_id,
+                    "media": {
+                        "track": {
+                            "type": "presentation/delivery",
+                            "mimetype": "video/mp4",
+                            "url": f"https://video.example.test/fresh-{episode_id}.mp4",
+                            "video": {"resolution": "1920x1080"},
+                        }
+                    },
+                }
+            }
+            for episode_id in episode_ids
+        ]
+
+    monkeypatch.setattr(opencast, "fetch_result_list", fetch_result_list)
+
+    tracks = [
+        opencast.resolve_tracks_from_episode(
+            loaded,
+            episode_id,
+            course_id=loaded_course.id,
+        )
+        for episode_id in episode_ids
+    ]
+
+    assert requested_urls == [
+        f"{opencast.OPENCAST_SEARCH_URL}?limit=100&offset=0&sid={series_id}"
+    ]
+    assert [resolved[0].url for resolved in tracks if resolved is not None] == [
+        f"https://video.example.test/fresh-{episode_id}.mp4"
+        for episode_id in episode_ids
+    ]
 
 
 def test_sync_prunes_cache_entries_for_removed_modules(tmp_path, monkeypatch):

--- a/tests/test_download_behavior.py
+++ b/tests/test_download_behavior.py
@@ -5,7 +5,7 @@ import os
 import pytest
 import requests
 
-from syncmymoodle import course_cache, downloader, links, moodle, pathing
+from syncmymoodle import course_cache, downloader, links, moodle, opencast, pathing
 from syncmymoodle.constants import COURSE_CACHE_FILENAME, YOUTUBE_WATCH_URL
 from syncmymoodle.downloader import download_file
 from syncmymoodle.node import Node, RemoteMarkerKind
@@ -32,6 +32,8 @@ DUPLICATE_SECTION_URL_B = (
     "https://moodle.rwth-aachen.de/pluginfile.php/502/mod_resource/content/1/"
     "Case%20Study%20Sezen.pdf"
 )
+OPENCAST_VIDEO_URL = "https://video.example.test/opencast/presentation.mp4"
+OPENCAST_EPISODE_ID = "11111111-2222-4333-8444-555555555555"
 
 
 def sha1(data: bytes) -> str:
@@ -216,6 +218,23 @@ def make_run_syncer(config, *, timemodified, etag=None, remote_size=None):
         remote_size=remote_size,
     )
     return syncer, file_node
+
+
+def build_opencast_tree(etag):
+    root = Node("", -1, "Root", None)
+    semester = root.add_child("26ss", None, "Semester")
+    course = semester.add_child("Opencast Course", 301, "Course")
+    section = course.add_child("Recordings", 401, "Section")
+    video = section.add_child(
+        "Lecture (presentation).mp4",
+        OPENCAST_EPISODE_ID,
+        "Opencast",
+        url=OPENCAST_VIDEO_URL,
+        etag=etag,
+        etag_kind=RemoteMarkerKind.CONTENT_HASH,
+        remote_size=5,
+    )
+    return root, video
 
 
 def build_duplicate_section_file_tree():
@@ -984,6 +1003,156 @@ def test_unchanged_linked_file_etag_skips_download(tmp_path):
     assert download_file(syncer, file_node).is_handled
     assert syncer.session.calls == []
     assert download_path.read_bytes() == content
+
+
+def test_unchanged_opencast_file_does_not_authorize(tmp_path, monkeypatch):
+    config = {"paths.sync_directory": str(tmp_path), "downloads.update_files": True}
+    marker = "11111111111111111111111111111111"
+    cached = make_context(config)
+    cached.root_node, cached_video = build_opencast_tree(marker)
+    cached_video.mark_handled()
+    course_cache.cache_root_node(cached)
+
+    current = make_context(config)
+    current.session = FakeSession()
+    current.root_node, video = build_opencast_tree(marker)
+    download_path = node_path(current, video)
+    download_path.parent.mkdir(parents=True)
+    download_path.write_bytes(b"video")
+    monkeypatch.setattr(
+        opencast,
+        "authorize_course_for_episode",
+        lambda *args, **kwargs: pytest.fail("unchanged video was authorized"),
+    )
+
+    outcome = download_file(current, video)
+
+    assert outcome.unchanged == 1
+    assert current.session.calls == []
+
+
+def test_stale_opencast_metadata_cannot_replace_existing_file(tmp_path, monkeypatch):
+    marker = "11111111111111111111111111111111"
+    current = make_context(
+        {
+            "paths.sync_directory": str(tmp_path),
+            "downloads.update_files": True,
+        }
+    )
+    current.session = FakeSession()
+    current.root_node, video = build_opencast_tree(marker)
+    opencast.store_episode(
+        current,
+        301,
+        OPENCAST_EPISODE_ID,
+        opencast.OpencastEpisode(
+            (
+                opencast.OpencastTrack(
+                    OPENCAST_VIDEO_URL,
+                    checksum_type="md5",
+                    checksum=marker,
+                    flavor_type="presentation",
+                ),
+            )
+        ),
+        state=None,
+    )
+    monkeypatch.setattr(
+        opencast,
+        "authorize_course_for_episode",
+        lambda *args, **kwargs: True,
+    )
+    monkeypatch.setattr(
+        opencast,
+        "fetch_result_list",
+        lambda *args, **kwargs: [{"mediapackage": {"id": OPENCAST_EPISODE_ID}}],
+    )
+    assert (
+        opencast.resolve_tracks_from_episode(
+            current,
+            OPENCAST_EPISODE_ID,
+            course_id=301,
+        )
+        is not None
+    )
+    download_path = node_path(current, video)
+    download_path.parent.mkdir(parents=True)
+    download_path.write_bytes(b"existing video")
+
+    outcome = download_file(current, video)
+
+    assert not outcome.is_handled
+    assert current.session.calls == []
+    assert download_path.read_bytes() == b"existing video"
+
+
+def test_missing_opencast_file_authorizes_immediately_before_download(
+    tmp_path,
+    monkeypatch,
+):
+    current = make_context({"paths.sync_directory": str(tmp_path)})
+    current.session = FakeSession()
+    current.root_node, video = build_opencast_tree("11111111111111111111111111111111")
+    authorized = []
+    monkeypatch.setattr(
+        opencast,
+        "authorize_course_for_episode",
+        lambda ctx, course_id, episode_id, log: (
+            authorized.append((course_id, episode_id)) or True
+        ),
+    )
+    current.session.add(
+        "GET",
+        OPENCAST_VIDEO_URL,
+        FakeResponse(
+            headers={"Content-Type": "video/mp4", "Content-Length": "5"},
+            chunks=[b"video"],
+        ),
+    )
+
+    outcome = download_file(current, video)
+
+    assert outcome.downloaded == 1
+    assert authorized == [(301, OPENCAST_EPISODE_ID)]
+    assert node_path(current, video).read_bytes() == b"video"
+
+
+def test_checksumless_opencast_validation_authorizes_before_conditional_get(
+    tmp_path,
+    monkeypatch,
+):
+    config = {"paths.sync_directory": str(tmp_path), "downloads.update_files": True}
+    cached = make_context(config)
+    cached.root_node, cached_video = build_opencast_tree('"video-v1"')
+    cached_video.etag_kind = RemoteMarkerKind.OPAQUE
+    cached_video.mark_handled()
+    course_cache.cache_root_node(cached)
+
+    current = make_context(config)
+    current.session = FakeSession()
+    current.root_node, video = build_opencast_tree(None)
+    download_path = node_path(current, video)
+    download_path.parent.mkdir(parents=True)
+    download_path.write_bytes(b"video")
+    authorized = []
+    monkeypatch.setattr(
+        opencast,
+        "authorize_course_for_episode",
+        lambda ctx, course_id, episode_id, log: (
+            authorized.append((course_id, episode_id)) or True
+        ),
+    )
+    current.session.add(
+        "GET",
+        OPENCAST_VIDEO_URL,
+        FakeResponse(status_code=304, headers={"ETag": '"video-v1"'}),
+    )
+
+    outcome = download_file(current, video)
+
+    assert outcome.unchanged == 1
+    assert authorized == [(301, OPENCAST_EPISODE_ID)]
+    assert current.session.count("GET", OPENCAST_VIDEO_URL) == 1
 
 
 def test_get_only_etag_304_skips_download(tmp_path):

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -114,10 +114,26 @@ def test_get_assignment_skips_course_on_api_error(caplog):
 
 def test_course_updates_distinguish_changed_unknown_and_unchanged_modules():
     session = FakeSession()
+    module_since = {42: 500, 43: 501, 44: 502, 99: 503}
 
     def update_response(url, kwargs):
-        assert kwargs["data"]["courseid"] == 101
-        assert kwargs["data"]["since"] == 500
+        assert kwargs["data"] == {
+            "wstoken": "token",
+            "wsfunction": moodle.MOODLE_UPDATE_FUNCTION,
+            "courseid": 101,
+            "tocheck[0][contextlevel]": "module",
+            "tocheck[0][id]": 42,
+            "tocheck[0][since]": 500,
+            "tocheck[1][contextlevel]": "module",
+            "tocheck[1][id]": 43,
+            "tocheck[1][since]": 501,
+            "tocheck[2][contextlevel]": "module",
+            "tocheck[2][id]": 44,
+            "tocheck[2][since]": 502,
+            "tocheck[3][contextlevel]": "module",
+            "tocheck[3][id]": 99,
+            "tocheck[3][since]": 503,
+        }
         return FakeResponse(
             json_payload={
                 "instances": [
@@ -145,14 +161,15 @@ def test_course_updates_distinguish_changed_unknown_and_unchanged_modules():
 
     session.add("POST", MOODLE_REST_URL, update_response)
 
-    updates = moodle.get_course_updates_since(session, "token", 101, 500)
+    updates = moodle.check_course_updates(session, "token", 101, module_since)
 
     assert updates is not None
     assert updates.confirms_unchanged(42, 500) is False
     assert updates.confirms_unchanged(44, 500) is False
     assert updates.confirms_unchanged(99, 500) is False
-    assert updates.confirms_unchanged(43, 500) is True
-    assert updates.confirms_unchanged(43, 499) is False
+    assert updates.confirms_unchanged(43, 501) is True
+    assert updates.confirms_unchanged(43, 500) is False
+    assert updates.confirms_unchanged(100, 501) is False
 
 
 def test_course_updates_fail_closed_on_non_module_warning():
@@ -168,7 +185,7 @@ def test_course_updates_fail_closed_on_non_module_warning():
         ),
     )
 
-    assert moodle.get_course_updates_since(session, "token", 101, 500) is None
+    assert moodle.check_course_updates(session, "token", 101, {43: 500}) is None
 
 
 def test_course_update_api_failure_is_silent_optional_cache_miss(caplog):
@@ -187,7 +204,7 @@ def test_course_update_api_failure_is_silent_optional_cache_miss(caplog):
         ),
     )
 
-    assert moodle.get_course_updates_since(session, "token", 101, 500) is None
+    assert moodle.check_course_updates(session, "token", 101, {43: 500}) is None
     assert "array_keys" not in caplog.text
 
 

--- a/tests/test_link_cache.py
+++ b/tests/test_link_cache.py
@@ -1,0 +1,357 @@
+import pytest
+
+from syncmymoodle import course_cache, links
+from syncmymoodle.context import MoodleAccount
+from syncmymoodle.moodle_tokens import MoodleTokens
+from syncmymoodle.node import Node
+
+from .helpers import FakeResponse, FakeSession, make_context
+
+LINK_URL = "https://links.example.test/overview"
+YOUTUBE_ONE = "https://youtu.be/abcdefghijk"
+YOUTUBE_TWO = "https://youtu.be/lmnopqrstuv"
+HTML_ONE = f'<a href="{YOUTUBE_ONE}">first</a>'
+HTML_TWO = f'<a href="{YOUTUBE_TWO}">second</a>'
+
+
+def _context(tmp_path, *, user_id=10001, extra_config=None):
+    config = {
+        "paths.sync_directory": str(tmp_path),
+        "links.youtube": True,
+        "links.opencast": False,
+        "links.sciebo": False,
+        "links.emedia": False,
+        **(extra_config or {}),
+    }
+    ctx = make_context(config)
+    ctx.moodle_account = MoodleAccount(
+        MoodleTokens(
+            "fake-user",
+            "fake-webservice-token",
+            "fake-private-token",
+            moodle_user_id=user_id,
+        )
+    )
+    root = Node("", -1, "Root", None)
+    semester = root.add_child("26ss", None, "Semester")
+    course = semester.add_child("Linked Course", 101, "Course")
+    section = course.add_child("General", 201, "Section")
+    ctx.root_node = root
+    course_cache.get_course_cache_root(ctx, course)
+    return ctx, course, section
+
+
+def _seed_html(tmp_path, headers=None, html=HTML_ONE):
+    ctx, _, section = _context(tmp_path)
+    session = FakeSession()
+    session.add(
+        "HEAD",
+        LINK_URL,
+        FakeResponse(headers={"Content-Type": "text/html"}),
+    )
+    session.add(
+        "GET",
+        LINK_URL,
+        FakeResponse(
+            text=html,
+            headers={"Content-Type": "text/html", **(headers or {})},
+        ),
+    )
+    ctx.session = session
+
+    links.scan_for_links(ctx, LINK_URL, section, 101, single=True)
+    course_cache.cache_root_node(ctx)
+
+    assert session.calls == [("HEAD", LINK_URL), ("GET", LINK_URL)]
+    return ctx
+
+
+def _youtube_ids(parent):
+    return [child.id for child in parent.children if child.type == "Youtube"]
+
+
+@pytest.mark.parametrize(
+    ("response_header", "request_header", "value"),
+    [
+        ("ETag", "If-None-Match", '"page-v1"'),
+        (
+            "Last-Modified",
+            "If-Modified-Since",
+            "Wed, 15 Jul 2026 10:00:00 GMT",
+        ),
+    ],
+)
+def test_cached_html_is_revalidated_and_rescanned(
+    tmp_path, response_header, request_header, value
+):
+    _seed_html(tmp_path, {response_header: value})
+    ctx, _, section = _context(tmp_path)
+    session = FakeSession()
+
+    def not_modified(url, kwargs):
+        assert kwargs["headers"] == {request_header: value}
+        assert kwargs["stream"] is True
+        return FakeResponse(status_code=304)
+
+    session.add("GET", LINK_URL, not_modified)
+    ctx.session = session
+
+    links.scan_for_links(ctx, LINK_URL, section, 101, single=True)
+
+    assert session.calls == [("GET", LINK_URL)]
+    assert _youtube_ids(section) == ["abcdefghijk"]
+
+
+def test_changed_html_replaces_the_persisted_cache(tmp_path):
+    _seed_html(tmp_path, {"ETag": '"page-v1"'})
+    changed, _, changed_section = _context(tmp_path)
+    changed_session = FakeSession()
+
+    def changed_page(url, kwargs):
+        assert kwargs["headers"] == {"If-None-Match": '"page-v1"'}
+        return FakeResponse(
+            text=HTML_TWO,
+            headers={"Content-Type": "text/html", "ETag": '"page-v2"'},
+        )
+
+    changed_session.add("GET", LINK_URL, changed_page)
+    changed.session = changed_session
+    links.scan_for_links(changed, LINK_URL, changed_section, 101, single=True)
+    course_cache.cache_root_node(changed)
+
+    current, _, current_section = _context(tmp_path)
+    current_session = FakeSession()
+
+    def current_page(url, kwargs):
+        assert kwargs["headers"] == {"If-None-Match": '"page-v2"'}
+        return FakeResponse(status_code=304)
+
+    current_session.add("GET", LINK_URL, current_page)
+    current.session = current_session
+    links.scan_for_links(current, LINK_URL, current_section, 101, single=True)
+
+    assert _youtube_ids(changed_section) == ["lmnopqrstuv"]
+    assert _youtube_ids(current_section) == ["lmnopqrstuv"]
+
+
+def test_cache_control_max_age_skips_fresh_requests(tmp_path, monkeypatch):
+    monkeypatch.setattr(links.time, "time", lambda: 1_000.0)
+    _seed_html(tmp_path, {"Cache-Control": "private, max-age=3600"})
+
+    monkeypatch.setattr(links.time, "time", lambda: 1_001.0)
+    ctx, _, section = _context(tmp_path)
+    session = FakeSession()
+    ctx.session = session
+
+    links.scan_for_links(ctx, LINK_URL, section, 101, single=True)
+
+    assert session.calls == []
+    assert _youtube_ids(section) == ["abcdefghijk"]
+
+
+def test_cached_html_without_validators_is_fetched_without_a_head(tmp_path):
+    _seed_html(tmp_path)
+    ctx, _, section = _context(tmp_path)
+    session = FakeSession()
+
+    def current_page(url, kwargs):
+        assert kwargs["headers"] == {}
+        return FakeResponse(text=HTML_ONE, headers={"Content-Type": "text/html"})
+
+    session.add("GET", LINK_URL, current_page)
+    ctx.session = session
+
+    links.scan_for_links(ctx, LINK_URL, section, 101, single=True)
+
+    assert session.calls == [("GET", LINK_URL)]
+    assert _youtube_ids(section) == ["abcdefghijk"]
+
+
+def test_identical_links_are_requested_once_per_run(tmp_path):
+    ctx, course, first_section = _context(tmp_path)
+    second_section = course.add_child("More", 202, "Section")
+    session = FakeSession()
+    session.add(
+        "HEAD",
+        LINK_URL,
+        FakeResponse(headers={"Content-Type": "text/html"}),
+    )
+    session.add(
+        "GET",
+        LINK_URL,
+        FakeResponse(text=HTML_ONE, headers={"Content-Type": "text/html"}),
+    )
+    ctx.session = session
+
+    links.scan_for_links(ctx, LINK_URL, first_section, 101, single=True)
+    links.scan_for_links(ctx, LINK_URL, second_section, 101, single=True)
+
+    assert session.calls == [("HEAD", LINK_URL), ("GET", LINK_URL)]
+    assert _youtube_ids(first_section) == ["abcdefghijk"]
+    assert _youtube_ids(second_section) == ["abcdefghijk"]
+
+
+def test_no_store_responses_are_not_persisted(tmp_path):
+    _seed_html(tmp_path, {"Cache-Control": "no-store", "ETag": '"private"'})
+    ctx, _, section = _context(tmp_path)
+    session = FakeSession()
+    session.add(
+        "HEAD",
+        LINK_URL,
+        FakeResponse(headers={"Content-Type": "text/html"}),
+    )
+    session.add(
+        "GET",
+        LINK_URL,
+        FakeResponse(text=HTML_ONE, headers={"Content-Type": "text/html"}),
+    )
+    ctx.session = session
+
+    links.scan_for_links(ctx, LINK_URL, section, 101, single=True)
+
+    assert session.calls == [("HEAD", LINK_URL), ("GET", LINK_URL)]
+
+
+def test_link_cache_is_bound_to_the_moodle_account(tmp_path):
+    _seed_html(tmp_path, {"ETag": '"account-one"'})
+    ctx, _, section = _context(tmp_path, user_id=20002)
+    session = FakeSession()
+    session.add(
+        "HEAD",
+        LINK_URL,
+        FakeResponse(headers={"Content-Type": "text/html"}),
+    )
+
+    def other_account_page(url, kwargs):
+        assert kwargs["headers"] == {}
+        return FakeResponse(text=HTML_ONE, headers={"Content-Type": "text/html"})
+
+    session.add("GET", LINK_URL, other_account_page)
+    ctx.session = session
+
+    links.scan_for_links(ctx, LINK_URL, section, 101, single=True)
+
+    assert session.calls == [("HEAD", LINK_URL), ("GET", LINK_URL)]
+
+
+def test_cached_direct_file_keeps_one_freshness_check(tmp_path):
+    ctx, _, section = _context(tmp_path)
+    session = FakeSession()
+    session.add(
+        "HEAD",
+        LINK_URL,
+        FakeResponse(
+            headers={
+                "Content-Type": "application/pdf",
+                "Content-Length": "1234",
+                "ETag": '"file-v1"',
+            }
+        ),
+    )
+    ctx.session = session
+    links.scan_for_links(ctx, LINK_URL, section, 101, single=True)
+    course_cache.cache_root_node(ctx)
+
+    current, _, current_section = _context(tmp_path)
+    current_session = FakeSession()
+
+    def not_modified(url, kwargs):
+        assert kwargs["headers"] == {"If-None-Match": '"file-v1"'}
+        return FakeResponse(status_code=304)
+
+    current_session.add("HEAD", LINK_URL, not_modified)
+    current.session = current_session
+    links.scan_for_links(current, LINK_URL, current_section, 101, single=True)
+
+    assert current_session.calls == [("HEAD", LINK_URL)]
+    assert len(current_section.children) == 1
+    file_node = current_section.children[0]
+    assert file_node.etag == '"file-v1"'
+    assert file_node.remote_size == 1234
+
+
+def test_known_provider_links_skip_generic_requests(tmp_path):
+    ctx = make_context(
+        {
+            "paths.sync_directory": str(tmp_path),
+            "links.youtube": False,
+            "links.opencast": False,
+            "links.sciebo": False,
+            "links.emedia": False,
+        }
+    )
+    session = FakeSession()
+    ctx.session = session
+    parent = Node("Section", 1, "Section", None)
+    provider_urls = [
+        YOUTUBE_ONE,
+        "https://engage.streaming.rwth-aachen.de/play/"
+        "11111111-2222-4333-8444-555555555555",
+        "https://rwth-aachen.sciebo.de/s/share-token-123",
+        "https://emedia-medizin.rwth-aachen.de/web/veira_fe/#/watch/864",
+    ]
+
+    for url in provider_urls:
+        links.scan_for_links(ctx, url, parent, 101, single=True)
+
+    assert session.calls == []
+    assert parent.children == []
+
+    youtube_ctx = make_context({"links.youtube": True})
+    youtube_ctx.session = FakeSession()
+    youtube_parent = Node("Section", 1, "Section", None)
+    links.scan_for_links(youtube_ctx, YOUTUBE_ONE, youtube_parent, 101, single=True)
+    assert _youtube_ids(youtube_parent) == ["abcdefghijk"]
+    assert youtube_ctx.session.calls == []
+
+
+def test_conditional_headers_are_stripped_from_cross_origin_redirects(tmp_path):
+    original_url = "https://links.example.test/redirect"
+    final_url = "https://pages.example.test/overview"
+    config = {"filters.allowed_domains": ["links.example.test", "pages.example.test"]}
+    seeded, _, seeded_section = _context(tmp_path, extra_config=config)
+    seeded_session = FakeSession()
+    seeded_session.add(
+        "HEAD",
+        original_url,
+        FakeResponse(status_code=302, headers={"Location": final_url}),
+    )
+    seeded_session.add(
+        "HEAD",
+        final_url,
+        FakeResponse(headers={"Content-Type": "text/html"}),
+    )
+    seeded_session.add(
+        "GET",
+        final_url,
+        FakeResponse(
+            text="<html></html>",
+            headers={"Content-Type": "text/html", "ETag": '"redirect-v1"'},
+        ),
+    )
+    seeded.session = seeded_session
+    links.scan_for_links(seeded, original_url, seeded_section, 101, single=True)
+    course_cache.cache_root_node(seeded)
+
+    current, _, current_section = _context(tmp_path, extra_config=config)
+    current_session = FakeSession()
+
+    def redirect(url, kwargs):
+        assert kwargs["headers"] == {"If-None-Match": '"redirect-v1"'}
+        return FakeResponse(status_code=302, headers={"Location": final_url})
+
+    def final_page(url, kwargs):
+        assert "If-None-Match" not in kwargs["headers"]
+        assert "If-Modified-Since" not in kwargs["headers"]
+        return FakeResponse(
+            text="<html></html>",
+            headers={"Content-Type": "text/html", "ETag": '"redirect-v1"'},
+        )
+
+    current_session.add("GET", original_url, redirect)
+    current_session.add("GET", final_url, final_page)
+    current.session = current_session
+
+    links.scan_for_links(current, original_url, current_section, 101, single=True)
+
+    assert current_session.calls == [("GET", original_url), ("GET", final_url)]

--- a/tests/test_sync_fixtures.py
+++ b/tests/test_sync_fixtures.py
@@ -1,6 +1,8 @@
 import io
 import logging
+import urllib.parse
 import zipfile
+from typing import Any
 
 import requests
 
@@ -35,6 +37,33 @@ PAGE_URL = "https://moodle.rwth-aachen.de/mod/page/view.php?id=123"
 PAGE_CONTENT_URL = (
     "https://moodle.rwth-aachen.de/pluginfile.php/1/mod_page/content/315/index.html"
 )
+
+
+def opencast_episode_entry(
+    episode_id: str,
+    url: str,
+    *,
+    series_id: str | None = None,
+    title: str | None = None,
+    checksum: str | None = None,
+) -> dict[str, Any]:
+    track: dict[str, Any] = {
+        "type": "presentation/delivery",
+        "mimetype": "video/mp4",
+        "url": url,
+        "video": {"resolution": "1920x1080"},
+    }
+    if checksum is not None:
+        track["checksum"] = {"type": "md5", "$": checksum}
+    mediapackage: dict[str, Any] = {
+        "id": episode_id,
+        "media": {"track": track},
+    }
+    if series_id is not None:
+        mediapackage["series"] = series_id
+    if title is not None:
+        mediapackage["title"] = title
+    return {"mediapackage": mediapackage}
 
 
 def run_page_handler(response):
@@ -536,14 +565,14 @@ def test_update_feed_reuses_and_refreshes_assignment_and_quiz_data(
         calls["review"] += 1
         return {"questions": [{"html": f"<p>Review v{state['version']}</p>"}]}
 
-    def course_updates(session, wstoken, course_id, since, log):
-        update_calls.append(since)
-        return moodle.CourseUpdates(since, state["changed"], frozenset())
+    def course_updates(session, wstoken, course_id, module_since, log):
+        update_calls.append(dict(module_since))
+        return moodle.CourseUpdates(dict(module_since), state["changed"], frozenset())
 
     monkeypatch.setattr(moodle, "get_assignment_submission_files", submission_files)
     monkeypatch.setattr(moodle, "get_quiz_attempts", quiz_attempts)
     monkeypatch.setattr(moodle, "get_quiz_attempt_review", quiz_review)
-    monkeypatch.setattr(moodle, "get_course_updates_since", course_updates)
+    monkeypatch.setattr(moodle, "check_course_updates", course_updates)
     monkeypatch.setattr(
         moodle,
         "get_quizzes_by_course",
@@ -578,7 +607,7 @@ def test_update_feed_reuses_and_refreshes_assignment_and_quiz_data(
     course_cache.cache_root_node(first)
     second = run_at(300)
 
-    assert update_calls == [200]
+    assert update_calls == [{42: 200, 43: 200}]
     assert calls == {"submission": 1, "attempts": 1, "review": 1}
     node_at_path(
         second.root_node,
@@ -598,7 +627,7 @@ def test_update_feed_reuses_and_refreshes_assignment_and_quiz_data(
     # A second account using the same sync directory must not reuse them.
     other_user = run_at(350, user_id=20002)
 
-    assert update_calls == [200]
+    assert update_calls == [{42: 200, 43: 200}]
     assert calls == {"submission": 2, "attempts": 2, "review": 2}
     assert "Review v1" in other_user.quiz_review_cache[review_url]
 
@@ -606,7 +635,7 @@ def test_update_feed_reuses_and_refreshes_assignment_and_quiz_data(
     state["changed"] = frozenset({42, 43})
     third = run_at(400)
 
-    assert update_calls == [200, 300]
+    assert update_calls == [{42: 200, 43: 200}, {42: 300, 43: 300}]
     assert calls == {"submission": 3, "attempts": 3, "review": 3}
     node_at_path(
         third.root_node,
@@ -628,7 +657,11 @@ def test_update_feed_reuses_and_refreshes_assignment_and_quiz_data(
     state["changed"] = frozenset()
     team_run = run_at(500)
 
-    assert update_calls == [200, 300, 400]
+    assert update_calls == [
+        {42: 200, 43: 200},
+        {42: 300, 43: 300},
+        {42: 400, 43: 400},
+    ]
     assert calls == {"submission": 4, "attempts": 3, "review": 3}
     node_at_path(
         team_run.root_node,
@@ -697,7 +730,7 @@ def test_quiz_cache_refreshes_at_review_phase_boundary(monkeypatch, tmp_path):
     first = run_at(100, None)
     course_cache.cache_root_node(first)
 
-    unchanged = moodle.CourseUpdates(95, frozenset(), frozenset())
+    unchanged = moodle.CourseUpdates({43: 95}, frozenset(), frozenset())
     before_boundary = run_at(160, unchanged)
     review_url = "https://moodle.rwth-aachen.de/mod/quiz/review.php?attempt=5"
 
@@ -713,14 +746,14 @@ def test_quiz_cache_refreshes_at_review_phase_boundary(monkeypatch, tmp_path):
     quiz_state["timeclose"] = 160
     after_override_change = run_at(
         180,
-        moodle.CourseUpdates(165, frozenset(), frozenset()),
+        moodle.CourseUpdates({43: 165}, frozenset(), frozenset()),
     )
 
     assert calls == {"attempts": 3, "review": 3}
     assert "Review 3" in after_override_change.quiz_review_cache[review_url]
 
 
-def test_failed_update_feed_is_tried_only_once_per_run(monkeypatch, caplog):
+def test_failed_course_update_check_does_not_disable_later_courses(monkeypatch, caplog):
     courses = [
         {"id": 901, "shortname": "First", "idnumber": "26ss-first"},
         {"id": 902, "shortname": "Second", "idnumber": "26ss-second"},
@@ -736,7 +769,13 @@ def test_failed_update_feed_is_tried_only_once_per_run(monkeypatch, caplog):
                         "instance": course_id,
                         "modname": "assign",
                         "name": "Assignment",
-                    }
+                    },
+                    {
+                        "id": course_id + 10_000,
+                        "instance": course_id + 10_000,
+                        "modname": "hsuforum",
+                        "name": "Open Forum",
+                    },
                 ],
             }
         ]
@@ -752,11 +791,13 @@ def test_failed_update_feed_is_tried_only_once_per_run(monkeypatch, caplog):
     )
     update_calls = []
 
-    def failed_update(session, wstoken, course_id, since, log):
-        update_calls.append(course_id)
-        return None
+    def course_update(session, wstoken, course_id, module_since, log):
+        update_calls.append((course_id, dict(module_since)))
+        if course_id == 901:
+            return None
+        return moodle.CourseUpdates(dict(module_since), frozenset(), frozenset())
 
-    monkeypatch.setattr(moodle, "get_course_updates_since", failed_update)
+    monkeypatch.setattr(moodle, "check_course_updates", course_update)
     context = make_context({"modules.assignment": True})
     context.session = FakeSession()
     context.moodle_functions = frozenset({moodle.MOODLE_UPDATE_FUNCTION})
@@ -764,12 +805,12 @@ def test_failed_update_feed_is_tried_only_once_per_run(monkeypatch, caplog):
 
     sync.sync(context)
 
-    assert update_calls == [901]
-    assert moodle.MOODLE_UPDATE_FUNCTION not in context.moodle_functions
+    assert update_calls == [(901, {901: 100}), (902, {902: 100})]
+    assert moodle.MOODLE_UPDATE_FUNCTION in context.moodle_functions
     assert (
         caplog.messages.count(
-            "Moodle incremental update checks are unavailable; using full module "
-            "queries for this run"
+            "Moodle incremental update check failed for First; using full module "
+            "queries for this course"
         )
         == 1
     )
@@ -790,51 +831,75 @@ def test_nested_moodle_folder_paths_are_preserved(monkeypatch):
     assert_snapshot("nested_folder_tree.txt", node_rows(syncer.root_node))
 
 
-def test_assignment_intro_opencast_embed_is_added_to_assignment_node(monkeypatch):
+def test_assignment_opencast_metadata_is_refreshed_between_runs(
+    monkeypatch,
+    tmp_path,
+):
     courses = [load_json_fixture("moodle", "courses.json")[1]]
-    syncer = make_context(
-        {
-            "modules.assignment": True,
-            "modules.resource": False,
-            "modules.folder": False,
-            "links.youtube": False,
-            "links.opencast": True,
-            "links.sciebo": False,
-        }
-    )
+    config = {
+        "paths.sync_directory": str(tmp_path),
+        "modules.assignment": True,
+        "modules.resource": False,
+        "modules.folder": False,
+        "links.youtube": False,
+        "links.opencast": True,
+        "links.sciebo": False,
+    }
     install_moodle_fixtures(
         monkeypatch,
         courses,
         {102: load_json_fixture("moodle", "assignment_opencast_course.json")},
         {102: load_json_fixture("moodle", "assignment_opencast_assignments.json")},
     )
-    syncer.session = FakeSession()
 
     authenticated = []
+    resolved = []
     monkeypatch.setattr(
         opencast,
-        "authenticate_episode",
+        "authorize_course_for_episode",
         lambda ctx, course_id, episode_id, *a, **k: (
             authenticated.append((course_id, episode_id)) or True
         ),
     )
-    monkeypatch.setattr(
-        opencast,
-        "resolve_tracks_from_episode",
-        lambda ctx, episode_id, *a, **k: (
-            opencast.OpencastTrack(
-                f"https://video.example.test/{episode_id}/presentation.mp4",
-                checksum_type="md5",
-                checksum="11111111111111111111111111111111",
-                flavor_type="presentation",
-            ),
-        ),
+    episode_id = "11111111-2222-4333-8444-555555555555"
+    series_id = "series-1111-2222"
+
+    def fetch_result_list(ctx, url, context, log):
+        resolved.append(url)
+        refreshed = len(resolved) == 2
+        return [
+            opencast_episode_entry(
+                episode_id,
+                "https://video.example.test/"
+                f"{episode_id}/presentation.mp4"
+                + ("?signature=refreshed" if refreshed else ""),
+                series_id=series_id,
+                checksum="2" * 32 if refreshed else "1" * 32,
+            )
+        ]
+
+    monkeypatch.setattr(opencast, "fetch_result_list", fetch_result_list)
+
+    first = make_context(config)
+    first.session = FakeSession()
+    sync.sync(first)
+    course_cache.cache_root_node(first)
+
+    second = make_context(config)
+    second.session = FakeSession()
+    sync.sync(second)
+
+    assert authenticated == [(102, episode_id), (102, episode_id)]
+    assert resolved == [
+        f"{opencast.OPENCAST_SEARCH_URL}?id={episode_id}",
+        f"{opencast.OPENCAST_SEARCH_URL}?limit=100&offset=0&sid={series_id}",
+    ]
+    assert_snapshot("assignment_opencast_tree.txt", node_rows(first.root_node))
+    assert node_rows(second.root_node) != node_rows(first.root_node)
+    assert any(
+        "?signature=refreshed" in row and "2" * 32 in row
+        for row in node_rows(second.root_node)
     )
-
-    sync.sync(syncer)
-
-    assert authenticated == [(102, "11111111-2222-4333-8444-555555555555")]
-    assert_snapshot("assignment_opencast_tree.txt", node_rows(syncer.root_node))
 
 
 def test_skip_rules_apply_to_sections_modules_links_and_domains(monkeypatch):
@@ -942,6 +1007,41 @@ def test_opencast_error_response_body_is_not_logged(caplog):
     assert opencast.fetch_result_list(syncer, url, "episode") is None
 
     assert "private-opencast-response" not in caplog.text
+
+
+def test_opencast_lti_authorization_is_reused_for_the_course():
+    syncer = make_context()
+    syncer.session = FakeSession()
+    syncer.browser_session = FakeSession()
+    syncer.browser_session_key = "browser-session-key"
+    episodes = (
+        (101, "11111111-2222-4333-8444-555555555555"),
+        (101, "22222222-3333-4444-8555-666666666666"),
+        (102, "33333333-4444-4555-8666-777777777777"),
+    )
+
+    def launch_url(course_id, episode_id):
+        query = urllib.parse.urlencode(
+            {
+                "courseid": course_id,
+                "episodeid": episode_id,
+                "sesskey": syncer.browser_session_key,
+                "ocinstanceid": 1,
+            }
+        )
+        return f"{opencast.MOODLE_URL}filter/opencast/ltilaunch.php?{query}"
+
+    form = FakeResponse(text='<input name="oauth_consumer_key" value="key">')
+    syncer.browser_session.add("GET", launch_url(*episodes[0]), form)
+    syncer.browser_session.add("GET", launch_url(*episodes[2]), form)
+    syncer.session.add("POST", opencast.OPENCAST_LTI_URL, FakeResponse(text="ok"))
+
+    assert opencast.authorize_course_for_episode(syncer, *episodes[0])
+    assert opencast.authorize_course_for_episode(syncer, *episodes[1])
+    assert opencast.authorize_course_for_episode(syncer, *episodes[2])
+
+    assert syncer.browser_session.count("GET") == 2
+    assert syncer.session.count("POST", opencast.OPENCAST_LTI_URL) == 2
 
 
 def test_opencast_repeated_503_opens_shared_service_circuit(caplog):
@@ -1441,7 +1541,7 @@ def test_opencast_series_fetches_every_page(monkeypatch):
         statuses.append,
     )
 
-    episodes = sync_handlers._opencast_series_episodes(
+    episodes = opencast.list_series_episodes(
         syncer,
         "series-123",
         logging.getLogger("test"),
@@ -1456,6 +1556,80 @@ def test_opencast_series_fetches_every_page(monkeypatch):
     assert statuses == [
         "listing Opencast episodes (0 found)",
         "listing Opencast episodes (100 found)",
+    ]
+
+
+def test_opencast_uses_refreshed_episode_from_partial_series(monkeypatch):
+    syncer = make_context()
+    course_id = 101
+    series_id = "series-123"
+    episode_id = "episode-0"
+    fallback_episode_id = "episode-missing"
+    for cached_episode_id in (episode_id, fallback_episode_id):
+        opencast.store_episode(
+            syncer,
+            course_id,
+            cached_episode_id,
+            opencast.OpencastEpisode(
+                (
+                    opencast.OpencastTrack(
+                        f"https://video.example.test/cached-{cached_episode_id}.mp4"
+                    ),
+                ),
+                series_id,
+            ),
+            state=None,
+        )
+    requested_urls = []
+
+    def fetch_result_list(ctx, url, context, log):
+        requested_urls.append(url)
+        if "?id=" in url:
+            return [
+                opencast_episode_entry(
+                    fallback_episode_id,
+                    "https://video.example.test/fallback.mp4",
+                    series_id=series_id,
+                )
+            ]
+        if "offset=100" in url:
+            return None
+        return [
+            opencast_episode_entry(
+                f"episode-{index}",
+                f"https://video.example.test/fresh-{index}.mp4",
+                series_id=series_id,
+                title=f"Episode {index}",
+            )
+            for index in range(100)
+        ]
+
+    monkeypatch.setattr(opencast, "fetch_result_list", fetch_result_list)
+    monkeypatch.setattr(
+        opencast,
+        "authorize_course_for_episode",
+        lambda *args, **kwargs: True,
+    )
+
+    series_tracks = opencast.resolve_tracks_from_episode(
+        syncer,
+        episode_id,
+        course_id=course_id,
+    )
+    fallback_tracks = opencast.resolve_tracks_from_episode(
+        syncer,
+        fallback_episode_id,
+        course_id=course_id,
+    )
+
+    assert series_tracks is not None
+    assert series_tracks[0].url == "https://video.example.test/fresh-0.mp4"
+    assert fallback_tracks is not None
+    assert fallback_tracks[0].url == "https://video.example.test/fallback.mp4"
+    assert requested_urls == [
+        f"{opencast.OPENCAST_SEARCH_URL}?limit=100&offset=0&sid={series_id}",
+        f"{opencast.OPENCAST_SEARCH_URL}?limit=100&offset=100&sid={series_id}",
+        f"{opencast.OPENCAST_SEARCH_URL}?id={fallback_episode_id}",
     ]
 
 
@@ -1480,20 +1654,79 @@ def test_opencast_series_stops_when_backend_repeats_page(monkeypatch, caplog):
 
     monkeypatch.setattr(opencast, "fetch_result_list", fetch_result_list)
 
-    episodes = sync_handlers._opencast_series_episodes(
+    episodes = opencast.list_series_episodes(
         syncer,
         "series-123",
         logging.getLogger("test"),
     )
 
-    assert episodes == [
+    assert episodes == tuple(
         (f"episode-{index}", f"Episode {index}") for index in range(100)
-    ]
+    )
     assert requested_urls == [
         f"{opencast.OPENCAST_SEARCH_URL}?limit=100&offset=0&sid=series-123",
         f"{opencast.OPENCAST_SEARCH_URL}?limit=100&offset=100&sid=series-123",
     ]
     assert "made no pagination progress at offset 100" in caplog.text
+
+
+def test_opencast_malformed_series_page_falls_back_to_episode_refresh(monkeypatch):
+    syncer = make_context()
+    course_id = 101
+    series_id = "series-123"
+    episode_id = "cached-episode"
+    opencast.store_episode(
+        syncer,
+        course_id,
+        episode_id,
+        opencast.OpencastEpisode(
+            (opencast.OpencastTrack("https://video.example.test/cached.mp4"),),
+            series_id,
+        ),
+        state=None,
+    )
+    requested_urls = []
+
+    def fetch_result_list(ctx, url, context, log):
+        requested_urls.append(url)
+        if "sid=" in url:
+            return [
+                opencast_episode_entry(
+                    "other-episode",
+                    "https://video.example.test/other.mp4",
+                    series_id=series_id,
+                    title="other-episode",
+                ),
+                {"mediapackage": {"title": "Missing id"}},
+            ]
+        return [
+            opencast_episode_entry(
+                episode_id,
+                "https://video.example.test/refreshed.mp4",
+                series_id=series_id,
+                title=episode_id,
+            )
+        ]
+
+    monkeypatch.setattr(opencast, "fetch_result_list", fetch_result_list)
+    monkeypatch.setattr(
+        opencast,
+        "authorize_course_for_episode",
+        lambda *args, **kwargs: True,
+    )
+
+    tracks = opencast.resolve_tracks_from_episode(
+        syncer,
+        episode_id,
+        course_id=course_id,
+    )
+
+    assert tracks is not None
+    assert tracks[0].url == "https://video.example.test/refreshed.mp4"
+    assert requested_urls == [
+        f"{opencast.OPENCAST_SEARCH_URL}?limit=100&offset=0&sid={series_id}",
+        f"{opencast.OPENCAST_SEARCH_URL}?id={episode_id}",
+    ]
 
 
 def test_mixed_course_sync_tree_covers_common_module_surfaces(monkeypatch):
@@ -1578,7 +1811,7 @@ def test_mixed_course_sync_tree_covers_common_module_surfaces(monkeypatch):
     syncer.session = session
     monkeypatch.setattr(
         opencast,
-        "authenticate_episode",
+        "authorize_course_for_episode",
         lambda ctx, course_id, episode_id, *a, **k: True,
     )
     monkeypatch.setattr(
@@ -1629,8 +1862,6 @@ def test_opencast_lti_single_and_series_use_lti_and_api_routes(monkeypatch):
     lti_submit_url = "https://engage.streaming.rwth-aachen.de/lti"
     single_episode = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
     series_id = "series-1111-2222"
-    series_episode_a = "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff"
-    series_episode_b = "cccccccc-dddd-4eee-8fff-aaaaaaaaaaaa"
     series_url = (
         "https://engage.streaming.rwth-aachen.de/search/episode.json"
         f"?limit=100&offset=0&sid={series_id}"
@@ -1677,6 +1908,16 @@ def test_opencast_lti_single_and_series_use_lti_and_api_routes(monkeypatch):
         }
 
     monkeypatch.setattr("syncmymoodle.moodle.get_lti_launch_data", launch_data)
+    series_payload = load_json_fixture("opencast", "series.json")
+    for episode, fixture_name in zip(
+        series_payload["result"],
+        ("episode_series_a.json", "episode_series_b.json"),
+        strict=True,
+    ):
+        episode["mediapackage"]["media"] = load_json_fixture(
+            "opencast",
+            fixture_name,
+        )["result"][0]["mediapackage"]["media"]
     session = FakeSession()
     session.add("POST", lti_submit_url, FakeResponse(text="ok"))
     session.add(
@@ -1688,28 +1929,13 @@ def test_opencast_lti_single_and_series_use_lti_and_api_routes(monkeypatch):
     session.add(
         "GET",
         series_url,
-        FakeResponse(json_payload=load_json_fixture("opencast", "series.json")),
-    )
-    session.add(
-        "GET",
-        "https://engage.streaming.rwth-aachen.de/search/episode.json"
-        f"?id={series_episode_a}",
-        FakeResponse(
-            json_payload=load_json_fixture("opencast", "episode_series_a.json")
-        ),
-    )
-    session.add(
-        "GET",
-        "https://engage.streaming.rwth-aachen.de/search/episode.json"
-        f"?id={series_episode_b}",
-        FakeResponse(
-            json_payload=load_json_fixture("opencast", "episode_series_b.json")
-        ),
+        FakeResponse(json_payload=series_payload),
     )
     syncer.session = session
 
     sync.sync(syncer)
 
     assert launch_calls == [9001, 9002]
-    assert session.count("POST", lti_submit_url) == 2
+    assert session.count("POST", lti_submit_url) == 1
+    assert session.count("GET") == 2
     assert_snapshot("opencast_lti_tree.txt", node_rows(syncer.root_node))


### PR DESCRIPTION
Reuses remote metadata where possible, reducing the number of requests made to Moodle, Opencast, and linked sites without changing what gets downloaded.

Combined with the previous h5p fixes, my sync time saw a 5x speed improvement.