### PR TITLE
Fix cache migration and artifact updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,8 +358,8 @@ another directory.
 
 `clean conflicts` removes only `.syncconflict.*` files whose content duplicates
 the current file or another conflict copy. `clean caches` removes per-course
-`.syncmymoodle_cache` files; it is a recovery command and makes the next sync
-rebuild its metadata.
+`.syncmymoodle-cache/.../.syncmymoodle_cache` files; it is a recovery command
+and makes the next sync rebuild its metadata.
 
 ## Migrating a legacy configuration
 

--- a/syncmymoodle/__init__.py
+++ b/syncmymoodle/__init__.py
@@ -33,7 +33,7 @@ Download:
 
 Persistence:
     storage         private gzip-JSON and cookie (de)serialization
-    course_cache    per-course sync-tree cache (.syncmymoodle_cache)
+    course_cache    account-bound per-course sync-tree cache
     pathing         path sanitization, traversal safety, conflict paths
     cleanup         local cleanup of redundant conflict files and caches
 

--- a/syncmymoodle/context.py
+++ b/syncmymoodle/context.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 # Retain a small overlap so a change committed at the integer-second token
 # validation boundary cannot fall between incremental update queries.
 MOODLE_UPDATE_OVERLAP_SECONDS = 5
+ModuleInstanceCache = dict[int, dict[int, dict[str, Any]] | None]
 
 
 class BrowserSessionUnavailable(RuntimeError):
@@ -146,9 +147,9 @@ class SyncContext:
     downloaded_paths: set[Path] = field(default_factory=set)
     filtered_items: set[FilteredItem] = field(default_factory=set)
     quiz_review_cache: dict[str, str] = field(default_factory=dict)
-    lti_instance_cache: dict[int, dict[str, Any]] = field(default_factory=dict)
-    h5p_activity_cache: dict[int, dict[str, Any]] = field(default_factory=dict)
-    quiz_instance_cache: dict[int, dict[str, Any]] = field(default_factory=dict)
+    lti_instance_cache: ModuleInstanceCache = field(default_factory=dict)
+    h5p_activity_cache: ModuleInstanceCache = field(default_factory=dict)
+    quiz_instance_cache: ModuleInstanceCache = field(default_factory=dict)
     linked_resources_by_course: dict[str, dict[str, LinkedResourceCacheEntry]] = field(
         default_factory=dict
     )
@@ -156,6 +157,7 @@ class SyncContext:
         default_factory=dict
     )
     seen_linked_resources: set[tuple[str, str]] = field(default_factory=set)
+    incomplete_course_ids: set[int] = field(default_factory=set)
 
     def __post_init__(self) -> None:
         self.auth = AuthState.from_config(self.config)
@@ -175,6 +177,14 @@ class SyncContext:
         reason: str,
     ) -> None:
         self.filtered_items.add(FilteredItem(config_key, category, item, reason))
+
+    def mark_course_incomplete(self, course_id: Any) -> None:
+        if (
+            isinstance(course_id, int)
+            and not isinstance(course_id, bool)
+            and course_id > 0
+        ):
+            self.incomplete_course_ids.add(course_id)
 
     def require_session(self) -> requests.Session:
         """Return the token-capable general HTTP session."""

--- a/syncmymoodle/course_cache.py
+++ b/syncmymoodle/course_cache.py
@@ -1,5 +1,8 @@
+import hashlib
 import logging
 import math
+import urllib.parse
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -8,6 +11,7 @@ from syncmymoodle import links, opencast
 from syncmymoodle.constants import COURSE_CACHE_FILENAME
 from syncmymoodle.context import LinkedResourceCacheEntry, SyncContext
 from syncmymoodle.http_utils import HTML_CONTENT_TYPES, normalized_http_origin
+from syncmymoodle.moodle_tokens import normalized_site
 from syncmymoodle.node import (
     NAME_CLASH_ID_UNSET,
     DownloadKind,
@@ -19,6 +23,7 @@ from syncmymoodle.storage import read_private_gzip_json, write_private_gzip_json
 
 logger = logging.getLogger(__name__)
 COURSE_CACHE_FORMAT = "syncmymoodle.course-cache.v1"
+COURSE_CACHE_DIRECTORY = ".syncmymoodle-cache"
 MODULE_CACHE_KEY = "module_data"
 CACHED_TEXT_CACHE_KEY = "cached_text"
 OPENCAST_EPISODES_CACHE_KEY = "opencast_episodes"
@@ -75,12 +80,224 @@ def _node_path(ctx: SyncContext, node: Node) -> Path:
     return get_sanitized_node_path(node, Path(ctx.config.sync_directory))
 
 
+def _node_artifact_paths(
+    ctx: SyncContext,
+    node: Node,
+    metadata_node: Node,
+) -> list[Path]:
+    node_path = _node_path(ctx, node)
+    if node.download_kind is not DownloadKind.QUIZ:
+        return [node_path]
+    return [
+        node_path.with_name(f"{node_path.name}.{suffix}")
+        for suffix in metadata_node.artifact_hashes
+    ]
+
+
 def _module_id(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
     try:
         module_id = int(value)
     except (TypeError, ValueError):
         return None
     return module_id if module_id > 0 else None
+
+
+def course_cache_path(ctx: SyncContext, course_node: Node) -> Path:
+    """Return the stable, account-bound cache path for one Moodle course."""
+    identity = _cache_identity(ctx, course_node)
+    site_key = hashlib.sha256(str(identity["site"]).encode("utf-8")).hexdigest()
+    return (
+        Path(ctx.config.sync_directory).expanduser()
+        / COURSE_CACHE_DIRECTORY
+        / site_key
+        / str(identity["user_id"])
+        / str(identity["course_id"])
+        / COURSE_CACHE_FILENAME
+    )
+
+
+def _cache_identity(ctx: SyncContext, course_node: Node) -> dict[str, Any]:
+    account = ctx.require_moodle_account()
+    course_id = _module_id(course_node.id)
+    if course_id is None:
+        raise ValueError("course cache requires a positive Moodle course id")
+    return {
+        "site": normalized_site(account.tokens.site),
+        "user_id": account.user_id,
+        "course_id": course_id,
+    }
+
+
+def _read_course_cache_payload(
+    cache_path: Path,
+    log: logging.Logger,
+) -> dict[str, Any] | None:
+    payload = read_private_gzip_json(cache_path, "course cache")
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("format") != COURSE_CACHE_FORMAT:
+        log.warning("Ignoring unsupported course cache format: %s", cache_path)
+        return None
+    return payload
+
+
+def _legacy_course_cache_paths(
+    ctx: SyncContext,
+    course_node: Node,
+) -> Iterator[Path]:
+    sync_directory = Path(ctx.config.sync_directory).expanduser()
+    direct_path = _node_path(ctx, course_node) / COURSE_CACHE_FILENAME
+    if direct_path.is_file():
+        yield direct_path
+    stable_directory = sync_directory / COURSE_CACHE_DIRECTORY
+    yield from (
+        path
+        for path in sync_directory.rglob(COURSE_CACHE_FILENAME)
+        if path != direct_path
+        and path.is_file()
+        and not path.is_relative_to(stable_directory)
+    )
+
+
+def _node_tree_has_site_url(course_root: Node, site: str) -> bool:
+    expected = urllib.parse.urlsplit(site)
+    expected_path = expected.path.rstrip("/") + "/"
+    pending = [course_root]
+    while pending:
+        node = pending.pop()
+        pending.extend(node.children)
+        if not node.url:
+            continue
+        actual = urllib.parse.urlsplit(node.url)
+        if (
+            actual.scheme.lower() == expected.scheme.lower()
+            and actual.netloc.lower() == expected.netloc.lower()
+            and actual.path.startswith(expected_path)
+        ):
+            return True
+    return False
+
+
+def _cached_download_kind(data: dict[str, Any]) -> DownloadKind | str | None:
+    value = data.get("download_kind")
+    if isinstance(value, str):
+        return value
+    node_type = data.get("type")
+    return LEGACY_DOWNLOAD_KINDS.get(node_type) if isinstance(node_type, str) else None
+
+
+def _shared_legacy_node_data(data: dict[str, Any]) -> dict[str, Any] | None:
+    node_type = data.get("type")
+    download_kind = _cached_download_kind(data)
+    if node_type == "Assignment File" or download_kind == DownloadKind.QUIZ:
+        return None
+
+    shared = dict(data)
+    children = data.get("children")
+    if isinstance(children, list):
+        shared["children"] = [
+            shared_child
+            for child in children
+            if isinstance(child, dict)
+            and (shared_child := _shared_legacy_node_data(child)) is not None
+        ]
+    return shared
+
+
+def _account_bound_legacy_payload(
+    ctx: SyncContext,
+    course_node: Node,
+    payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    identity = _cache_identity(ctx, course_node)
+    course_data = payload.get("course")
+    if (
+        not isinstance(course_data, dict)
+        or _module_id(course_data.get("id")) != identity["course_id"]
+    ):
+        return None
+    try:
+        course_root = node_from_cache_data(course_data)
+    except (TypeError, ValueError):
+        return None
+
+    cached_identity = payload.get("identity")
+    if cached_identity is not None:
+        if not isinstance(cached_identity, dict) or (
+            cached_identity.get("site") != identity["site"]
+            or cached_identity.get("course_id") != identity["course_id"]
+        ):
+            return None
+        owner_matches = cached_identity.get("user_id") == identity["user_id"]
+    else:
+        if not _node_tree_has_site_url(course_root, str(identity["site"])):
+            return None
+        raw_module_cache = payload.get(MODULE_CACHE_KEY)
+        owner_matches = isinstance(raw_module_cache, dict) and (
+            raw_module_cache.get("owner_user_id") == identity["user_id"]
+        )
+
+    migrated = {**payload, "identity": identity}
+    if owner_matches:
+        return migrated
+
+    shared_course = _shared_legacy_node_data(course_data)
+    assert shared_course is not None
+    migrated["course"] = shared_course
+    raw_module_cache = payload.get(MODULE_CACHE_KEY)
+    cached_text = (
+        raw_module_cache.get(CACHED_TEXT_CACHE_KEY)
+        if isinstance(raw_module_cache, dict)
+        else None
+    )
+    if cached_text is None:
+        migrated.pop(MODULE_CACHE_KEY, None)
+    else:
+        migrated[MODULE_CACHE_KEY] = {CACHED_TEXT_CACHE_KEY: cached_text}
+    return migrated
+
+
+def _migrate_legacy_course_cache(
+    ctx: SyncContext,
+    course_node: Node,
+    cache_path: Path,
+    log: logging.Logger,
+) -> dict[str, Any] | None:
+    for legacy_path in _legacy_course_cache_paths(ctx, course_node):
+        payload = _read_course_cache_payload(legacy_path, log)
+        if payload is None:
+            continue
+        migrated = _account_bound_legacy_payload(ctx, course_node, payload)
+        if migrated is None:
+            continue
+        if ctx.config.dry_run:
+            log.info("Using legacy course cache for this dry run: %s", legacy_path)
+            return migrated
+        try:
+            write_private_gzip_json(cache_path, migrated)
+        except OSError as error:
+            log.warning(
+                "Could not move legacy course cache %s to %s: %s",
+                legacy_path,
+                cache_path,
+                error,
+            )
+            return migrated
+        try:
+            legacy_path.unlink()
+        except OSError as error:
+            log.warning(
+                "Moved legacy course cache to %s but could not remove %s: %s",
+                cache_path,
+                legacy_path,
+                error,
+            )
+        else:
+            log.info("Moved legacy course cache %s to %s", legacy_path, cache_path)
+        return migrated
+    return None
 
 
 def _cache_since(value: Any) -> int | None:
@@ -304,17 +521,15 @@ def _course_cache_state(
     if course_node in ctx.course_cache_states:
         return ctx.course_cache_states[course_node]
 
-    course_path = _node_path(ctx, course_node)
-    cache_path = course_path / COURSE_CACHE_FILENAME
-    payload = (
-        read_private_gzip_json(cache_path, "course cache")
-        if cache_path.exists()
-        else None
-    )
-    if not isinstance(payload, dict):
-        payload = None
-    elif payload.get("format") != COURSE_CACHE_FORMAT:
-        log.warning("Ignoring unsupported course cache format: %s", cache_path)
+    cache_path = course_cache_path(ctx, course_node)
+    cache_exists = cache_path.exists()
+    payload = _read_course_cache_payload(cache_path, log) if cache_exists else None
+    if not cache_exists:
+        payload = _migrate_legacy_course_cache(ctx, course_node, cache_path, log)
+    if payload is not None and payload.get("identity") != _cache_identity(
+        ctx, course_node
+    ):
+        log.warning("Ignoring course cache with mismatched identity: %s", cache_path)
         payload = None
 
     course_root = None
@@ -681,27 +896,41 @@ def node_to_cache_data(
     etag = node.etag
     etag_kind = node.etag_kind
     content_hash = node.content_hash
+    artifact_hashes = dict(node.artifact_hashes)
     remote_size = node.remote_size
     is_handled = node.is_handled
-    node_path = _node_path(ctx, node)
-    downloaded_this_run = node_path in ctx.downloaded_paths
+    is_verified = node.is_verified
+    node_paths = _node_artifact_paths(ctx, node, node)
+    verified_this_run = any(path in ctx.downloaded_paths for path in node_paths)
+    old_node_paths = (
+        _node_artifact_paths(ctx, node, old_node) if old_node is not None else []
+    )
     # If this file was not actually downloaded this run but a previously
     # downloaded version is still on disk, keep the previously cached version
     # markers. The node may still be marked as handled when download traversal
     # skipped an unchanged existing file; downloaded_paths tells us whether
-    # bytes were really replaced in this run.
+    # current remote bytes were installed or verified in this run.
     if (
-        not downloaded_this_run
+        not verified_this_run
         and old_node is not None
-        and old_node.is_handled
-        and node_path.exists()
+        and old_node.is_verified
+        and old_node_paths
+        and all(path.exists() for path in old_node_paths)
     ):
         timemodified = old_node.timemodified
         etag = old_node.etag
         etag_kind = old_node.etag_kind
         content_hash = old_node.content_hash
+        artifact_hashes = dict(old_node.artifact_hashes)
         remote_size = remote_size if remote_size is not None else old_node.remote_size
         is_handled = True
+        is_verified = True
+    elif is_handled and not is_verified:
+        timemodified = None
+        etag = None
+        etag_kind = None
+        content_hash = None
+        artifact_hashes = {}
     return {
         "name": node.name,
         "id": node.id,
@@ -712,10 +941,15 @@ def node_to_cache_data(
         "etag": etag,
         "etag_kind": str(etag_kind) if etag_kind else None,
         "content_hash": content_hash,
+        "artifact_hashes": artifact_hashes,
         "remote_size": remote_size,
         "name_clash_id": node.name_clash_id,
         "download_status": str(
-            DownloadStatus.HANDLED if is_handled else DownloadStatus.PENDING
+            DownloadStatus.HANDLED
+            if is_verified
+            else DownloadStatus.SKIPPED
+            if is_handled
+            else DownloadStatus.PENDING
         ),
         "children": [
             node_to_cache_data(ctx, child, match_old_cache_child(old_node, child))
@@ -736,7 +970,7 @@ def node_from_cache_data(data: dict[str, Any], parent: Node | None = None) -> No
         raise ValueError("course cache node has invalid children")
 
     download_status = data.get("download_status")
-    if download_status is None and data.get("is_downloaded"):
+    if download_status is None and data.get("is_downloaded") is True:
         download_status = DownloadStatus.HANDLED
     node = Node(
         name,
@@ -748,11 +982,11 @@ def node_from_cache_data(data: dict[str, Any], parent: Node | None = None) -> No
         etag=data.get("etag"),
         etag_kind=data.get("etag_kind"),
         content_hash=data.get("content_hash"),
+        artifact_hashes=data.get("artifact_hashes"),
         remote_size=data.get("remote_size"),
         name_clash_id=data.get("name_clash_id", NAME_CLASH_ID_UNSET),
         download_status=download_status,
-        download_kind=data.get("download_kind")
-        or LEGACY_DOWNLOAD_KINDS.get(node_type, DownloadKind.DIRECT),
+        download_kind=_cached_download_kind(data),
     )
     node.children = [node_from_cache_data(child, node) for child in children]
     return node
@@ -814,12 +1048,7 @@ def cache_root_node(
     ctx: SyncContext,
     log: logging.Logger = logger,
 ) -> None:
-    """Persist per-course caches into .syncmymoodle_cache files.
-
-    Each course directory beneath the sync directory receives its own cache file
-    containing the course subtree, which makes caching less brittle than
-    a single global root cache.
-    """
+    """Persist account-bound course caches under the stable cache directory."""
     if not ctx.root_node:
         return
 
@@ -829,12 +1058,14 @@ def cache_root_node(
         for course_node in semester_node.children:
             if course_node.type != "Course":
                 continue
-            course_path = _node_path(ctx, course_node)
             state = _course_cache_state(ctx, course_node, log)
-            course_path.mkdir(parents=True, exist_ok=True)
-            cache_path = course_path / COURSE_CACHE_FILENAME
+            if course_node.id in ctx.incomplete_course_ids:
+                continue
+            cache_path = course_cache_path(ctx, course_node)
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
             payload: dict[str, Any] = {
                 "format": COURSE_CACHE_FORMAT,
+                "identity": _cache_identity(ctx, course_node),
                 "course": node_to_cache_data(ctx, course_node, state.course_root),
             }
             module_cache = _course_module_cache_data(ctx, state, course_node)

--- a/syncmymoodle/downloader.py
+++ b/syncmymoodle/downloader.py
@@ -14,7 +14,7 @@ from typing import Any
 import requests
 import yt_dlp
 
-from syncmymoodle import course_cache, filters, links, opencast, pathing, quiz
+from syncmymoodle import course_cache, filters, links, opencast, pathing, quiz, storage
 from syncmymoodle.constants import (
     DEFAULT_BLOCK_SIZE,
     HASH_ALGOS_BY_LENGTH,
@@ -37,8 +37,9 @@ from syncmymoodle.http_utils import (
 from syncmymoodle.node import DownloadKind, Node, RemoteMarkerKind
 from syncmymoodle.outcomes import (
     FAILED_DOWNLOAD,
-    HANDLED_DOWNLOAD,
     PLANNED_DOWNLOAD,
+    POLICY_SKIPPED_DOWNLOAD,
+    SKIPPED_DOWNLOAD,
     UNCHANGED_DOWNLOAD,
     DownloadOutcome,
     completed_download,
@@ -95,6 +96,7 @@ class DownloadDecision(Enum):
 
     DOWNLOAD = "download"
     SKIP = "skip"
+    POLICY_SKIP = "policy_skip"
     CONFLICT = "conflict"
 
 
@@ -302,7 +304,7 @@ def conditional_get_confirms_unchanged(
     download_origin = normalized_http_origin(node.url)
     if download_origin and ctx.service_outages.should_skip(download_origin):
         return False
-    if node.type == "Opencast":
+    if node.download_kind is DownloadKind.OPENCAST:
         if ctx.config.dry_run:
             return False
         authorized, _ = authorize_opencast_download(ctx, node, log)
@@ -398,6 +400,15 @@ def assess_local_copy(
     cached_timemodified: Any,
 ) -> LocalCopyState:
     """Classify the on-disk file when the remote may have changed."""
+    remote_etag = getattr(node, "etag", None)
+    remote_etag_kind = node.etag_kind
+    if (
+        remote_etag_kind == RemoteMarkerKind.CONTENT_HASH
+        and classify_local_file(downloadpath, remote_etag) is FileMatch.MATCH
+    ):
+        align_mtime_with_timemodified(node, downloadpath)
+        return LocalCopyState.UP_TO_DATE
+
     verdict = classify_local_file(downloadpath, local_verification_marker(old_node))
     if verdict is FileMatch.MATCH:
         return LocalCopyState.CLEAN
@@ -412,16 +423,6 @@ def assess_local_copy(
         except (OSError, ValueError):
             return LocalCopyState.MODIFIED
 
-    remote_etag = getattr(node, "etag", None)
-    remote_etag_kind = node.etag_kind
-    if (
-        remote_etag_kind == RemoteMarkerKind.CONTENT_HASH
-        and classify_local_file(downloadpath, remote_etag) is FileMatch.MATCH
-    ):
-        node.etag = remote_etag
-        node.etag_kind = remote_etag_kind
-        align_mtime_with_timemodified(node, downloadpath)
-        return LocalCopyState.UP_TO_DATE
     return LocalCopyState.MODIFIED
 
 
@@ -437,22 +438,21 @@ def decide_download(
     if not downloadpath.exists():
         return DownloadDecision.DOWNLOAD
     if not ctx.config.update_files:
-        return DownloadDecision.SKIP
+        return DownloadDecision.POLICY_SKIP
 
     old_node = course_cache.get_old_node_for(ctx, node, log)
-    if old_node is not None and not old_node.is_handled:
+    if old_node is not None and not old_node.is_verified:
         old_node = None
     cached_timemodified = (
         getattr(old_node, "timemodified", None) if old_node is not None else None
     )
 
+    verdict = assess_local_copy(node, downloadpath, old_node, cached_timemodified)
+    if verdict is LocalCopyState.UP_TO_DATE:
+        return DownloadDecision.SKIP
     if old_node is not None and remote_unchanged(
         ctx, node, old_node, cached_timemodified, log
     ):
-        return DownloadDecision.SKIP
-
-    verdict = assess_local_copy(node, downloadpath, old_node, cached_timemodified)
-    if verdict is LocalCopyState.UP_TO_DATE:
         return DownloadDecision.SKIP
     if verdict is LocalCopyState.MODIFIED:
         return DownloadDecision.CONFLICT
@@ -463,7 +463,7 @@ def should_skip_before_decision(
     ctx: SyncContext, node: Node, downloadpath: Path
 ) -> DownloadOutcome | None:
     if filters.should_skip_url(ctx, node.url, f"{node.type} file"):
-        return HANDLED_DOWNLOAD
+        return SKIPPED_DOWNLOAD
     extension = node.name.split(".")[-1]
     if extension in ctx.config.exclude_filetypes:
         ctx.record_filtered(
@@ -472,7 +472,7 @@ def should_skip_before_decision(
             str(downloadpath),
             f"extension {extension!r} is excluded",
         )
-        return HANDLED_DOWNLOAD
+        return SKIPPED_DOWNLOAD
     pattern = next(
         (
             pattern
@@ -488,7 +488,7 @@ def should_skip_before_decision(
             str(downloadpath),
             f"matches {pattern!r}",
         )
-        return HANDLED_DOWNLOAD
+        return SKIPPED_DOWNLOAD
     if downloadpath in ctx.downloaded_paths:
         return UNCHANGED_DOWNLOAD
     return None
@@ -605,7 +605,7 @@ def planned_download_action(
     early_outcome = should_skip_before_decision(ctx, node, downloadpath)
     if early_outcome is not None:
         return early_outcome
-    if node.type == "Opencast":
+    if node.download_kind is DownloadKind.OPENCAST:
         course_node = _opencast_course_node(node)
         course_id = course_node.id if course_node is not None else None
         if opencast.episode_metadata_is_stale(
@@ -614,7 +614,7 @@ def planned_download_action(
             str(node.id or ""),
         ):
             if downloadpath.exists() and not ctx.config.update_files:
-                return UNCHANGED_DOWNLOAD
+                return POLICY_SKIPPED_DOWNLOAD
             log.warning(
                 "Skipping Opencast download %s because its metadata could not be "
                 "refreshed",
@@ -622,9 +622,11 @@ def planned_download_action(
             )
             return FAILED_DOWNLOAD
     if known_remote_size_violates_limit(ctx, node, downloadpath):
-        return HANDLED_DOWNLOAD
+        return SKIPPED_DOWNLOAD
 
     decision = decide_download(ctx, node, downloadpath, log)
+    if decision is DownloadDecision.POLICY_SKIP:
+        return POLICY_SKIPPED_DOWNLOAD
     if decision is DownloadDecision.SKIP:
         return UNCHANGED_DOWNLOAD
     action = (
@@ -633,7 +635,7 @@ def planned_download_action(
         else ConflictAction.DOWNLOAD
     )
     if action == ConflictAction.SKIP:
-        return UNCHANGED_DOWNLOAD
+        return POLICY_SKIPPED_DOWNLOAD
     return action
 
 
@@ -776,27 +778,15 @@ def install_downloaded_file(
     action: ConflictAction,
     log: logging.Logger = logger,
 ) -> bool:
-    if action == ConflictAction.RENAME_LOCAL:
-        conflict_path = pathing.make_conflict_path(downloadpath)
-        try:
-            downloadpath.rename(conflict_path)
-            log.warning(
-                "Detected local changes for %s, moved to %s before installing "
-                "the updated file from Moodle",
-                downloadpath,
-                conflict_path,
-            )
-        except OSError:
-            log.exception(
-                "Failed to move locally modified file %s to %s; keeping it "
-                "and discarding the downloaded update to avoid data loss",
-                downloadpath,
-                conflict_path,
-            )
-            transfer.discard_partial()
-            return False
-
-    os.replace(transfer.tmp_path, downloadpath)
+    if not storage.install_staged_file(
+        transfer.tmp_path,
+        downloadpath,
+        rename_local=action is ConflictAction.RENAME_LOCAL,
+        description="the updated file from Moodle",
+        log=log,
+    ):
+        transfer.discard_partial()
+        return False
     transfer.etag_sidecar.unlink(missing_ok=True)
     return True
 
@@ -805,12 +795,9 @@ def record_download_metadata(
     node: Node,
     downloadpath: Path,
     etag_header: str | None,
+    content_hash: str | None = None,
 ) -> None:
-    try:
-        with downloadpath.open("rb") as fh:
-            node.content_hash = hashlib.file_digest(fh, "sha256").hexdigest()
-    except OSError:
-        pass
+    node.content_hash = content_hash or storage.file_sha256(downloadpath)
 
     align_mtime_with_timemodified(node, downloadpath)
 
@@ -837,7 +824,7 @@ def process_download_response(
     if not download_response_is_usable(node, response, downloadpath, log):
         return FAILED_DOWNLOAD
     if download_violates_size_limits(ctx, node, response, resume_size, downloadpath):
-        return HANDLED_DOWNLOAD
+        return SKIPPED_DOWNLOAD
 
     if ctx.config.dry_run:
         return report_planned_download(ctx, downloadpath, node.type)
@@ -858,9 +845,19 @@ def process_download_response(
         content,
         first_chunk,
     )
+    staged_hash = storage.file_sha256(transfer.tmp_path)
+    local_hash = storage.file_sha256(downloadpath) if downloadpath.exists() else None
+    if staged_hash is not None and staged_hash == local_hash:
+        transfer.discard_partial()
+        record_download_metadata(node, downloadpath, etag_header, staged_hash)
+        ctx.downloaded_paths.add(downloadpath)
+        return DownloadOutcome(
+            unchanged=1,
+            transferred_bytes=transferred_bytes,
+        )
     if not install_downloaded_file(downloadpath, transfer, action, log):
         return FAILED_DOWNLOAD
-    record_download_metadata(node, downloadpath, etag_header)
+    record_download_metadata(node, downloadpath, etag_header, staged_hash)
     ctx.downloaded_paths.add(downloadpath)
     return completed_download(existed=existed, transferred_bytes=transferred_bytes)
 
@@ -940,12 +937,12 @@ def download_file(
     action = action_or_outcome
 
     if ctx.config.dry_run and (
-        node.type == "Opencast" or not size_limits_configured(ctx)
+        node.download_kind is DownloadKind.OPENCAST or not size_limits_configured(ctx)
     ):
         return report_planned_download(ctx, downloadpath, node.type)
 
     opencast_course_id: Any = None
-    if node.type == "Opencast":
+    if node.download_kind is DownloadKind.OPENCAST:
         authorized, opencast_course_id = authorize_opencast_download(ctx, node, log)
         if not authorized:
             return FAILED_DOWNLOAD
@@ -993,7 +990,7 @@ def download_file(
             log,
         )
         if (
-            node.type == "Opencast"
+            node.download_kind is DownloadKind.OPENCAST
             and not outcome.is_handled
             and (
                 response.status_code in {401, 403, 404, 410}
@@ -1070,7 +1067,10 @@ def download_node_tree(
         outcome = download_leaf(ctx, node, log)
         ctx.stats.record_download(outcome)
         if outcome.is_handled:
-            node.mark_handled()
+            if outcome.cache_verified:
+                node.mark_handled()
+            else:
+                node.mark_skipped()
         progress.finish_item(index)
 
 
@@ -1090,7 +1090,7 @@ def download_emedia_video(
         return action_or_outcome
     action = action_or_outcome
     if cached_yt_dlp_size_violates_limit(ctx, node, downloadpath, log):
-        return HANDLED_DOWNLOAD
+        return SKIPPED_DOWNLOAD
     if ctx.config.dry_run and not size_limits_configured(ctx):
         return report_planned_download(ctx, downloadpath, "Emedia")
 
@@ -1117,7 +1117,7 @@ def download_emedia_video(
         ydl_opts["fixup"] = "never"
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:
         if yt_dlp_violates_size_limits(ctx, ydl, node, node.url, "emedia video"):
-            return HANDLED_DOWNLOAD
+            return SKIPPED_DOWNLOAD
         if ctx.config.dry_run:
             return report_planned_download(ctx, downloadpath, "Emedia")
         ctx.output.action("Downloading", downloadpath, "Emedia")
@@ -1167,7 +1167,7 @@ def scan_and_download_youtube(
     path = pathing.get_sanitized_node_path(node.parent, Path(ctx.config.sync_directory))
     link = node.url
     if filters.should_skip_url(ctx, link, "YouTube link"):
-        return HANDLED_DOWNLOAD
+        return SKIPPED_DOWNLOAD
     video_id = links.youtube_video_id_from_node(node)
     if youtube_download_exists(path, video_id):
         return UNCHANGED_DOWNLOAD
@@ -1179,7 +1179,7 @@ def scan_and_download_youtube(
             verb="Would download YouTube video",
         )
     if cached_yt_dlp_size_violates_limit(ctx, node, path, log):
-        return HANDLED_DOWNLOAD
+        return SKIPPED_DOWNLOAD
     outtmpl = pathing.with_windows_extended_length_prefix(
         path / "%(title)s-%(id)s.%(ext)s",
         force=True,
@@ -1195,7 +1195,7 @@ def scan_and_download_youtube(
     }
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:
         if yt_dlp_violates_size_limits(ctx, ydl, node, link, "YouTube video"):
-            return HANDLED_DOWNLOAD
+            return SKIPPED_DOWNLOAD
         if ctx.config.dry_run:
             return report_planned_download(
                 ctx,
@@ -1228,7 +1228,7 @@ def cached_yt_dlp_size_violates_limit(
     log: logging.Logger = logger,
 ) -> bool:
     old_node = course_cache.get_old_node_for(ctx, node, log)
-    if old_node is None or not old_node.is_handled or old_node.remote_size is None:
+    if old_node is None or not old_node.is_verified or old_node.remote_size is None:
         return False
     node.remote_size = old_node.remote_size
     return known_remote_size_violates_limit(ctx, node, path)

--- a/syncmymoodle/links.py
+++ b/syncmymoodle/links.py
@@ -356,6 +356,7 @@ def _scan_single_link(
         return False
     course_key = str(course_id)
     cache = ctx.linked_resources_by_course.setdefault(course_key, {})
+    cached_resource = cache.get(url)
     ctx.seen_linked_resources.add((course_key, url))
     if url in ctx.linked_resource_results:
         resource = ctx.linked_resource_results[url]
@@ -371,6 +372,8 @@ def _scan_single_link(
             cache.pop(url, None)
 
     if resource is None:
+        if cached_resource is not None:
+            ctx.mark_course_incomplete(course_id)
         return False
     if resource.html is None:
         parent_node.add_child(

--- a/syncmymoodle/moodle.py
+++ b/syncmymoodle/moodle.py
@@ -617,20 +617,28 @@ def _get_course_module_instances(
     course_id: int,
     function: str,
     response_key: str,
-) -> list[dict[str, Any]]:
+) -> list[dict[str, Any]] | None:
     payload = call_webservice(
         session,
         wstoken,
         function,
         {"courseids[0]": course_id},
     )
-    instances = payload.get(response_key) if isinstance(payload, dict) else None
-    return [item for item in instances or [] if isinstance(item, dict)]
+    return _dict_list_field(payload, response_key)
+
+
+def _dict_list_field(payload: Any, key: str) -> list[dict[str, Any]] | None:
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get(key)
+    if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
+        return None
+    return value
 
 
 def get_ltis_by_course(
     session: requests.Session, wstoken: str, course_id: int
-) -> list[dict[str, Any]]:
+) -> list[dict[str, Any]] | None:
     return _get_course_module_instances(
         session, wstoken, course_id, "mod_lti_get_ltis_by_courses", "ltis"
     )
@@ -647,7 +655,7 @@ def get_lti_launch_data(
 
 def get_h5pactivities_by_course(
     session: requests.Session, wstoken: str, course_id: int
-) -> list[dict[str, Any]]:
+) -> list[dict[str, Any]] | None:
     return _get_course_module_instances(
         session,
         wstoken,
@@ -659,7 +667,7 @@ def get_h5pactivities_by_course(
 
 def get_quizzes_by_course(
     session: requests.Session, wstoken: str, course_id: int
-) -> list[dict[str, Any]]:
+) -> list[dict[str, Any]] | None:
     return _get_course_module_instances(
         session, wstoken, course_id, "mod_quiz_get_quizzes_by_courses", "quizzes"
     )
@@ -958,7 +966,7 @@ def get_folders_by_courses(
     wstoken: str,
     course_id: Any,
     log: logging.Logger = logger,
-) -> Any:
+) -> list[dict[str, Any]] | None:
     payload = call_webservice(
         session,
         wstoken,
@@ -970,6 +978,4 @@ def get_folders_by_courses(
         },
         log,
     )
-    if not isinstance(payload, dict):
-        return []
-    return payload.get("folders") or []
+    return _dict_list_field(payload, "folders")

--- a/syncmymoodle/moodle_files.py
+++ b/syncmymoodle/moodle_files.py
@@ -1,12 +1,41 @@
+import urllib.parse
 from typing import Any
 
+from syncmymoodle.constants import HASH_ALGOS_BY_LENGTH, MOODLE_URL
 from syncmymoodle.http_utils import (
     HTML_CONTENT_TYPES,
     filename_from_url,
     media_type_without_parameters,
+    same_origin,
 )
-from syncmymoodle.node import NAME_CLASH_ID_UNSET, Node
+from syncmymoodle.node import NAME_CLASH_ID_UNSET, Node, RemoteMarkerKind
 from syncmymoodle.pathing import sanitize_path_part
+
+
+def canonicalize_moodle_file_url(url: str) -> str:
+    """Normalize Moodle file endpoint quirks without changing external URLs."""
+    if not same_origin(url, MOODLE_URL):
+        return url
+
+    parsed = urllib.parse.urlsplit(url)
+    path = parsed.path
+    webservice_prefix = "/webservice/pluginfile.php/"
+    if path.startswith(webservice_prefix):
+        path = f"/pluginfile.php/{path.removeprefix(webservice_prefix)}"
+    legacy_page_prefix = "/mod_page/content/3/"
+    if legacy_page_prefix in path:
+        path = path.replace(legacy_page_prefix, "/mod_page/content/", 1)
+    query = urllib.parse.urlencode(
+        [
+            (name, value)
+            for name, value in urllib.parse.parse_qsl(
+                parsed.query,
+                keep_blank_values=True,
+            )
+            if name.casefold() != "forcedownload"
+        ]
+    )
+    return urllib.parse.urlunsplit(parsed._replace(path=path, query=query))
 
 
 def get_or_add_child(
@@ -35,7 +64,10 @@ def add_moodle_file_node(
     timemodified: Any = None,
     remote_size: int | None = None,
     name_clash_id: Any = NAME_CLASH_ID_UNSET,
+    remote_content_hash: Any = None,
 ) -> Node | None:
+    if url is not None:
+        url = canonicalize_moodle_file_url(url)
     target_node: Node | None = parent_node
     path_segments = [
         segment
@@ -54,12 +86,23 @@ def add_moodle_file_node(
     if target_node is None:
         return None
 
+    content_hash = (
+        remote_content_hash.lower()
+        if isinstance(remote_content_hash, str)
+        and len(remote_content_hash) in HASH_ALGOS_BY_LENGTH
+        and all(
+            character in "0123456789abcdefABCDEF" for character in remote_content_hash
+        )
+        else None
+    )
     return target_node.add_child(
         filename,
         id,
         type,
         url=url,
         timemodified=timemodified,
+        etag=content_hash,
+        etag_kind=RemoteMarkerKind.CONTENT_HASH if content_hash else None,
         remote_size=remote_size,
         name_clash_id=name_clash_id,
     )
@@ -90,6 +133,7 @@ def add_moodle_content_file_node(
         timemodified=content.get("timemodified"),
         remote_size=content.get("filesize"),
         name_clash_id=None,
+        remote_content_hash=content.get("contenthash"),
     )
 
 

--- a/syncmymoodle/node.py
+++ b/syncmymoodle/node.py
@@ -1,12 +1,7 @@
 from __future__ import annotations
 
-import base64
-import hashlib
 from enum import StrEnum
-from pathlib import Path
 from typing import Any
-
-from syncmymoodle.pathing import sanitize_path_part, sanitized_node_path_parts
 
 NAME_CLASH_ID_UNSET = object()
 
@@ -19,6 +14,7 @@ class RemoteMarkerKind(StrEnum):
 class DownloadStatus(StrEnum):
     PENDING = "pending"
     HANDLED = "handled"
+    SKIPPED = "skipped"
 
 
 class DownloadKind(StrEnum):
@@ -68,6 +64,20 @@ def _optional_int(value: Any) -> int | None:
     return parsed if parsed >= 0 else None
 
 
+def _artifact_hashes(value: Any) -> dict[str, str]:
+    if not isinstance(value, dict):
+        return {}
+    return {
+        key: digest
+        for key, digest in value.items()
+        if isinstance(key, str)
+        and key.isalnum()
+        and isinstance(digest, str)
+        and len(digest) == 64
+        and all(character in "0123456789abcdef" for character in digest)
+    }
+
+
 class Node:
     def __init__(
         self,
@@ -81,6 +91,7 @@ class Node:
         etag: str | None = None,
         etag_kind: RemoteMarkerKind | str | None = None,
         content_hash: str | None = None,
+        artifact_hashes: dict[str, str] | None = None,
         remote_size: Any = None,
         name_clash_id: Any = NAME_CLASH_ID_UNSET,
         download_status: DownloadStatus | str | None = None,
@@ -100,6 +111,7 @@ class Node:
         # Unlike etag, which for Sciebo/WebDAV is an opaque revision token, this
         # is a real hash of our copy, used to detect local user modifications.
         self.content_hash = content_hash
+        self.artifact_hashes = _artifact_hashes(artifact_hashes)
         self.remote_size = _optional_int(remote_size)
         self.name_clash_id = (
             id if name_clash_id is NAME_CLASH_ID_UNSET else name_clash_id
@@ -117,10 +129,17 @@ class Node:
 
     @property
     def is_handled(self) -> bool:
+        return self.download_status != DownloadStatus.PENDING
+
+    @property
+    def is_verified(self) -> bool:
         return self.download_status == DownloadStatus.HANDLED
 
     def mark_handled(self) -> None:
         self.download_status = DownloadStatus.HANDLED
+
+    def mark_skipped(self) -> None:
+        self.download_status = DownloadStatus.SKIPPED
 
     def add_child(
         self,
@@ -136,14 +155,8 @@ class Node:
         name_clash_id: Any = NAME_CLASH_ID_UNSET,
         download_kind: DownloadKind | str | None = None,
     ) -> Node | None:
-        if url:
-            url = url.replace("?forcedownload=1", "").replace(
-                "mod_page/content/3/", "mod_page/content/"
-            )
-            url = url.replace("webservice/pluginfile.php", "pluginfile.php")
-
         # Check for duplicate urls and just ignore those nodes:
-        if url and any([True for c in self.children if c.url == url]):
+        if url and any(child.url == url for child in self.children):
             return None
 
         temp = Node(
@@ -175,6 +188,7 @@ class Node:
             etag=self.etag,
             etag_kind=self.etag_kind,
             content_hash=self.content_hash,
+            artifact_hashes=self.artifact_hashes,
             remote_size=self.remote_size,
             name_clash_id=self.name_clash_id,
             download_status=self.download_status,
@@ -190,130 +204,3 @@ class Node:
             ret.insert(0, cur.name)
             cur = cur.parent
         return ret
-
-    def _clash_suffix(self) -> str:
-        # Stable, distinct suffix used to disambiguate same-named siblings.
-        # A URL identifies the actual downloadable file, including direct-link
-        # nodes whose name_clash_id is None. Non-downloadable nodes such as
-        # courses fall back to their stable Moodle id.
-        key = self.url if self.url is not None else self.name_clash_id
-        return base64.urlsafe_b64encode(
-            hashlib.md5(str(key).encode("utf-8")).hexdigest().encode("utf-8")
-        ).decode()[:10]
-
-    def _stable_clash_name(self) -> str:
-        filename = Path(self.name)
-        return filename.stem + "_" + self._clash_suffix() + filename.suffix
-
-    def _opencast_clash_name(self) -> str:
-        return f"{Path(self.name).name}_{str(self.url).split('/')[-1]}"
-
-    @staticmethod
-    def _filesystem_name_key(node: Node) -> str:
-        return sanitize_path_part(node.name).casefold()
-
-    def _filesystem_path_key(self) -> tuple[str, ...]:
-        return tuple(part.casefold() for part in sanitized_node_path_parts(self))
-
-    @classmethod
-    def _general_name_clash(cls, left: Node, right: Node) -> bool:
-        if cls._filesystem_name_key(left) != cls._filesystem_name_key(right):
-            return False
-        if left.url != right.url:
-            return True
-        return (
-            left.type == "Course"
-            and right.type == "Course"
-            and left.name_clash_id != right.name_clash_id
-        )
-
-    @classmethod
-    def _apply_opencast_name_clashes(cls, children: list[Node]) -> list[Node]:
-        remaining = children.copy()
-        renamed: list[Node] = []
-
-        while remaining:
-            child = remaining.pop(0)
-            renamed.append(child)
-            if child.download_kind is not DownloadKind.OPENCAST:
-                continue
-
-            siblings = [
-                sibling
-                for sibling in remaining
-                if cls._filesystem_name_key(sibling) == cls._filesystem_name_key(child)
-                and sibling.url != child.url
-            ]
-            if not siblings:
-                continue
-
-            child.name = child._opencast_clash_name()
-            for sibling in siblings:
-                sibling.name = sibling._opencast_clash_name()
-                remaining.remove(sibling)
-                renamed.append(sibling)
-
-        return renamed
-
-    @classmethod
-    def _apply_general_name_clashes(cls, children: list[Node]) -> list[Node]:
-        remaining = children.copy()
-        renamed: list[Node] = []
-
-        while remaining:
-            child = remaining.pop(0)
-            renamed.append(child)
-            siblings = [
-                sibling
-                for sibling in remaining
-                if cls._general_name_clash(child, sibling)
-            ]
-            if not siblings:
-                continue
-
-            child.name = child._stable_clash_name()
-            for sibling in siblings:
-                sibling.name = sibling._stable_clash_name()
-                remaining.remove(sibling)
-                renamed.append(sibling)
-
-        return renamed
-
-    def _remove_sibling_nameclashes(self) -> None:
-        self.children = self._apply_opencast_name_clashes(self.children)
-        self.children = self._apply_general_name_clashes(self.children)
-
-        for child in self.children:
-            child._remove_sibling_nameclashes()
-
-    def _resolve_download_path_clashes(self) -> None:
-        download_nodes: list[Node] = []
-        remaining = [self]
-        while remaining:
-            node = remaining.pop()
-            remaining.extend(node.children)
-            if node.url:
-                download_nodes.append(node)
-
-        # Each pass either resolves every collision or moves a colliding file
-        # away from a pre-existing generated name. At most one such name can be
-        # consumed per file; the bound prevents a malformed tree from looping.
-        for _ in range(len(download_nodes) + 1):
-            nodes_by_path: dict[tuple[str, ...], list[Node]] = {}
-            for node in download_nodes:
-                nodes_by_path.setdefault(node._filesystem_path_key(), []).append(node)
-            clashes = [
-                nodes
-                for nodes in nodes_by_path.values()
-                if len({node.url for node in nodes}) > 1
-            ]
-            if not clashes:
-                return
-            for nodes in clashes:
-                for node in nodes:
-                    node.name = node._stable_clash_name()
-        raise ValueError("Could not create unique paths for downloaded files")
-
-    def remove_children_nameclashes(self) -> None:
-        self._remove_sibling_nameclashes()
-        self._resolve_download_path_clashes()

--- a/syncmymoodle/outcomes.py
+++ b/syncmymoodle/outcomes.py
@@ -24,6 +24,7 @@ class DownloadOutcome:
     unchanged: int = 0
     planned: int = 0
     transferred_bytes: int = 0
+    cache_verified: bool = True
 
     @property
     def is_handled(self) -> bool:
@@ -46,13 +47,19 @@ class DownloadOutcome:
             unchanged=self.unchanged + other.unchanged,
             planned=self.planned + other.planned,
             transferred_bytes=self.transferred_bytes + other.transferred_bytes,
+            cache_verified=self.cache_verified and other.cache_verified,
         )
 
 
 HANDLED_DOWNLOAD = DownloadOutcome()
-FAILED_DOWNLOAD = DownloadOutcome(state=DownloadState.FAILED)
+SKIPPED_DOWNLOAD = DownloadOutcome(cache_verified=False)
+POLICY_SKIPPED_DOWNLOAD = DownloadOutcome(unchanged=1, cache_verified=False)
+FAILED_DOWNLOAD = DownloadOutcome(
+    state=DownloadState.FAILED,
+    cache_verified=False,
+)
 UNCHANGED_DOWNLOAD = DownloadOutcome(unchanged=1)
-PLANNED_DOWNLOAD = DownloadOutcome(planned=1)
+PLANNED_DOWNLOAD = DownloadOutcome(planned=1, cache_verified=False)
 
 
 def completed_download(*, existed: bool, transferred_bytes: int = 0) -> DownloadOutcome:

--- a/syncmymoodle/pathing.py
+++ b/syncmymoodle/pathing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import hashlib
 import html
 import ntpath
@@ -9,12 +10,9 @@ import sys
 import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path, PureWindowsPath
-from typing import TYPE_CHECKING
 
 from syncmymoodle.constants import INVALID_CHARS
-
-if TYPE_CHECKING:
-    from syncmymoodle.node import Node
+from syncmymoodle.node import DownloadKind, Node
 
 WINDOWS_EXTENDED_PATH_THRESHOLD = 240
 # Leave room for download sidecars and ``.syncconflict`` suffixes while staying
@@ -132,6 +130,136 @@ def sanitized_node_path_parts(node: Node) -> tuple[str, ...]:
         for index, part in enumerate(node.get_path())
         if not (index == 0 and part == "")
     )
+
+
+def _clash_suffix(node: Node) -> str:
+    # A URL identifies the actual downloadable file, including direct-link
+    # nodes whose name_clash_id is None. Non-downloadable nodes such as courses
+    # fall back to their stable Moodle id.
+    key = node.url if node.url is not None else node.name_clash_id
+    digest = hashlib.md5(str(key).encode("utf-8"), usedforsecurity=False).hexdigest()
+    return base64.urlsafe_b64encode(digest.encode("utf-8")).decode()[:10]
+
+
+def _stable_clash_name(node: Node) -> str:
+    filename = Path(node.name)
+    return f"{filename.stem}_{_clash_suffix(node)}{filename.suffix}"
+
+
+def _opencast_clash_name(node: Node) -> str:
+    return f"{Path(node.name).name}_{str(node.url).split('/')[-1]}"
+
+
+def _filesystem_name_key(node: Node) -> str:
+    return sanitize_path_part(node.name).casefold()
+
+
+def _filesystem_path_key(node: Node) -> tuple[str, ...]:
+    return tuple(part.casefold() for part in sanitized_node_path_parts(node))
+
+
+def _general_name_clash(left: Node, right: Node) -> bool:
+    if _filesystem_name_key(left) != _filesystem_name_key(right):
+        return False
+    if left.url != right.url:
+        return True
+    return (
+        left.type == "Course"
+        and right.type == "Course"
+        and left.name_clash_id != right.name_clash_id
+    )
+
+
+def _apply_opencast_name_clashes(children: list[Node]) -> list[Node]:
+    remaining = children.copy()
+    renamed: list[Node] = []
+
+    while remaining:
+        child = remaining.pop(0)
+        renamed.append(child)
+        if child.download_kind is not DownloadKind.OPENCAST:
+            continue
+
+        siblings = [
+            sibling
+            for sibling in remaining
+            if _filesystem_name_key(sibling) == _filesystem_name_key(child)
+            and sibling.url != child.url
+        ]
+        if not siblings:
+            continue
+
+        child.name = _opencast_clash_name(child)
+        for sibling in siblings:
+            sibling.name = _opencast_clash_name(sibling)
+            remaining.remove(sibling)
+            renamed.append(sibling)
+
+    return renamed
+
+
+def _apply_general_name_clashes(children: list[Node]) -> list[Node]:
+    remaining = children.copy()
+    renamed: list[Node] = []
+
+    while remaining:
+        child = remaining.pop(0)
+        renamed.append(child)
+        siblings = [
+            sibling for sibling in remaining if _general_name_clash(child, sibling)
+        ]
+        if not siblings:
+            continue
+
+        child.name = _stable_clash_name(child)
+        for sibling in siblings:
+            sibling.name = _stable_clash_name(sibling)
+            remaining.remove(sibling)
+            renamed.append(sibling)
+
+    return renamed
+
+
+def _resolve_sibling_name_clashes(node: Node) -> None:
+    node.children = _apply_opencast_name_clashes(node.children)
+    node.children = _apply_general_name_clashes(node.children)
+    for child in node.children:
+        _resolve_sibling_name_clashes(child)
+
+
+def _resolve_download_path_clashes(root: Node) -> None:
+    download_nodes: list[Node] = []
+    remaining = [root]
+    while remaining:
+        node = remaining.pop()
+        remaining.extend(node.children)
+        if node.url:
+            download_nodes.append(node)
+
+    # Each pass either resolves every collision or moves a colliding file away
+    # from a pre-existing generated name. At most one such name can be consumed
+    # per file; the bound prevents a malformed tree from looping.
+    for _ in range(len(download_nodes) + 1):
+        nodes_by_path: dict[tuple[str, ...], list[Node]] = {}
+        for node in download_nodes:
+            nodes_by_path.setdefault(_filesystem_path_key(node), []).append(node)
+        clashes = [
+            nodes
+            for nodes in nodes_by_path.values()
+            if len({node.url for node in nodes}) > 1
+        ]
+        if not clashes:
+            return
+        for nodes in clashes:
+            for node in nodes:
+                node.name = _stable_clash_name(node)
+    raise ValueError("Could not create unique paths for downloaded files")
+
+
+def resolve_node_path_clashes(root: Node) -> None:
+    """Make every materialized node path unique on supported filesystems."""
+    _resolve_sibling_name_clashes(root)
+    _resolve_download_path_clashes(root)
 
 
 def windows_extended_length_path(path: str) -> str:

--- a/syncmymoodle/quiz.py
+++ b/syncmymoodle/quiz.py
@@ -22,7 +22,7 @@ from typing import Any
 import latex2mathml.converter
 import requests
 
-from syncmymoodle import pathing
+from syncmymoodle import course_cache, pathing, storage
 from syncmymoodle.config import Config
 from syncmymoodle.constants import (
     CHROMIUM_BINARY_NAMES,
@@ -44,6 +44,7 @@ from syncmymoodle.http_utils import (
     request_following_safe_redirects,
     same_origin,
 )
+from syncmymoodle.node import Node
 from syncmymoodle.outcomes import (
     FAILED_DOWNLOAD,
     HANDLED_DOWNLOAD,
@@ -703,12 +704,12 @@ def render_pdf_with_chromium(
 
 def render_quiz_pdf(
     ctx: SyncContext,
-    node: Any,
+    node: Node,
     html_path: Path,
     pdf_path: Path,
-    mode: str,
+    display_path: Path,
     log: logging.Logger = logger,
-) -> DownloadOutcome:
+) -> bool:
     browser = find_chromium(ctx.config, log)
     if browser is None:
         log.warning(
@@ -717,18 +718,16 @@ def render_quiz_pdf(
             "Edge, or set 'browser' in the [paths] table of your config.",
             node.name,
         )
-        return FAILED_DOWNLOAD
+        return False
 
-    ctx.output.action("Rendering", pdf_path, "Quiz PDF")
+    ctx.output.action("Rendering", display_path, "Quiz PDF")
     pdf_ok = render_pdf_with_chromium(browser, html_path, pdf_path, log)
     if not pdf_ok:
         log.warning(
             "Keeping the HTML snapshot for %s after PDF rendering failed.",
             node.name,
         )
-    elif mode == "pdf":
-        html_path.unlink(missing_ok=True)
-    return completed_download(existed=False) if pdf_ok else FAILED_DOWNLOAD
+    return pdf_ok
 
 
 def report_quiz_dry_run(
@@ -738,21 +737,285 @@ def report_quiz_dry_run(
     *,
     want_html: bool,
     want_pdf: bool,
+    refresh: bool,
 ) -> DownloadOutcome:
     outcome = HANDLED_DOWNLOAD
-    if not html_path.exists():
-        ctx.output.action("Would download", html_path, "Quiz", dry_run=True)
-        if want_html:
-            outcome = outcome.merge(PLANNED_DOWNLOAD)
-    if want_pdf and not pdf_path.exists():
-        ctx.output.action("Would render", pdf_path, "Quiz PDF", dry_run=True)
+    if want_html and (refresh or not html_path.exists()):
+        verb = "Would update" if html_path.exists() else "Would download"
+        ctx.output.action(verb, html_path, "Quiz", dry_run=True)
         outcome = outcome.merge(PLANNED_DOWNLOAD)
+    if want_pdf and (refresh or not pdf_path.exists()):
+        verb = "Would update" if pdf_path.exists() else "Would render"
+        ctx.output.action(verb, pdf_path, "Quiz PDF", dry_run=True)
+        outcome = outcome.merge(PLANNED_DOWNLOAD)
+    return outcome
+
+
+def _same_quiz_revision(node: Node, old_node: Node | None) -> bool:
+    if node.etag is None:
+        return True
+    return (
+        old_node is not None
+        and old_node.etag == node.etag
+        and old_node.etag_kind == node.etag_kind
+    )
+
+
+def _known_quiz_artifacts(
+    node: Node,
+    old_node: Node | None,
+    artifacts: dict[str, Path],
+) -> set[str]:
+    existing = {kind for kind, path in artifacts.items() if path.exists()}
+    if node.etag is None or (old_node is not None and old_node.is_verified):
+        return existing
+    if old_node is None:
+        return set()
+    return existing & old_node.artifact_hashes.keys()
+
+
+def _initialize_quiz_artifact_hashes(
+    node: Node,
+    old_node: Node | None,
+    same_revision: bool,
+) -> None:
+    if same_revision and old_node is not None:
+        node.artifact_hashes = dict(old_node.artifact_hashes)
+    elif not same_revision:
+        node.artifact_hashes = {}
+
+
+def _retain_old_quiz_revision(
+    node: Node,
+    old_node: Node | None,
+    unchanged: int,
+) -> DownloadOutcome:
+    if old_node is None or not old_node.is_verified:
+        node.etag = None
+        node.etag_kind = None
+        node.artifact_hashes = {}
+        return DownloadOutcome(unchanged=unchanged, cache_verified=False)
+    node.timemodified = old_node.timemodified
+    node.etag = old_node.etag
+    node.etag_kind = old_node.etag_kind
+    node.artifact_hashes = dict(old_node.artifact_hashes)
+    return DownloadOutcome(unchanged=unchanged)
+
+
+def _temporary_quiz_path(path: Path) -> Path:
+    return pathing.with_windows_extended_length_prefix(
+        path.with_name(f".{path.name}.smmpart")
+    )
+
+
+def _install_quiz_artifact(
+    ctx: SyncContext,
+    node: Node,
+    kind: str,
+    staged_path: Path,
+    target_path: Path,
+    rename_local: bool,
+    log: logging.Logger,
+) -> DownloadOutcome:
+    existed = target_path.exists()
+    if not storage.install_staged_file(
+        staged_path,
+        target_path,
+        rename_local=rename_local,
+        description="the updated quiz artifact",
+        log=log,
+    ):
+        staged_path.unlink(missing_ok=True)
+        return FAILED_DOWNLOAD
+
+    digest = storage.file_sha256(target_path)
+    if digest is None:
+        return FAILED_DOWNLOAD
+    node.artifact_hashes[kind] = digest
+    ctx.downloaded_paths.add(target_path)
+    return completed_download(existed=existed)
+
+
+def _quiz_modified_artifacts(
+    old_node: Node | None,
+    artifacts: dict[str, Path],
+) -> set[str]:
+    baseline = old_node if old_node is not None and old_node.is_verified else None
+    return {
+        kind
+        for kind, path in artifacts.items()
+        if path.exists()
+        and (
+            baseline is None
+            or baseline.artifact_hashes.get(kind) is None
+            or storage.file_sha256(path) != baseline.artifact_hashes[kind]
+        )
+    }
+
+
+def _quiz_policy_outcome(
+    ctx: SyncContext,
+    node: Node,
+    old_node: Node | None,
+    *,
+    same_revision: bool,
+    existing: set[str],
+    known: set[str],
+    modified: set[str],
+) -> DownloadOutcome | None:
+    replacing_existing = bool(existing - known) or (
+        not same_revision and bool(existing)
+    )
+    pending_revision = (
+        same_revision and old_node is not None and not old_node.is_verified
+    )
+    if replacing_existing and not ctx.config.update_files:
+        return (
+            FAILED_DOWNLOAD
+            if pending_revision
+            else _retain_old_quiz_revision(node, old_node, len(existing))
+        )
+    if modified and ctx.config.conflict_handling == "keep":
+        return (
+            FAILED_DOWNLOAD
+            if pending_revision
+            else _retain_old_quiz_revision(node, old_node, len(existing))
+        )
+    return None
+
+
+def _stage_quiz_snapshot(
+    ctx: SyncContext,
+    node: Node,
+    html_path: Path,
+    log: logging.Logger,
+) -> Path | None:
+    if node.url is None:
+        log.warning("No token-derived quiz review is available for %s", node.url)
+        return None
+    review_html = ctx.quiz_review_cache.get(node.url)
+    if review_html is None:
+        log.warning("No token-derived quiz review is available for %s", node.url)
+        return None
+    ctx.output.action("Downloading", html_path, "Quiz")
+    html_path.parent.mkdir(parents=True, exist_ok=True)
+    staged_path = _temporary_quiz_path(html_path)
+    staged_path.unlink(missing_ok=True)
+    try:
+        snapshot = build_quiz_snapshot(
+            review_html,
+            ctx.require_session(),
+            node.url,
+            log,
+        )
+        staged_path.write_text(snapshot, encoding="utf-8")
+    except (OSError, ValueError):
+        log.exception("Failed to create quiz snapshot %s", html_path)
+        staged_path.unlink(missing_ok=True)
+        return None
+    return staged_path
+
+
+def _prepare_quiz_artifacts(
+    ctx: SyncContext,
+    node: Node,
+    html_path: Path,
+    pdf_path: Path,
+    *,
+    snapshot_needed: bool,
+    pdf_needed: bool,
+    log: logging.Logger,
+) -> tuple[Path | None, Path | None, bool]:
+    html_stage = (
+        _stage_quiz_snapshot(ctx, node, html_path, log) if snapshot_needed else None
+    )
+    if snapshot_needed and html_stage is None:
+        return None, None, False
+    if not pdf_needed:
+        return html_stage, None, True
+
+    html_source = html_stage or html_path
+    pdf_stage = _temporary_quiz_path(pdf_path)
+    pdf_stage.unlink(missing_ok=True)
+    if not render_quiz_pdf(ctx, node, html_source, pdf_stage, pdf_path, log):
+        pdf_stage.unlink(missing_ok=True)
+        return html_stage, None, False
+    return html_stage, pdf_stage, True
+
+
+def _install_prepared_quiz_artifacts(
+    ctx: SyncContext,
+    node: Node,
+    html_path: Path,
+    pdf_path: Path,
+    html_stage: Path | None,
+    pdf_stage: Path | None,
+    *,
+    want_html: bool,
+    pdf_needed: bool,
+    prepared: bool,
+    modified: set[str],
+    log: logging.Logger,
+) -> DownloadOutcome:
+    outcome = HANDLED_DOWNLOAD
+    rename_conflicts = ctx.config.conflict_handling == "rename"
+    install_html = html_stage is not None and (
+        (prepared and want_html)
+        or (not prepared and not html_path.exists() and not pdf_path.exists())
+    )
+    if install_html:
+        assert html_stage is not None
+        outcome = outcome.merge(
+            _install_quiz_artifact(
+                ctx,
+                node,
+                "html",
+                html_stage,
+                html_path,
+                rename_conflicts and "html" in modified,
+                log,
+            )
+        )
+        html_stage = None
+    if not outcome.is_handled:
+        if pdf_stage is not None:
+            pdf_stage.unlink(missing_ok=True)
+        return outcome
+
+    if pdf_stage is not None:
+        outcome = outcome.merge(
+            _install_quiz_artifact(
+                ctx,
+                node,
+                "pdf",
+                pdf_stage,
+                pdf_path,
+                rename_conflicts and "pdf" in modified,
+                log,
+            )
+        )
+        expected_html_hash = node.artifact_hashes.get("html")
+        if (
+            outcome.is_handled
+            and not want_html
+            and expected_html_hash is not None
+            and storage.file_sha256(html_path) == expected_html_hash
+        ):
+            try:
+                html_path.unlink(missing_ok=True)
+                node.artifact_hashes.pop("html", None)
+            except OSError:
+                log.warning("Could not remove temporary quiz snapshot %s", html_path)
+    if html_stage is not None:
+        html_stage.unlink(missing_ok=True)
+    if not prepared:
+        outcome = outcome.merge(FAILED_DOWNLOAD)
     return outcome
 
 
 def download_quiz(
     ctx: SyncContext,
-    node: Any,
+    node: Node,
     log: logging.Logger = logger,
 ) -> DownloadOutcome:
     """Save a quiz review attempt as an HTML snapshot and/or a rendered PDF.
@@ -763,7 +1026,7 @@ def download_quiz(
     as a usable fallback when no browser is available.
     """
     mode = ctx.config.quiz_mode
-    if mode == "off":
+    if mode == "off" or node.parent is None:
         return FAILED_DOWNLOAD
     want_html = mode in ("html", "both")
     want_pdf = mode in ("pdf", "both")
@@ -773,52 +1036,83 @@ def download_quiz(
     html_path = pathing.with_windows_extended_length_prefix(path / f"{safe_name}.html")
     pdf_path = pathing.with_windows_extended_length_prefix(path / f"{safe_name}.pdf")
 
-    # Idempotency: skip when every wanted artifact is already on disk.
-    html_done = html_path.exists() if want_html else True
-    pdf_done = pdf_path.exists() if want_pdf else True
-    outcome = DownloadOutcome(
-        unchanged=int(want_html and html_path.exists())
-        + int(want_pdf and pdf_path.exists())
+    old_node = course_cache.get_old_node_for(ctx, node, log)
+    same_revision = _same_quiz_revision(node, old_node)
+    refresh = not same_revision
+    artifacts = {
+        kind: artifact_path
+        for kind, artifact_path, wanted in (
+            ("html", html_path, want_html),
+            ("pdf", pdf_path, want_pdf),
+        )
+        if wanted
+    }
+    existing = {
+        kind for kind, artifact_path in artifacts.items() if artifact_path.exists()
+    }
+    _initialize_quiz_artifact_hashes(node, old_node, same_revision)
+    known = _known_quiz_artifacts(node, old_node, artifacts) if same_revision else set()
+    if same_revision:
+        for kind in known:
+            digest = storage.file_sha256(artifacts[kind])
+            if digest is not None:
+                node.artifact_hashes.setdefault(kind, digest)
+    if same_revision and len(known) == len(artifacts):
+        return DownloadOutcome(unchanged=len(known))
+
+    unverified_existing = existing - known if same_revision else set()
+    modified = set(unverified_existing)
+    if refresh:
+        modified.update(_quiz_modified_artifacts(old_node, artifacts))
+    policy_outcome = _quiz_policy_outcome(
+        ctx,
+        node,
+        old_node,
+        same_revision=same_revision,
+        existing=existing,
+        known=known,
+        modified=modified,
     )
-    if html_done and pdf_done:
-        return outcome
+    if policy_outcome is not None:
+        return policy_outcome
 
     if ctx.config.dry_run:
-        return outcome.merge(
-            report_quiz_dry_run(
-                ctx,
-                html_path,
-                pdf_path,
-                want_html=want_html,
-                want_pdf=want_pdf,
-            )
+        return report_quiz_dry_run(
+            ctx,
+            html_path,
+            pdf_path,
+            want_html=want_html,
+            want_pdf=want_pdf,
+            refresh=refresh or bool(unverified_existing),
         )
 
-    # Only (re)build the snapshot when it is not already on disk. When just the
-    # PDF is missing (e.g. a "both"/"pdf" run that previously found no browser),
-    # we render from the existing snapshot rather than re-downloading the page
-    # and re-inlining every asset.
-    if not html_path.exists():
-        ctx.output.action("Downloading", html_path, "Quiz")
-        review_html = ctx.quiz_review_cache.get(node.url)
-        if review_html is None:
-            log.warning("No token-derived quiz review is available for %s", node.url)
-            return outcome.merge(FAILED_DOWNLOAD)
-
-        path.mkdir(parents=True, exist_ok=True)
-        html_path.write_text(
-            build_quiz_snapshot(
-                review_html,
-                ctx.require_session(),
-                node.url,
-                log,
-            ),
-            encoding="utf-8",
+    html_needed = want_html and (refresh or "html" not in known)
+    pdf_needed = want_pdf and (refresh or "pdf" not in known)
+    snapshot_needed = html_needed or (
+        pdf_needed and (refresh or not html_path.exists())
+    )
+    html_stage, pdf_stage, prepared = _prepare_quiz_artifacts(
+        ctx,
+        node,
+        html_path,
+        pdf_path,
+        snapshot_needed=snapshot_needed,
+        pdf_needed=pdf_needed,
+        log=log,
+    )
+    outcome = DownloadOutcome(unchanged=0 if refresh else len(known))
+    return outcome.merge(
+        _install_prepared_quiz_artifacts(
+            ctx,
+            node,
+            html_path,
+            pdf_path,
+            html_stage,
+            pdf_stage,
+            want_html=want_html,
+            pdf_needed=pdf_needed,
+            prepared=prepared,
+            modified=modified,
+            log=log,
         )
-        if want_html:
-            outcome = outcome.merge(completed_download(existed=False))
-
-    if not want_pdf or pdf_path.exists():
-        return outcome
-
-    return outcome.merge(render_quiz_pdf(ctx, node, html_path, pdf_path, mode, log))
+    )

--- a/syncmymoodle/sciebo.py
+++ b/syncmymoodle/sciebo.py
@@ -81,7 +81,12 @@ def scan_public_shares(
         if _reuse_cached_share(ctx, link, parent_node):
             continue
         ctx.output.sync_progress.module_status("connecting to Sciebo share")
-        _scan_new_share(ctx, link, parent_node, log)
+        if not _scan_new_share(ctx, link, parent_node, log):
+            current: Node | None = parent_node
+            while current is not None and current.type != "Course":
+                current = current.parent
+            if current is not None:
+                ctx.mark_course_incomplete(current.id)
 
 
 def _reuse_cached_share(
@@ -173,18 +178,18 @@ def _scan_new_share(
     link: str,
     parent_node: Node,
     log: logging.Logger,
-) -> None:
+) -> bool:
     share_auth = _share_auth_headers(ctx, link, log)
     if share_auth is None:
         ctx.sciebo_link_cache[link] = None
-        return
+        return False
     sharing_token, auth_headers = share_auth
 
     sciebo_root = parent_node.add_child(
         f"sciebo-{sharing_token}", None, "Sciebo Folder"
     )
     if sciebo_root is None:
-        return
+        return True
 
     if _add_sciebo_files(
         ctx,
@@ -196,10 +201,11 @@ def _scan_new_share(
     ):
         ctx.service_outages.record_available(SCIEBO_URL)
         ctx.sciebo_link_cache[link] = sciebo_root.clone()
-        return
+        return True
 
     parent_node.children.remove(sciebo_root)
     ctx.sciebo_link_cache[link] = None
+    return False
 
 
 def _fetch_webdav_listing(

--- a/syncmymoodle/storage.py
+++ b/syncmymoodle/storage.py
@@ -1,4 +1,5 @@
 import gzip
+import hashlib
 import importlib
 import json
 import logging
@@ -12,6 +13,47 @@ import requests
 from syncmymoodle import pathing
 
 logger = logging.getLogger(__name__)
+
+
+def file_sha256(path: Path) -> str | None:
+    """Return a file's SHA-256 digest, or ``None`` when it cannot be read."""
+    try:
+        with path.open("rb") as handle:
+            return hashlib.file_digest(handle, "sha256").hexdigest()
+    except OSError:
+        return None
+
+
+def install_staged_file(
+    staged_path: Path,
+    target_path: Path,
+    *,
+    rename_local: bool,
+    description: str,
+    log: logging.Logger = logger,
+) -> bool:
+    """Atomically install a staged file, preserving a conflicting local copy."""
+    conflict_path: Path | None = None
+    try:
+        if target_path.exists() and rename_local:
+            conflict_path = pathing.make_conflict_path(target_path)
+            target_path.rename(conflict_path)
+            log.warning(
+                "Detected local changes for %s, moved to %s before installing %s",
+                target_path,
+                conflict_path,
+                description,
+            )
+        os.replace(staged_path, target_path)
+        return True
+    except OSError:
+        log.exception("Failed to install %s at %s", description, target_path)
+        if conflict_path is not None and not target_path.exists():
+            try:
+                conflict_path.rename(target_path)
+            except OSError:
+                log.exception("Failed to restore local file %s", target_path)
+        return False
 
 
 def restrict_private_file_windows(path: Path) -> None:

--- a/syncmymoodle/sync.py
+++ b/syncmymoodle/sync.py
@@ -3,7 +3,7 @@ import time
 from dataclasses import dataclass
 from typing import Any, cast
 
-from syncmymoodle import course_cache, filters, sync_handlers
+from syncmymoodle import course_cache, filters, pathing, sync_handlers
 from syncmymoodle import moodle as moodle_api
 from syncmymoodle.context import SyncContext
 from syncmymoodle.http_utils import redact_url_secrets
@@ -268,15 +268,17 @@ def _course_updates(
 
 def _assignments_by_cmid(
     ctx: SyncContext,
-    course_id: int,
+    course: _PreparedCourse,
     module_names: set[Any],
 ) -> dict[Any, Any]:
     assignments = None
     if ctx.config.module_assignment and "assign" in module_names:
         account = ctx.require_moodle_account()
         assignments = moodle_api.get_assignment(
-            ctx.require_session(), account.wstoken, course_id
+            ctx.require_session(), account.wstoken, course.course_id
         )
+        if assignments is None:
+            ctx.mark_course_incomplete(course.node.id)
     return {
         assignment["cmid"]: assignment
         for assignment in ((assignments or {}).get("assignments") or [])
@@ -286,16 +288,18 @@ def _assignments_by_cmid(
 
 def _folders_by_coursemodule(
     ctx: SyncContext,
-    course_id: int,
+    course: _PreparedCourse,
     module_names: set[Any],
 ) -> dict[Any, Any]:
-    folders = []
+    folders: list[dict[str, Any]] | None = []
     if ctx.config.module_folder and "folder" in module_names:
         account = ctx.require_moodle_account()
         folders = moodle_api.get_folders_by_courses(
-            ctx.require_session(), account.wstoken, course_id
+            ctx.require_session(), account.wstoken, course.course_id
         )
-    return {folder.get("coursemodule"): folder for folder in folders}
+        if folders is None:
+            ctx.mark_course_incomplete(course.node.id)
+    return {folder.get("coursemodule"): folder for folder in folders or []}
 
 
 def _sync_module(
@@ -308,6 +312,7 @@ def _sync_module(
     module_kind = str(module.get("modname") or "unknown")
     run.update_progress(section_index, f"{module_name} [{module_kind}]")
     module_started_at = time.monotonic()
+    failed_before = run.ctx.stats.failed
     try:
         if not filters.should_skip_module(run.ctx, module, module_context.course_id):
             sync_handlers.handle_module(module_context, module)
@@ -318,6 +323,8 @@ def _sync_module(
             module.get("id"),
             module.get("modname"),
         )
+    if run.ctx.stats.failed > failed_before:
+        run.ctx.mark_course_incomplete(run.course.node.id)
     elapsed = time.monotonic() - module_started_at
     if elapsed >= SLOW_MODULE_SECONDS:
         logger.info(
@@ -336,9 +343,10 @@ def _sync_section(
     section: Any,
     section_index: int,
 ) -> None:
-    if isinstance(section, str):
+    if not isinstance(section, dict):
         logger.error("Moodle returned an invalid section for %s", run.course.name)
         run.ctx.stats.failed += 1
+        run.ctx.mark_course_incomplete(run.course.node.id)
         run.update_progress(section_index)
         return
 
@@ -395,12 +403,12 @@ def _sync_course(
     modules = _course_modules(course_sections)
     if _has_complete_module_inventory(course_sections):
         course_cache.retain_current_modules(ctx, course.node, modules, logger)
+    else:
+        ctx.mark_course_incomplete(course.node.id)
     module_names = {module.get("modname") for module in modules}
     run.course_updates = _course_updates(ctx, course, modules)
-    run.assignments_by_cmid = _assignments_by_cmid(ctx, course.course_id, module_names)
-    run.folders_by_coursemodule = _folders_by_coursemodule(
-        ctx, course.course_id, module_names
-    )
+    run.assignments_by_cmid = _assignments_by_cmid(ctx, course, module_names)
+    run.folders_by_coursemodule = _folders_by_coursemodule(ctx, course, module_names)
     for section_index, section in enumerate(course_sections, start=1):
         _sync_section(run, section, section_index)
     ctx.output.sync_progress.finish_course(course_index)
@@ -414,11 +422,11 @@ def sync(ctx: SyncContext) -> None:
     courses = _courses_after_role_filter(ctx, _locally_selected_courses(ctx))
 
     prepared_courses = _prepare_course_nodes(root_node, courses)
-    root_node.remove_children_nameclashes()
+    pathing.resolve_node_path_clashes(root_node)
     progress = ctx.output.sync_progress
     progress.begin_courses(len(prepared_courses))
     for course_index, course in enumerate(prepared_courses, start=1):
         ctx.stats.courses += 1
         progress.start_course(course_index, course.name)
         _sync_course(ctx, root_node, course, course_index)
-    root_node.remove_children_nameclashes()
+    pathing.resolve_node_path_clashes(root_node)

--- a/syncmymoodle/sync_handlers.py
+++ b/syncmymoodle/sync_handlers.py
@@ -1,3 +1,4 @@
+import hashlib
 import html
 import io
 import logging
@@ -16,7 +17,7 @@ from syncmymoodle import links as links_api
 from syncmymoodle import moodle as moodle_api
 from syncmymoodle import opencast as opencast_api
 from syncmymoodle.constants import HTTP_TIMEOUT_SECONDS, MOODLE_URL
-from syncmymoodle.context import SyncContext
+from syncmymoodle.context import ModuleInstanceCache, SyncContext
 from syncmymoodle.http_utils import (
     HTML_CONTENT_TYPES,
     content_length,
@@ -26,7 +27,7 @@ from syncmymoodle.http_utils import (
     read_capped_body,
     safe_request_error,
 )
-from syncmymoodle.node import DownloadKind, Node
+from syncmymoodle.node import DownloadKind, Node, RemoteMarkerKind
 
 logger = logging.getLogger(__name__)
 H5P_PACKAGE_MAX_BYTES = 2 * 1024**3
@@ -51,6 +52,9 @@ class ModuleContext:
 
     def status(self, message: str) -> None:
         self.ctx.output.sync_progress.module_status(message)
+
+    def mark_incomplete(self) -> None:
+        self.ctx.mark_course_incomplete(self.course_node.id)
 
 
 @dataclass(frozen=True)
@@ -361,20 +365,38 @@ def _read_h5p_content(
 
 
 def module_instance(
-    ctx: SyncContext,
+    module_context: ModuleContext,
     module: dict[str, Any],
-    course_id: Any,
-    cache: dict[int, dict[str, Any]],
-    fetch: Callable[[Any, str, int], list[dict[str, Any]]],
+    cache: ModuleInstanceCache,
+    fetch: Callable[[Any, str, int], list[dict[str, Any]] | None],
 ) -> dict[str, Any] | None:
+    ctx = module_context.ctx
     module_id = int(module["id"])
-    if module_id not in cache:
+    course_id = int(module_context.course_id)
+    if course_id not in cache:
         account = ctx.require_moodle_account()
-        for item in fetch(ctx.require_session(), account.wstoken, int(course_id)):
-            course_module = item.get("coursemodule")
-            if isinstance(course_module, int):
-                cache[course_module] = item
-    return cache.get(module_id)
+        items = fetch(ctx.require_session(), account.wstoken, course_id)
+        if items is None:
+            cache[course_id] = None
+            module_context.mark_incomplete()
+        else:
+            instances: dict[int, dict[str, Any]] = {}
+            for item in items:
+                course_module = item.get("coursemodule")
+                if (
+                    not isinstance(course_module, int)
+                    or isinstance(course_module, bool)
+                    or course_module <= 0
+                    or course_module in instances
+                ):
+                    cache[course_id] = None
+                    module_context.mark_incomplete()
+                    break
+                instances[course_module] = item
+            else:
+                cache[course_id] = instances
+    course_instances = cache[course_id]
+    return course_instances.get(module_id) if course_instances is not None else None
 
 
 def _assignment_submission_files(
@@ -406,6 +428,7 @@ def _assignment_submission_files(
         assignment_id,
     )
     if fetched is None:
+        module_context.mark_incomplete()
         return None
     return [item for item in fetched if isinstance(item, dict)]
 
@@ -429,6 +452,7 @@ def _add_assignment_file_nodes(
             item["fileurl"],
             timemodified=item.get("timemodified"),
             remote_size=item.get("filesize"),
+            remote_content_hash=item.get("contenthash"),
         )
 
 
@@ -576,6 +600,7 @@ def handle_folder_module(
                 c["fileurl"],
                 timemodified=c.get("timemodified"),
                 remote_size=c.get("filesize"),
+                remote_content_hash=c.get("contenthash"),
             )
 
 
@@ -669,6 +694,7 @@ def _fetch_page(
             safe_request_error(error),
         )
         module_context.ctx.stats.failed += 1
+        module_context.mark_incomplete()
         return None
     if 200 <= response.status_code < 300:
         return response
@@ -678,6 +704,7 @@ def _fetch_page(
         response.status_code,
     )
     module_context.ctx.stats.failed += 1
+    module_context.mark_incomplete()
     return None
 
 
@@ -822,9 +849,8 @@ def _handle_h5p_links(
     ctx = module_context.ctx
     module_context.status("loading H5P activity")
     activity = module_instance(
-        ctx,
+        module_context,
         module,
-        module_context.course_id,
         ctx.h5p_activity_cache,
         moodle_api.get_h5pactivities_by_course,
     )
@@ -853,6 +879,8 @@ def _handle_h5p_links(
             module_context.log,
             package_file.get("filesize"),
         )
+        if content is None:
+            module_context.mark_incomplete()
         if content is not None and module_id is not None and marker is not None:
             course_cache.store_cached_text(
                 ctx,
@@ -885,9 +913,8 @@ def _opencast_lti_launch(
     ctx = module_context.ctx
     module_context.status("loading Opencast activity")
     instance = module_instance(
-        ctx,
+        module_context,
         module,
-        module_context.course_id,
         ctx.lti_instance_cache,
         moodle_api.get_ltis_by_course,
     )
@@ -902,6 +929,7 @@ def _opencast_lti_launch(
         ctx.require_session(), ctx.require_moodle_account().wstoken, tool_id
     )
     if launch_data is None:
+        module_context.mark_incomplete()
         return None
     endpoint = launch_data.get("endpoint")
     if not isinstance(endpoint, str):
@@ -951,6 +979,7 @@ def _handle_opencast_series(
         module_context.course_id,
     )
     if episodes is None:
+        module_context.mark_incomplete()
         return
     series_node = cast(
         Node,
@@ -1173,12 +1202,15 @@ def _add_quiz_nodes(
             continue
         name = f"{module_name}, Versuch {index}"
         review_url = f"{MOODLE_URL}mod/quiz/review.php?attempt={attempt_id}"
-        ctx.quiz_review_cache[review_url] = _quiz_review_html(name, review)
+        review_html = _quiz_review_html(name, review)
+        ctx.quiz_review_cache[review_url] = review_html
         section_node.add_child(
             name,
             attempt_id,
             "Quiz",
             url=review_url,
+            etag=hashlib.sha256(review_html.encode("utf-8")).hexdigest(),
+            etag_kind=RemoteMarkerKind.OPAQUE,
             download_kind=DownloadKind.QUIZ,
         )
 
@@ -1203,9 +1235,8 @@ def handle_quiz_module(
     # when Moodle changes which review fields are visible.
     module_context.status("loading quiz activity")
     instance = module_instance(
-        ctx,
+        module_context,
         module,
-        module_context.course_id,
         ctx.quiz_instance_cache,
         moodle_api.get_quizzes_by_course,
     )
@@ -1221,6 +1252,7 @@ def handle_quiz_module(
     else:
         loaded = _load_quiz_data(module_context, quiz_id)
         if loaded is None:
+            module_context.mark_incomplete()
             return
         attempts, reviews, complete = loaded
         timing = _quiz_cache_timing(

--- a/tests/test_course_cache_safety.py
+++ b/tests/test_course_cache_safety.py
@@ -1,7 +1,9 @@
-from syncmymoodle import course_cache, moodle, opencast, sync
-from syncmymoodle.constants import COURSE_CACHE_FILENAME
-from syncmymoodle.node import Node
-from syncmymoodle.storage import write_private_gzip_json
+from syncmymoodle import course_cache, moodle, opencast, pathing, sync, sync_handlers
+from syncmymoodle.constants import COURSE_CACHE_FILENAME, MOODLE_URL
+from syncmymoodle.context import MoodleAccount
+from syncmymoodle.moodle_tokens import MoodleTokens
+from syncmymoodle.node import DownloadKind, Node
+from syncmymoodle.storage import read_private_gzip_json, write_private_gzip_json
 
 from .helpers import FakeSession, make_context, node_path
 
@@ -23,12 +25,44 @@ def course_tree():
     return root, course
 
 
+def tagged_v1_payload(*, site=MOODLE_URL):
+    file_url = f"{site.rstrip('/')}/pluginfile.php/301/slides.pdf"
+    return {
+        "format": course_cache.COURSE_CACHE_FORMAT,
+        "course": {
+            "name": "Download Course",
+            "id": 301,
+            "type": "Course",
+            "download_status": "pending",
+            "children": [
+                {
+                    "name": "General",
+                    "id": 401,
+                    "type": "Section",
+                    "download_status": "pending",
+                    "children": [
+                        {
+                            "name": "slides.pdf",
+                            "id": "file-id",
+                            "type": "Linked file [application/pdf]",
+                            "url": file_url,
+                            "timemodified": 100,
+                            "download_status": "handled",
+                            "children": [],
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+
+
 def test_failed_course_fetch_preserves_previous_course_cache(tmp_path, monkeypatch):
     config = {"paths.sync_directory": str(tmp_path)}
     cached_context = make_context(config)
     cached_context.root_node, course_node = course_tree()
     course_cache.cache_root_node(cached_context)
-    cache_path = node_path(cached_context, course_node) / COURSE_CACHE_FILENAME
+    cache_path = course_cache.course_cache_path(cached_context, course_node)
     cached_bytes = cache_path.read_bytes()
     context = make_context(config)
     context.session = FakeSession()
@@ -54,24 +88,211 @@ def test_failed_course_fetch_preserves_previous_course_cache(tmp_path, monkeypat
 
 
 def test_malformed_nested_course_cache_is_ignored(tmp_path, caplog):
-    context = make_context({"paths.sync_directory": str(tmp_path)})
-    _, course_node = course_tree()
-    cache_path = node_path(context, course_node) / COURSE_CACHE_FILENAME
+    config = {"paths.sync_directory": str(tmp_path)}
+    writer = make_context(config)
+    writer.root_node, course_node = course_tree()
+    course_cache.cache_root_node(writer)
+    cache_path = course_cache.course_cache_path(writer, course_node)
+    payload = read_private_gzip_json(cache_path, "course cache")
+    assert isinstance(payload, dict)
+    payload["course"]["children"] = 1
+    write_private_gzip_json(cache_path, payload)
+
+    reader = make_context(config)
+    _, reader_course = course_tree()
+    assert course_cache.get_course_cache_root(reader, reader_course) is None
+    assert "Ignoring malformed course cache" in caplog.text
+
+
+def test_course_cache_survives_course_rename(tmp_path):
+    config = {"paths.sync_directory": str(tmp_path)}
+    seeded = make_context(config)
+    seeded.root_node, course_node = course_tree()
+    course_cache.store_cached_text(
+        seeded,
+        course_node,
+        course_cache.H5P_CONTENT_KIND,
+        11,
+        "marker",
+        "cached page",
+    )
+    course_cache.cache_root_node(seeded)
+
+    loaded = make_context(config)
+    _, renamed_course = course_tree()
+    renamed_course.name = "Renamed Course"
+
+    entry = course_cache.get_cached_text(
+        loaded,
+        renamed_course,
+        course_cache.H5P_CONTENT_KIND,
+        11,
+        "marker",
+    )
+    assert entry is not None
+    assert entry.content == "cached page"
+
+
+def test_tagged_v1_course_cache_is_moved_from_renamed_course_directory(tmp_path):
+    config = {"paths.sync_directory": str(tmp_path)}
+    context = make_context(config)
+    _, old_course = course_tree()
+    legacy_path = node_path(context, old_course) / COURSE_CACHE_FILENAME
+    write_private_gzip_json(legacy_path, tagged_v1_payload())
+
+    _, renamed_course = course_tree()
+    renamed_course.name = "Renamed Course"
+    cached_root = course_cache.get_course_cache_root(context, renamed_course)
+
+    assert cached_root is not None
+    cached_file = cached_root.children[0].children[0]
+    assert cached_file.is_verified
+    assert cached_file.download_kind is DownloadKind.DIRECT
+    cache_path = course_cache.course_cache_path(context, renamed_course)
+    migrated = read_private_gzip_json(cache_path, "course cache")
+    assert isinstance(migrated, dict)
+    assert migrated["format"] == "syncmymoodle.course-cache.v1"
+    assert migrated["identity"] == {
+        "site": MOODLE_URL,
+        "user_id": 10001,
+        "course_id": 301,
+    }
+    assert not legacy_path.exists()
+
+
+def test_legacy_course_cache_from_another_site_is_not_moved(tmp_path):
+    config = {"paths.sync_directory": str(tmp_path)}
+    context = make_context(config)
+    _, course = course_tree()
+    legacy_path = node_path(context, course) / COURSE_CACHE_FILENAME
     write_private_gzip_json(
-        cache_path,
-        {
-            "format": course_cache.COURSE_CACHE_FORMAT,
-            "course": {
-                "name": course_node.name,
-                "id": course_node.id,
-                "type": "Course",
-                "children": 1,
-            },
-        },
+        legacy_path,
+        tagged_v1_payload(site="https://other-moodle.example/"),
     )
 
-    assert course_cache.get_course_cache_root(context, course_node) is None
-    assert "Ignoring malformed course cache" in caplog.text
+    assert course_cache.get_course_cache_root(context, course) is None
+    assert legacy_path.exists()
+    assert not course_cache.course_cache_path(context, course).exists()
+
+
+def test_legacy_cache_drops_personal_data_without_matching_owner(tmp_path):
+    config = {"paths.sync_directory": str(tmp_path)}
+    context = make_context(config)
+    _, course = course_tree()
+    payload = tagged_v1_payload()
+    section_children = payload["course"]["children"][0]["children"]
+    section_children.extend(
+        [
+            {
+                "name": "my-submission.pdf",
+                "id": "submission-id",
+                "type": "Assignment File",
+                "url": f"{MOODLE_URL}pluginfile.php/301/submission.pdf",
+                "download_status": "handled",
+                "children": [],
+            },
+            {
+                "name": "Attempt 1",
+                "id": 123,
+                "type": "Quiz",
+                "url": f"{MOODLE_URL}mod/quiz/review.php?attempt=123",
+                "download_status": "handled",
+                "children": [],
+            },
+        ]
+    )
+    payload[course_cache.MODULE_CACHE_KEY] = {
+        "owner_user_id": 20002,
+        "assignments": {"501": {"since": 1, "files": []}},
+        course_cache.CACHED_TEXT_CACHE_KEY: {
+            course_cache.H5P_CONTENT_KIND: {
+                "11": {"marker": "marker", "content": "shared"}
+            }
+        },
+    }
+    legacy_path = node_path(context, course) / COURSE_CACHE_FILENAME
+    write_private_gzip_json(legacy_path, payload)
+
+    cached_root = course_cache.get_course_cache_root(context, course)
+
+    assert cached_root is not None
+    assert [child.name for child in cached_root.children[0].children] == ["slides.pdf"]
+    migrated = read_private_gzip_json(
+        course_cache.course_cache_path(context, course), "course cache"
+    )
+    assert isinstance(migrated, dict)
+    assert set(migrated[course_cache.MODULE_CACHE_KEY]) == {
+        course_cache.CACHED_TEXT_CACHE_KEY
+    }
+
+
+def test_course_cache_is_isolated_by_moodle_account(tmp_path):
+    config = {"paths.sync_directory": str(tmp_path)}
+    seeded = make_context(config)
+    seeded.root_node, course_node = course_tree()
+    course_cache.cache_root_node(seeded)
+
+    other = make_context(config)
+    other.moodle_account = MoodleAccount(
+        MoodleTokens(
+            "other-user",
+            "other-token",
+            "other-private-token",
+            moodle_user_id=10002,
+        )
+    )
+    _, other_course = course_tree()
+
+    assert course_cache.course_cache_path(
+        seeded, course_node
+    ) != course_cache.course_cache_path(other, other_course)
+    assert course_cache.get_course_cache_root(other, other_course) is None
+
+
+def test_module_handler_failure_preserves_previous_course_cache(
+    tmp_path,
+    monkeypatch,
+):
+    config = {"paths.sync_directory": str(tmp_path)}
+    seeded = make_context(config)
+    seeded.root_node, course_node = course_tree()
+    course_cache.cache_root_node(seeded)
+    cache_path = course_cache.course_cache_path(seeded, course_node)
+    cached_bytes = cache_path.read_bytes()
+
+    monkeypatch.setattr(
+        moodle,
+        "get_all_courses",
+        lambda session, wstoken, user_id: [
+            {"id": 301, "shortname": "Download Course", "idnumber": "26ss"}
+        ],
+    )
+    monkeypatch.setattr(
+        moodle,
+        "get_course",
+        lambda session, wstoken, course_id: [
+            {
+                "id": 401,
+                "name": "General",
+                "modules": [
+                    {"id": 501, "modname": "resource", "name": "Broken module"}
+                ],
+            }
+        ],
+    )
+
+    def fail_module(module_context, module):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(sync_handlers, "handle_module", fail_module)
+    current = make_context(config)
+    current.session = FakeSession()
+
+    sync.sync(current)
+    course_cache.cache_root_node(current)
+
+    assert current.stats.failed == 1
+    assert cache_path.read_bytes() == cached_bytes
 
 
 def test_cached_module_data_survives_course_name_disambiguation(tmp_path):
@@ -102,12 +323,12 @@ def test_cached_module_data_survives_course_name_disambiguation(tmp_path):
         "second",
     )
 
-    root.remove_children_nameclashes()
+    pathing.resolve_node_path_clashes(root)
     course_cache.cache_root_node(context)
 
     loaded = make_context({"paths.sync_directory": str(tmp_path)})
     loaded_root, loaded_first, loaded_second = colliding_courses(loaded)
-    loaded_root.remove_children_nameclashes()
+    pathing.resolve_node_path_clashes(loaded_root)
 
     assert (
         course_cache.get_cached_text(

--- a/tests/test_course_prefix_handling.py
+++ b/tests/test_course_prefix_handling.py
@@ -1,7 +1,8 @@
+from syncmymoodle import moodle_files
 from syncmymoodle.config import Config
 from syncmymoodle.filters import format_course_name as format_course_name_impl
 from syncmymoodle.node import DownloadKind, Node
-from syncmymoodle.pathing import sanitize_path_part
+from syncmymoodle.pathing import resolve_node_path_clashes, sanitize_path_part
 
 
 def format_course_name(handling, name):
@@ -37,35 +38,29 @@ def test_non_matching_names_are_preserved():
     assert format_course_name("remove", "(ABC) Analysis") == "(ABC) Analysis"
 
 
-def test_page_content_url_normalization_preserves_larger_content_ids():
-    root = Node("", -1, "Root", None)
-
-    child = root.add_child(
-        "Video",
-        101,
-        "Embedded videojs",
-        url=(
-            "https://moodle.rwth-aachen.de/pluginfile.php/104/"
-            "mod_page/content/315/page-video.mp4"
-        ),
-    )
-    normalized_child = root.add_child(
-        "Legacy page file",
-        102,
-        "Linked file [application/pdf]",
-        url=(
-            "https://moodle.rwth-aachen.de/pluginfile.php/104/"
-            "mod_page/content/3/legacy.pdf?forcedownload=1"
-        ),
-    )
-
-    assert child.url == (
+def test_moodle_file_url_normalization_is_origin_aware_and_query_safe():
+    current_url = (
         "https://moodle.rwth-aachen.de/pluginfile.php/104/"
         "mod_page/content/315/page-video.mp4"
     )
-    assert normalized_child.url == (
-        "https://moodle.rwth-aachen.de/pluginfile.php/104/mod_page/content/legacy.pdf"
+    assert moodle_files.canonicalize_moodle_file_url(current_url) == current_url
+    assert moodle_files.canonicalize_moodle_file_url(
+        "https://moodle.rwth-aachen.de/webservice/pluginfile.php/104/"
+        "mod_page/content/3/legacy.pdf?forcedownload=1&sig=abc#page"
+    ) == (
+        "https://moodle.rwth-aachen.de/pluginfile.php/104/"
+        "mod_page/content/legacy.pdf?sig=abc#page"
     )
+
+    external_url = "https://example.test/file?forcedownload=1&sig=abc"
+    assert moodle_files.canonicalize_moodle_file_url(external_url) == external_url
+    child = Node("", -1, "Root", None).add_child(
+        "External file",
+        101,
+        "File",
+        url=external_url,
+    )
+    assert child.url == external_url
 
 
 def test_same_course_folder_name_without_url_gets_stable_suffixes():
@@ -74,7 +69,7 @@ def test_same_course_folder_name_without_url_gets_stable_suffixes():
     semester.add_child("Software Quality Assurance", 101, "Course")
     semester.add_child("Software Quality Assurance", 102, "Course")
 
-    root.remove_children_nameclashes()
+    resolve_node_path_clashes(root)
 
     names = [course.name for course in semester.children]
     assert len(names) == 2
@@ -90,7 +85,7 @@ def test_same_section_name_without_url_keeps_legacy_merged_path():
     course.add_child("Case Study", 201, "Section")
     course.add_child("Case Study", 202, "Section")
 
-    root.remove_children_nameclashes()
+    resolve_node_path_clashes(root)
 
     names = [section.name for section in course.children]
     assert names == ["Case Study", "Case Study"]
@@ -127,7 +122,7 @@ def test_different_files_in_merged_sections_get_distinct_names():
         )
     )
 
-    root.remove_children_nameclashes()
+    resolve_node_path_clashes(root)
 
     assert first_section.name == second_section.name == "Case Study"
     materialized_names = {
@@ -144,7 +139,7 @@ def test_same_file_in_merged_sections_keeps_shared_name():
         "https://example.test/slides.pdf",
     )
 
-    root.remove_children_nameclashes()
+    resolve_node_path_clashes(root)
 
     assert first_file.name == second_file.name == "slides.pdf"
 
@@ -155,7 +150,7 @@ def test_same_name_with_different_urls_still_gets_stable_suffixes():
     section.add_child("Slides", 201, "URL", url="https://example.com/slides-a")
     section.add_child("Slides", 202, "URL", url="https://example.com/slides-b")
 
-    root.remove_children_nameclashes()
+    resolve_node_path_clashes(root)
 
     names = [link.name for link in section.children]
     assert len(names) == 2
@@ -186,7 +181,7 @@ def test_clashing_files_without_name_clash_id_use_url_for_distinct_names():
         name_clash_id=None,
     )
 
-    root.remove_children_nameclashes()
+    resolve_node_path_clashes(root)
 
     names = [child.name for child in section.children]
     assert len(names) == 2
@@ -209,7 +204,7 @@ def test_generated_file_name_cannot_collide_with_existing_file():
         "Linked file [application/pdf]",
         url="https://example.test/second.pdf",
     )
-    probe.remove_children_nameclashes()
+    resolve_node_path_clashes(probe)
 
     root = Node("", -1, "Root", None)
     section = root.add_child("General", None, "Section")
@@ -232,7 +227,7 @@ def test_generated_file_name_cannot_collide_with_existing_file():
         url="https://example.test/reserved.pdf",
     )
 
-    root.remove_children_nameclashes()
+    resolve_node_path_clashes(root)
 
     materialized_names = [
         sanitize_path_part(child.name).casefold() for child in section.children
@@ -258,7 +253,7 @@ def test_names_that_sanitize_to_same_windows_path_get_distinct_suffixes():
         name_clash_id=None,
     )
 
-    root.remove_children_nameclashes()
+    resolve_node_path_clashes(root)
 
     materialized_names = [
         sanitize_path_part(child.name).casefold() for child in section.children
@@ -284,7 +279,7 @@ def test_case_only_file_name_clashes_get_distinct_suffixes():
         name_clash_id=None,
     )
 
-    root.remove_children_nameclashes()
+    resolve_node_path_clashes(root)
 
     materialized_names = [
         sanitize_path_part(child.name).casefold() for child in section.children
@@ -310,7 +305,7 @@ def test_opencast_name_clashes_use_uploaded_filename_suffix():
         download_kind=DownloadKind.OPENCAST,
     )
 
-    root.remove_children_nameclashes()
+    resolve_node_path_clashes(root)
 
     assert [child.name for child in section.children] == [
         "Recording_high.mp4",
@@ -336,7 +331,7 @@ def test_case_only_opencast_name_clashes_use_uploaded_filename_suffix():
         download_kind=DownloadKind.OPENCAST,
     )
 
-    root.remove_children_nameclashes()
+    resolve_node_path_clashes(root)
 
     materialized_names = [
         sanitize_path_part(child.name).casefold() for child in section.children

--- a/tests/test_download_behavior.py
+++ b/tests/test_download_behavior.py
@@ -5,13 +5,21 @@ import os
 import pytest
 import requests
 
-from syncmymoodle import course_cache, downloader, links, moodle, opencast, pathing
+from syncmymoodle import (
+    course_cache,
+    downloader,
+    links,
+    moodle,
+    moodle_files,
+    opencast,
+    pathing,
+)
 from syncmymoodle.constants import COURSE_CACHE_FILENAME, YOUTUBE_WATCH_URL
 from syncmymoodle.downloader import download_file
-from syncmymoodle.node import DownloadKind, Node, RemoteMarkerKind
+from syncmymoodle.node import DownloadKind, DownloadStatus, Node, RemoteMarkerKind
 from syncmymoodle.outcomes import HANDLED_DOWNLOAD
 from syncmymoodle.output import format_size
-from syncmymoodle.storage import write_private_gzip_json
+from syncmymoodle.storage import read_private_gzip_json, write_private_gzip_json
 
 from .helpers import (
     FakeResponse,
@@ -60,6 +68,45 @@ def test_classify_local_file_is_tristate(tmp_path):
     assert classify_local_file(f, None) is FileMatch.UNKNOWN
     assert classify_local_file(f, "") is FileMatch.UNKNOWN
     assert classify_local_file(tmp_path / "nope", sha1(b"x")) is FileMatch.UNKNOWN
+
+
+def test_moodle_content_hash_skips_identical_untracked_file(tmp_path):
+    content = b"already downloaded Moodle file"
+    ctx = make_context(
+        {
+            "paths.sync_directory": str(tmp_path),
+            "downloads.update_files": True,
+            "downloads.conflict_handling": "rename",
+        }
+    )
+    ctx.session = FakeSession()
+    root = Node("", -1, "Root", None)
+    semester = root.add_child("26ss", None, "Semester")
+    course = semester.add_child("Course", 301, "Course")
+    section = course.add_child("General", 401, "Section")
+    file_node = moodle_files.add_moodle_content_file_node(
+        section,
+        {
+            "filename": "slides.pdf",
+            "fileurl": URL,
+            "mimetype": "application/pdf",
+            "timemodified": 1710000300,
+            "filesize": len(content),
+            "contenthash": sha1(content),
+        },
+    )
+    assert file_node is not None
+    download_path = node_path(ctx, file_node)
+    download_path.parent.mkdir(parents=True, exist_ok=True)
+    download_path.write_bytes(content)
+
+    outcome = download_file(ctx, file_node)
+
+    assert outcome.unchanged == 1
+    assert file_node.etag == sha1(content)
+    assert file_node.etag_kind is RemoteMarkerKind.CONTENT_HASH
+    assert ctx.session.calls == []
+    assert list(download_path.parent.glob("*.syncconflict.*")) == []
 
 
 def test_transfer_plan_applies_windows_prefix_to_appended_temp_paths(
@@ -234,6 +281,7 @@ def build_opencast_tree(etag):
         etag=etag,
         etag_kind=RemoteMarkerKind.CONTENT_HASH,
         remote_size=5,
+        download_kind=DownloadKind.OPENCAST,
     )
     return root, video
 
@@ -981,6 +1029,35 @@ def test_conflict_rename_moves_local_file_aside_before_download(tmp_path):
     assert syncer.session.count("GET", URL) == 1
 
 
+def test_identical_staged_update_does_not_create_conflict_copy(tmp_path):
+    syncer, file_node, download_path, local_modified = _setup_conflict(
+        tmp_path, "rename"
+    )
+    _add_new_remote(syncer, local_modified)
+    root = file_node
+    while root.parent is not None:
+        root = root.parent
+    syncer.root_node = root
+
+    downloader.download_node_tree(syncer, root)
+    course_cache.cache_root_node(syncer)
+
+    assert syncer.stats.unchanged == 1
+    assert syncer.stats.updated == 0
+    assert syncer.stats.transferred_bytes == len(local_modified)
+    assert download_path.read_bytes() == local_modified
+    assert file_node.content_hash == sha256(local_modified)
+    assert int(download_path.stat().st_mtime) == 1710000400
+    assert download_path in syncer.downloaded_paths
+    assert list(download_path.parent.glob("*.syncconflict.*")) == []
+    assert not (download_path.parent / f".{download_path.name}.smmpart").exists()
+    loaded = make_context({"paths.sync_directory": str(tmp_path)})
+    cached_file = course_cache.get_old_node_for(loaded, file_node)
+    assert cached_file is not None
+    assert cached_file.timemodified == 1710000400
+    assert cached_file.content_hash == sha256(local_modified)
+
+
 def test_unchanged_timemodified_skips_download_despite_local_edit(tmp_path):
     # When Moodle reports the same timemodified as the cache, the file is
     # considered unchanged remotely and the local copy is left untouched.
@@ -999,6 +1076,43 @@ def test_unchanged_timemodified_skips_download_despite_local_edit(tmp_path):
     assert download_file(syncer, file_node).is_handled
     assert syncer.session.calls == []
     assert list(download_path.parent.glob("*.syncconflict.*")) == []
+
+
+def test_legacy_course_cache_prevents_unchanged_file_false_conflict(tmp_path):
+    config = {
+        "paths.sync_directory": str(tmp_path),
+        "downloads.update_files": True,
+        "downloads.conflict_handling": "rename",
+    }
+    seeded = make_context(config)
+    seeded.root_node, seeded_file = build_single_file_tree(
+        "slides.pdf", URL, timemodified=1710000300
+    )
+    seeded_file.mark_handled()
+    course_node = seeded.root_node.children[0].children[0]
+    course_cache.cache_root_node(seeded)
+    stable_path = course_cache.course_cache_path(seeded, course_node)
+    payload = read_private_gzip_json(stable_path, "course cache")
+    assert isinstance(payload, dict)
+    payload.pop("identity")
+    legacy_path = node_path(seeded, course_node) / COURSE_CACHE_FILENAME
+    write_private_gzip_json(legacy_path, payload)
+    stable_path.unlink()
+
+    current, current_file = make_run_syncer(config, timemodified=1710000300)
+    download_path = node_path(current, current_file)
+    download_path.parent.mkdir(parents=True, exist_ok=True)
+    download_path.write_bytes(b"unchanged remote bytes")
+    os.utime(download_path, (1710000300, 1710000300))
+
+    outcome = download_file(current, current_file)
+
+    assert outcome.unchanged == 1
+    assert current.session.calls == []
+    assert download_path.read_bytes() == b"unchanged remote bytes"
+    assert list(download_path.parent.glob("*.syncconflict.*")) == []
+    assert stable_path.exists()
+    assert not legacy_path.exists()
 
 
 def test_failed_previous_download_is_retried_not_skipped(tmp_path):
@@ -1130,6 +1244,7 @@ def test_missing_opencast_file_authorizes_immediately_before_download(
     current = make_context({"paths.sync_directory": str(tmp_path)})
     current.session = FakeSession()
     current.root_node, video = build_opencast_tree("11111111111111111111111111111111")
+    video.type = "Lecture recording"
     authorized = []
     monkeypatch.setattr(
         opencast,
@@ -1315,7 +1430,7 @@ def test_distinct_files_in_merged_sections_are_both_downloaded(tmp_path):
     syncer = make_context({"paths.sync_directory": str(tmp_path)})
     syncer.session = FakeSession()
     root, first_file, second_file = build_duplicate_section_file_tree()
-    root.remove_children_nameclashes()
+    pathing.resolve_node_path_clashes(root)
     first_path = node_path(syncer, first_file)
     second_path = node_path(syncer, second_file)
     syncer.session.add(
@@ -1801,6 +1916,64 @@ def _cached_file_node(config, course_node):
     return cached_course.children[0].children[0]  # General -> slides.pdf
 
 
+def test_update_disabled_does_not_verify_an_untracked_existing_file(tmp_path):
+    remote = b"server version"
+    local = b"untracked local version"
+    initial_config = {
+        "paths.sync_directory": str(tmp_path),
+        "downloads.update_files": False,
+    }
+    initial = make_context(initial_config)
+    initial.session = FakeSession()
+    root, file_node = build_single_file_tree(
+        "slides.pdf",
+        URL,
+        timemodified=100,
+        etag=sha1(remote),
+    )
+    file_node.etag_kind = RemoteMarkerKind.CONTENT_HASH
+    initial.root_node = root
+    download_path = node_path(initial, file_node)
+    download_path.parent.mkdir(parents=True, exist_ok=True)
+    download_path.write_bytes(local)
+
+    downloader.download_node_tree(initial, root)
+    course_cache.cache_root_node(initial)
+
+    cached_file = course_cache.get_old_node_for(initial, file_node)
+    assert cached_file is not None
+    assert cached_file.download_status is DownloadStatus.SKIPPED
+    assert cached_file.etag is None
+
+    update_config = {
+        "paths.sync_directory": str(tmp_path),
+        "downloads.update_files": True,
+    }
+    current = make_context(update_config)
+    current.session = FakeSession()
+    current.root_node, current_file = build_single_file_tree(
+        "slides.pdf",
+        URL,
+        timemodified=100,
+        etag=sha1(remote),
+    )
+    current_file.etag_kind = RemoteMarkerKind.CONTENT_HASH
+    current.session.add(
+        "GET",
+        URL,
+        FakeResponse(
+            headers={"Content-Type": "application/pdf"},
+            chunks=[remote],
+        ),
+    )
+
+    assert download_file(current, current_file).updated == 1
+    assert download_path.read_bytes() == remote
+    conflicts = list(download_path.parent.glob("*.syncconflict.*"))
+    assert len(conflicts) == 1
+    assert conflicts[0].read_bytes() == local
+
+
 def test_cache_preserves_markers_for_failed_download_over_existing_file(tmp_path):
     config = {"paths.sync_directory": str(tmp_path), "downloads.update_files": True}
     v1 = b"version one"
@@ -1825,74 +1998,6 @@ def test_cache_preserves_markers_for_failed_download_over_existing_file(tmp_path
     assert cached_file.timemodified == 100
     assert cached_file.etag == sha1(v1)
     assert cached_file.is_handled is True
-
-
-def test_legacy_is_downloaded_cache_key_is_read_as_handled(tmp_path):
-    config = {"paths.sync_directory": str(tmp_path), "downloads.update_files": True}
-    content = b"legacy cached file"
-    root, cached_file = build_single_file_tree(
-        "slides.pdf", URL, timemodified=100, etag=sha1(content)
-    )
-    course_node = root.children[0].children[0]
-    course_path = node_path(make_context(config), course_node)
-    course_path.mkdir(parents=True, exist_ok=True)
-    write_private_gzip_json(
-        course_path / COURSE_CACHE_FILENAME,
-        {
-            "format": course_cache.COURSE_CACHE_FORMAT,
-            "course": {
-                "name": course_node.name,
-                "id": course_node.id,
-                "type": course_node.type,
-                "children": [
-                    {
-                        "name": cached_file.parent.name,
-                        "id": cached_file.parent.id,
-                        "type": cached_file.parent.type,
-                        "children": [
-                            {
-                                "name": cached_file.name,
-                                "id": cached_file.id,
-                                "type": cached_file.type,
-                                "url": cached_file.url,
-                                "timemodified": cached_file.timemodified,
-                                "etag": cached_file.etag,
-                                "is_downloaded": True,
-                            }
-                        ],
-                    }
-                ],
-            },
-        },
-    )
-
-    syncer, current_file = make_run_syncer(config, timemodified=100)
-    download_path = node_path(syncer, current_file)
-    download_path.parent.mkdir(parents=True, exist_ok=True)
-    download_path.write_bytes(content)
-
-    assert download_file(syncer, current_file).is_handled
-    assert syncer.session.calls == []
-    assert download_path.read_bytes() == content
-    assert course_cache.get_old_node_for(syncer, current_file).is_handled is True
-
-
-@pytest.mark.parametrize(
-    ("node_type", "expected_kind"),
-    [
-        ("Youtube", DownloadKind.YOUTUBE),
-        ("Emedia", DownloadKind.EMEDIA),
-        ("Quiz", DownloadKind.QUIZ),
-        ("Opencast", DownloadKind.OPENCAST),
-        ("Linked file [application/pdf]", DownloadKind.DIRECT),
-    ],
-)
-def test_legacy_cache_derives_download_kind_from_node_type(node_type, expected_kind):
-    node = course_cache.node_from_cache_data(
-        {"name": "cached", "type": node_type, "children": []}
-    )
-
-    assert node.download_kind is expected_kind
 
 
 def test_course_cache_round_trips_remote_size(tmp_path):

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -6,17 +6,17 @@ import pytest
 import requests
 
 import syncmymoodle.cli as cli
-from syncmymoodle import moodle
+from syncmymoodle import moodle, sync_handlers
 from syncmymoodle.config import Config, ConfigValidationError
 from syncmymoodle.moodle import MOODLE_REST_URL
 from syncmymoodle.moodle_files import (
     add_moodle_content_file_node,
     add_moodle_file_node,
 )
-from syncmymoodle.node import Node
+from syncmymoodle.node import Node, RemoteMarkerKind
 from syncmymoodle.totp import hotp
 
-from .helpers import FakeResponse, FakeSession
+from .helpers import FakeResponse, FakeSession, make_context
 
 INVALID_TOKEN_PAYLOAD = {
     "exception": "moodle_exception",
@@ -208,9 +208,96 @@ def test_course_update_api_failure_is_silent_optional_cache_miss(caplog):
     assert "array_keys" not in caplog.text
 
 
-def test_get_folders_skips_course_on_api_error(caplog):
-    assert moodle.get_folders_by_courses(_error_session(), "token", 101) == []
+def test_get_folders_distinguishes_api_error_from_empty_course(caplog):
+    assert moodle.get_folders_by_courses(_error_session(), "token", 101) is None
     assert "invalidtoken" in caplog.text
+
+
+def test_course_module_inventory_rejects_malformed_items():
+    session = FakeSession()
+    session.add(
+        "POST",
+        MOODLE_REST_URL,
+        FakeResponse(json_payload={"quizzes": [None]}),
+    )
+
+    assert moodle.get_quizzes_by_course(session, "token", 101) is None
+
+
+def _module_context():
+    ctx = make_context()
+    ctx.session = FakeSession()
+    course_node = Node("Course", 1, "Course", None)
+    section_node = course_node.add_child("Section", 2, "Section")
+    assert section_node is not None
+    return ctx, sync_handlers.ModuleContext(
+        ctx,
+        1,
+        course_node,
+        section_node,
+        {},
+        {},
+    )
+
+
+def test_module_instance_fetches_a_successful_course_inventory_once():
+    ctx, module_context = _module_context()
+    calls = []
+
+    def fetch(session, wstoken, course_id):
+        calls.append(course_id)
+        return [{"coursemodule": 99, "id": 7}]
+
+    for module_id in (41, 42):
+        assert (
+            sync_handlers.module_instance(
+                module_context,
+                {"id": module_id},
+                ctx.quiz_instance_cache,
+                fetch,
+            )
+            is None
+        )
+
+    assert calls == [1]
+
+
+def test_module_instance_caches_course_inventory_failure():
+    ctx, module_context = _module_context()
+    calls = []
+
+    def fetch(session, wstoken, course_id):
+        calls.append(course_id)
+        return None
+
+    for module_id in (41, 42):
+        assert (
+            sync_handlers.module_instance(
+                module_context,
+                {"id": module_id},
+                ctx.quiz_instance_cache,
+                fetch,
+            )
+            is None
+        )
+
+    assert calls == [1]
+    assert ctx.incomplete_course_ids == {1}
+
+
+def test_module_instance_rejects_incomplete_course_inventory():
+    ctx, module_context = _module_context()
+
+    assert (
+        sync_handlers.module_instance(
+            module_context,
+            {"id": 41},
+            ctx.quiz_instance_cache,
+            lambda session, wstoken, course_id: [{}],
+        )
+        is None
+    )
+    assert ctx.incomplete_course_ids == {1}
 
 
 def test_submission_files_tolerate_null_fields():
@@ -322,3 +409,30 @@ def test_content_file_without_filename_gets_placeholder_name():
     )
     assert node is not None
     assert node.name == "file"
+
+
+def test_content_file_accepts_only_strong_moodle_content_hashes():
+    parent = Node("Section", 1, "Section", None)
+    valid = add_moodle_content_file_node(
+        parent,
+        {
+            "filename": "valid.pdf",
+            "fileurl": "https://moodle.rwth-aachen.de/pluginfile.php/1/valid.pdf",
+            "contenthash": "A" * 40,
+        },
+    )
+    invalid = add_moodle_content_file_node(
+        parent,
+        {
+            "filename": "invalid.pdf",
+            "fileurl": "https://moodle.rwth-aachen.de/pluginfile.php/1/invalid.pdf",
+            "contenthash": "opaque-revision",
+        },
+    )
+
+    assert valid is not None
+    assert valid.etag == "a" * 40
+    assert valid.etag_kind is RemoteMarkerKind.CONTENT_HASH
+    assert invalid is not None
+    assert invalid.etag is None
+    assert invalid.etag_kind is None

--- a/tests/test_quiz.py
+++ b/tests/test_quiz.py
@@ -1,8 +1,9 @@
+import hashlib
 import subprocess
 from types import SimpleNamespace
 
-from syncmymoodle import quiz, sync_handlers
-from syncmymoodle.node import DownloadKind, Node
+from syncmymoodle import course_cache, quiz, sync_handlers
+from syncmymoodle.node import DownloadKind, Node, RemoteMarkerKind
 
 from .helpers import FakeResponse, FakeSession, make_context
 
@@ -158,6 +159,9 @@ def test_quiz_api_review_preserves_grade_and_feedback_titles(monkeypatch, tmp_pa
     assert "<h2>Grade</h2><p>9.00 &lt; 10.00</p>" in review
     assert "<div>Question body</div>" in review
     assert "<h2>Overall &lt;feedback&gt;</h2><p>Great</p>" in review
+    quiz_attempt = module_context.section_node.children[0]
+    assert quiz_attempt.etag == hashlib.sha256(review.encode("utf-8")).hexdigest()
+    assert quiz_attempt.etag_kind is RemoteMarkerKind.OPAQUE
 
 
 def test_quiz_node_keeps_remote_name_until_path_materialization(monkeypatch):
@@ -304,6 +308,43 @@ def test_html_mode_is_idempotent(tmp_path, capsys):
     assert ctx.session.count("GET", QUIZ_URL) == 0
 
 
+def test_changed_quiz_review_replaces_an_unmodified_snapshot(tmp_path):
+    def quiz_tree(review_html):
+        root = Node("", -1, "Root", None)
+        semester = root.add_child("26ss", None, "Semester")
+        course = semester.add_child("Course", 301, "Course")
+        section = course.add_child("General", 401, "Section")
+        attempt = section.add_child(
+            "My Quiz, Versuch 1",
+            5,
+            "Quiz",
+            url=QUIZ_URL,
+            etag=hashlib.sha256(review_html.encode("utf-8")).hexdigest(),
+            etag_kind=RemoteMarkerKind.OPAQUE,
+            download_kind=DownloadKind.QUIZ,
+        )
+        return root, attempt
+
+    first = quiz_context(tmp_path, "html")
+    first.root_node, first_node = quiz_tree(QUIZ_HTML)
+    assert quiz.download_quiz(first, first_node).downloaded == 1
+    first_node.mark_handled()
+    course_cache.cache_root_node(first)
+
+    updated_review = QUIZ_HTML.replace("My answer", "Updated answer")
+    current = quiz_context(tmp_path, "html")
+    current.config.update_files = True
+    current.quiz_review_cache[QUIZ_URL] = updated_review
+    current.root_node, current_node = quiz_tree(updated_review)
+
+    outcome = quiz.download_quiz(current, current_node)
+
+    html_path = tmp_path / "26ss" / "Course" / "General" / "My Quiz, Versuch 1.html"
+    assert outcome.updated == 1
+    assert "Updated answer" in html_path.read_text(encoding="utf-8")
+    assert list(html_path.parent.glob("*.syncconflict.*")) == []
+
+
 def test_pdf_mode_removes_html_on_success(tmp_path, monkeypatch, capsys):
     def fake_render(browser, html_path, pdf_path, log=quiz.logger):
         pdf_path.write_bytes(b"%PDF-1.4 fake")
@@ -336,6 +377,24 @@ def test_pdf_mode_keeps_html_when_no_browser(tmp_path, monkeypatch):
     # failure so the missing requested PDF is retried on future runs.
     assert (tmp_path / "root" / "My Quiz, Versuch 1.html").exists()
     assert not (tmp_path / "root" / "My Quiz, Versuch 1.pdf").exists()
+
+
+def test_pdf_mode_retry_removes_generated_html_fallback(tmp_path, monkeypatch):
+    monkeypatch.setattr(quiz, "find_chromium", lambda *a, **k: None)
+    ctx = quiz_context(tmp_path, "pdf")
+    node = quiz_node()
+    assert not quiz.download_quiz(ctx, node).is_handled
+
+    def fake_render(browser, html_path, pdf_path, log=quiz.logger):
+        pdf_path.write_bytes(b"%PDF-1.4 fake")
+        return True
+
+    monkeypatch.setattr(quiz, "find_chromium", lambda *a, **k: "/fake/chrome")
+    monkeypatch.setattr(quiz, "render_pdf_with_chromium", fake_render)
+
+    assert quiz.download_quiz(ctx, node).is_handled
+    assert not (tmp_path / "root" / "My Quiz, Versuch 1.html").exists()
+    assert (tmp_path / "root" / "My Quiz, Versuch 1.pdf").exists()
 
 
 def test_both_mode_retries_pdf_without_refetching(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes cases where changed artifacts were missed or identical files caused false conflicts. It also safely carries over the cache from 0.5.0 for the matching Moodle account.

One big change is that instead of leaving a cache file in every course directory, they get centralized under one directory in the sync directory with stable course ids.