### PR TITLE
Avoid unnecessary downloads on repeat syncs

### DIFF
--- a/syncmymoodle/cli.py
+++ b/syncmymoodle/cli.py
@@ -2022,6 +2022,12 @@ def report_filtered_items(ctx: SyncContext, show_details: bool) -> None:
     ctx.output.filtered_items(items, show_details=show_details)
 
 
+def report_removed_content(ctx: SyncContext) -> None:
+    items = sorted(ctx.removed_content)
+    if items:
+        ctx.output.removed_content(items)
+
+
 def run(ctx: SyncContext, *, show_filtered: bool = False) -> None:
     """Execute a full sync run against an already-configured context."""
     tokens, validation = resolve_moodle_tokens_for_run(ctx)
@@ -2063,6 +2069,7 @@ def run(ctx: SyncContext, *, show_filtered: bool = False) -> None:
         logger.critical("%s", error)
         raise SystemExit(1) from error
     report_filtered_items(ctx, show_filtered)
+    report_removed_content(ctx)
     ctx.output.summary(
         ctx.stats,
         len(ctx.filtered_items),

--- a/syncmymoodle/context.py
+++ b/syncmymoodle/context.py
@@ -10,8 +10,8 @@ import requests
 from syncmymoodle.config import Config
 from syncmymoodle.http_utils import ServiceOutageTracker
 from syncmymoodle.moodle_tokens import MoodleTokens
-from syncmymoodle.node import Node
-from syncmymoodle.outcomes import RunStatistics
+from syncmymoodle.node import Node, RemoteMarkerKind
+from syncmymoodle.outcomes import RemovedContent, RunStatistics
 from syncmymoodle.output import TerminalOutput, get_output
 from syncmymoodle.pathing import InternalPathRoot
 
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 # validation boundary cannot fall between incremental update queries.
 MOODLE_UPDATE_OVERLAP_SECONDS = 5
 ModuleInstanceCache = dict[int, dict[int, dict[str, Any]] | None]
+TransferReuseKey = tuple[str, str, RemoteMarkerKind, str]
 
 
 class BrowserSessionUnavailable(RuntimeError):
@@ -102,6 +103,15 @@ class LinkedResourceCacheEntry:
     remote_size: int | None = None
 
 
+@dataclass(frozen=True)
+class VerifiedDownloadArtifact:
+    """One remote artifact verified and installed during this sync run."""
+
+    path: Path
+    content_hash: str
+    size: int
+
+
 @dataclass
 class SyncContext:
     config: Config
@@ -132,6 +142,8 @@ class SyncContext:
     browser_bootstrap_error_logged: bool = False
     # None negatively caches a share that already failed during this run.
     sciebo_link_cache: dict[str, Node | None] = field(default_factory=dict)
+    # None means unprobed; False means the HTML/request-token bootstrap is required.
+    sciebo_direct_webdav_supported: bool | None = None
     service_outages: ServiceOutageTracker = field(default_factory=ServiceOutageTracker)
     opencast_course_auth_cache: set[tuple[str, str]] = field(default_factory=set)
     opencast_episode_cache: dict[tuple[str | None, str], OpencastEpisode] = field(
@@ -148,7 +160,12 @@ class SyncContext:
     emedia_revision_cache: dict[str, str | None] = field(default_factory=dict)
     emedia_output_suffix: str | None = None
     downloaded_paths: set[Path] = field(default_factory=set)
+    verified_download_artifacts: dict[TransferReuseKey, VerifiedDownloadArtifact] = (
+        field(default_factory=dict, repr=False)
+    )
     filtered_items: set[FilteredItem] = field(default_factory=set)
+    inventory_filtered_course_ids: set[int] = field(default_factory=set)
+    removed_content: set[RemovedContent] = field(default_factory=set)
     quiz_review_cache: dict[str, str] = field(default_factory=dict)
     lti_instance_cache: ModuleInstanceCache = field(default_factory=dict)
     h5p_activity_cache: ModuleInstanceCache = field(default_factory=dict)
@@ -200,6 +217,15 @@ class SyncContext:
             and course_id > 0
         ):
             self.incomplete_course_ids.add(course_id)
+
+    def mark_course_inventory_filtered(self, course_id: Any) -> None:
+        """Suppress removals for a policy- or availability-truncated tree."""
+        if (
+            isinstance(course_id, int)
+            and not isinstance(course_id, bool)
+            and course_id > 0
+        ):
+            self.inventory_filtered_course_ids.add(course_id)
 
     def record_course_failure(self, course_id: Any) -> None:
         """Record a failed course source and retain its last complete cache."""

--- a/syncmymoodle/course_cache.py
+++ b/syncmymoodle/course_cache.py
@@ -16,6 +16,7 @@ from syncmymoodle.node import (
     DownloadStatus,
     Node,
     NodeKind,
+    match_equivalent_child,
 )
 from syncmymoodle.pathing import (
     InternalPathRoot,
@@ -32,6 +33,7 @@ MODULE_CACHE_KEY = "module_data"
 CACHED_TEXT_CACHE_KEY = "cached_text"
 OPENCAST_EPISODES_CACHE_KEY = "opencast_episodes"
 LINKED_RESOURCES_CACHE_KEY = "linked_resources"
+INVENTORY_SCOPE_CACHE_KEY = "inventory_scope"
 H5P_CONTENT_KIND = "h5p"
 PAGE_CONTENT_KIND = "page"
 CACHED_TEXT_KINDS = (H5P_CONTENT_KIND, PAGE_CONTENT_KIND)
@@ -82,6 +84,8 @@ class QuizCacheEntry:
 @dataclass
 class CourseCacheState:
     course_root: Node | None = None
+    cached_inventory_scope: str | None = None
+    current_inventory_scope: str | None = None
     cached_text: dict[str, dict[int, CachedTextEntry]] = field(
         default_factory=lambda: {kind: {} for kind in CACHED_TEXT_KINDS}
     )
@@ -341,6 +345,16 @@ def _cache_since(value: Any) -> int | None:
     )
 
 
+def _inventory_scope(value: Any) -> str | None:
+    return (
+        value
+        if isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+        else None
+    )
+
+
 def _dict_list(value: Any) -> list[dict[str, Any]] | None:
     if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
         return None
@@ -484,6 +498,9 @@ def _course_cache_state(
     course_id = _module_id(course_node.id)
     state = CourseCacheState(
         course_root=course_root,
+        cached_inventory_scope=_inventory_scope(
+            payload.get(INVENTORY_SCOPE_CACHE_KEY) if payload else None
+        ),
         cached_text={
             kind: _cached_text_entries(raw_cached_text.get(kind), kind)
             for kind in CACHED_TEXT_KINDS
@@ -728,22 +745,7 @@ def match_old_cache_child(old_node: Node | None, child: Node) -> Node | None:
         for candidate in old_node.children:
             if links.youtube_video_id_from_node(candidate) == child_youtube_id:
                 return candidate
-
-    candidates = [
-        c for c in old_node.children if c.name == child.name and c.type == child.type
-    ]
-    if not candidates:
-        return None
-
-    for attr in ("url", "name_clash_id", "id"):
-        child_value = getattr(child, attr, None)
-        if child_value is None or child_value is NAME_CLASH_ID_UNSET:
-            continue
-        for candidate in candidates:
-            if getattr(candidate, attr, None) == child_value:
-                return candidate
-
-    return candidates[0]
+    return match_equivalent_child(old_node, child)
 
 
 def node_to_cache_data(
@@ -865,6 +867,20 @@ def get_course_cache_root(
     return _course_cache_state(ctx, course_node, log).course_root
 
 
+def comparable_course_cache_root(
+    ctx: SyncContext,
+    course_node: Node,
+    inventory_scope: str,
+    log: logging.Logger = logger,
+) -> Node | None:
+    """Return the prior tree only when its discovery policy matches this run."""
+    state = _course_cache_state(ctx, course_node, log)
+    state.current_inventory_scope = inventory_scope
+    return (
+        state.course_root if state.cached_inventory_scope == inventory_scope else None
+    )
+
+
 def get_old_node_for(
     ctx: SyncContext,
     node: Node,
@@ -924,8 +940,11 @@ def cache_root_node(
                 "identity": _cache_identity(ctx, course_node),
                 "course": node_to_cache_data(ctx, course_node, state.course_root),
             }
+            if state.current_inventory_scope is not None:
+                payload[INVENTORY_SCOPE_CACHE_KEY] = state.current_inventory_scope
             module_cache = _course_module_cache_data(ctx, state, course_node)
             if module_cache:
                 payload[MODULE_CACHE_KEY] = module_cache
             write_private_gzip_json(cache_path, payload)
             state.course_root = node_from_cache_data(payload["course"])
+            state.cached_inventory_scope = state.current_inventory_scope

--- a/syncmymoodle/downloader.py
+++ b/syncmymoodle/downloader.py
@@ -3,6 +3,7 @@ import logging
 import math
 import os
 import re
+import shutil
 import urllib.parse
 from contextlib import closing
 from dataclasses import dataclass
@@ -20,10 +21,15 @@ from syncmymoodle.constants import (
     HASH_ALGOS_BY_LENGTH,
     HTTP_TIMEOUT_SECONDS,
 )
-from syncmymoodle.context import SyncContext
+from syncmymoodle.context import (
+    SyncContext,
+    TransferReuseKey,
+    VerifiedDownloadArtifact,
+)
 from syncmymoodle.http_utils import (
     HTML_CONTENT_TYPES,
     HttpFailureKind,
+    canonical_remote_url,
     classify_http_failure,
     classify_request_failure,
     content_length,
@@ -31,6 +37,7 @@ from syncmymoodle.http_utils import (
     normalized_http_origin,
     record_service_failure,
     redact_url_secrets,
+    remote_request_scope_fingerprint,
     request_following_safe_redirects,
     safe_request_error,
 )
@@ -95,6 +102,7 @@ class DownloadDecision(Enum):
     """Outcome of change detection before conflict policy is applied."""
 
     DOWNLOAD = "download"
+    ADOPT = "adopt"
     SKIP = "skip"
     POLICY_SKIP = "policy_skip"
     CONFLICT = "conflict"
@@ -111,8 +119,13 @@ class TransferPlan:
     def discard_partial(self) -> None:
         self.resume_size = 0
         self.partial_etag = None
-        self.tmp_path.unlink(missing_ok=True)
-        self.etag_sidecar.unlink(missing_ok=True)
+        for path in (self.tmp_path, self.etag_sidecar):
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                # Windows may temporarily lock a stale partial. The caller can
+                # still fail safely or use a different staging path.
+                pass
 
 
 @dataclass(frozen=True)
@@ -241,6 +254,7 @@ def request_node_url(
             url,
             f"redirected {node.type} file",
             course_id=course_id,
+            inventory=False,
         ),
         **kwargs,
     )
@@ -442,21 +456,47 @@ def local_verification_marker(old_node: Node | None) -> str | None:
     return None
 
 
+def uncached_timestamp_matches_local_copy(
+    node: Node,
+    downloadpath: Path,
+    baseline: storage.FileSnapshot,
+) -> bool:
+    """Recognize a file whose mtime was aligned by an earlier sync."""
+    remote_timemodified = node.timemodified
+    if (
+        node.has_remote_marker_conflict
+        or not isinstance(remote_timemodified, int)
+        or isinstance(remote_timemodified, bool)
+        or remote_timemodified < 0
+        or baseline.digest is None
+    ):
+        return False
+    try:
+        return int(downloadpath.stat().st_mtime) == remote_timemodified
+    except OSError:
+        return False
+
+
 def assess_local_copy(
     node: Node,
     downloadpath: Path,
     old_node: Node | None,
     cached_timemodified: Any,
     baseline: storage.FileSnapshot,
+    *,
+    allow_timestamp_adoption: bool,
 ) -> LocalCopyState:
     """Classify the on-disk file when the remote may have changed."""
     remote_etag = getattr(node, "etag", None)
     remote_etag_kind = node.etag_kind
-    if (
-        remote_etag_kind == RemoteMarkerKind.CONTENT_HASH
-        and classify_local_file(downloadpath, remote_etag, baseline) is FileMatch.MATCH
-    ):
-        return LocalCopyState.UP_TO_DATE
+    if remote_etag_kind is RemoteMarkerKind.CONTENT_HASH:
+        remote_match = classify_local_file(downloadpath, remote_etag, baseline)
+        if remote_match is FileMatch.MATCH:
+            return LocalCopyState.UP_TO_DATE
+        if old_node is None:
+            # A differing or malformed current checksum is stronger evidence
+            # than a coincidentally matching timestamp.
+            return LocalCopyState.MODIFIED
 
     verdict = classify_local_file(
         downloadpath,
@@ -475,6 +515,11 @@ def assess_local_copy(
             return LocalCopyState.CLEAN
         except (OSError, ValueError):
             return LocalCopyState.MODIFIED
+
+    if allow_timestamp_adoption and uncached_timestamp_matches_local_copy(
+        node, downloadpath, baseline
+    ):
+        return LocalCopyState.UP_TO_DATE
 
     return LocalCopyState.MODIFIED
 
@@ -496,7 +541,9 @@ def decide_download(
         return DownloadDecision.POLICY_SKIP
 
     old_node = course_cache.get_old_node_for(ctx, node, log)
+    allow_timestamp_adoption = old_node is None
     if old_node is not None and not old_node.is_verified:
+        allow_timestamp_adoption = False
         old_node = None
     cached_timemodified = (
         getattr(old_node, "timemodified", None) if old_node is not None else None
@@ -509,9 +556,10 @@ def decide_download(
         old_node,
         cached_timemodified,
         baseline,
+        allow_timestamp_adoption=allow_timestamp_adoption,
     )
     if verdict is LocalCopyState.UP_TO_DATE:
-        return DownloadDecision.SKIP
+        return DownloadDecision.ADOPT if old_node is None else DownloadDecision.SKIP
     if old_node is not None and remote_unchanged(
         ctx, node, old_node, cached_timemodified, log
     ):
@@ -531,6 +579,7 @@ def should_skip_before_decision(
         node.url,
         f"{node.type} file",
         course_id=course_id,
+        inventory=False,
     ):
         return SKIPPED_DOWNLOAD
     extension = Path(node.name).suffix.removeprefix(".").casefold()
@@ -691,6 +740,23 @@ def stable_download_decision(
     return decision, baseline
 
 
+def record_unchanged_copy(
+    node: Node,
+    downloadpath: Path,
+    decision: DownloadDecision,
+    baseline: storage.FileSnapshot,
+) -> DownloadOutcome:
+    if decision is DownloadDecision.ADOPT:
+        assert baseline.digest is not None
+        node.content_hash = baseline.digest
+    if (
+        node.etag_kind is RemoteMarkerKind.CONTENT_HASH
+        and classify_local_file(downloadpath, node.etag, baseline) is FileMatch.MATCH
+    ):
+        align_mtime_with_timemodified(node, downloadpath)
+    return UNCHANGED_DOWNLOAD
+
+
 def planned_download_action(
     ctx: SyncContext,
     node: Node,
@@ -723,14 +789,8 @@ def planned_download_action(
     decision, baseline = stable_download_decision(ctx, node, downloadpath, log)
     if decision is DownloadDecision.POLICY_SKIP:
         return POLICY_SKIPPED_DOWNLOAD
-    if decision is DownloadDecision.SKIP:
-        if (
-            node.etag_kind is RemoteMarkerKind.CONTENT_HASH
-            and classify_local_file(downloadpath, node.etag, baseline)
-            is FileMatch.MATCH
-        ):
-            align_mtime_with_timemodified(node, downloadpath)
-        return UNCHANGED_DOWNLOAD
+    if decision in {DownloadDecision.ADOPT, DownloadDecision.SKIP}:
+        return record_unchanged_copy(node, downloadpath, decision, baseline)
     action = (
         conflict_action(ctx, downloadpath, log)
         if decision is DownloadDecision.CONFLICT
@@ -1018,10 +1078,7 @@ def install_downloaded_file(
         description="the updated file from Moodle",
         log=log,
     )
-    if result is not storage.InstallResult.INSTALLED:
-        transfer.discard_partial()
-        return result
-    transfer.etag_sidecar.unlink(missing_ok=True)
+    transfer.discard_partial()
     return result
 
 
@@ -1053,6 +1110,175 @@ def record_download_metadata(
     if etag_header is not None and node.etag is None:
         node.etag = etag_header
         node.etag_kind = RemoteMarkerKind.OPAQUE
+
+
+def record_verified_download(
+    ctx: SyncContext,
+    node: Node,
+    downloadpath: Path,
+    etag_header: str | None,
+    content_hash: str,
+) -> None:
+    record_download_metadata(node, downloadpath, etag_header, content_hash)
+    ctx.downloaded_paths.add(downloadpath)
+    key = transfer_reuse_key(node)
+    if key is None:
+        return
+    try:
+        size = downloadpath.stat().st_size
+    except OSError:
+        return
+    ctx.verified_download_artifacts[key] = VerifiedDownloadArtifact(
+        downloadpath,
+        content_hash,
+        size,
+    )
+
+
+def transfer_reuse_key(node: Node) -> TransferReuseKey | None:
+    """Identify direct downloads whose discovered revision is trustworthy."""
+    if (
+        node.download_kind is not DownloadKind.DIRECT
+        or not node.url
+        or node.etag_kind is None
+        or not node.etag
+        or node.has_remote_marker_conflict
+    ):
+        return None
+    marker = node.etag
+    if node.etag_kind is RemoteMarkerKind.CONTENT_HASH:
+        parsed = parse_content_hash(marker)
+        if parsed is None:
+            return None
+        algorithm, digest = parsed
+        marker = f"{algorithm}:{digest}"
+    identity_url, _ = canonical_remote_url(node.url)
+    if not identity_url:
+        return None
+    scope = remote_request_scope_fingerprint(node.url, node.download_headers)
+    return identity_url, scope, node.etag_kind, marker
+
+
+def stage_reusable_artifact(
+    artifact: VerifiedDownloadArtifact,
+    downloadpath: Path,
+) -> TransferPlan | None:
+    """Copy a prior verified artifact to a target-local, verified stage."""
+    downloadpath.parent.mkdir(parents=True, exist_ok=True)
+    stage_path = pathing.with_windows_extended_length_prefix(
+        downloadpath.parent / f".{downloadpath.name}.smmreuse"
+    )
+    transfer = TransferPlan(
+        tmp_path=stage_path,
+        etag_sidecar=stage_path.with_name(stage_path.name + ".etag"),
+        headers={},
+    )
+    transfer.discard_partial()
+    try:
+        shutil.copyfile(artifact.path, transfer.tmp_path)
+    except OSError:
+        transfer.discard_partial()
+        return None
+
+    snapshot = storage.snapshot_file(transfer.tmp_path)
+    try:
+        size = transfer.tmp_path.stat().st_size
+    except OSError:
+        size = None
+    if (
+        snapshot.digest != artifact.content_hash
+        or size != artifact.size
+        or not snapshot.metadata_still_matches(transfer.tmp_path)
+    ):
+        transfer.discard_partial()
+        return None
+    return transfer
+
+
+def record_reused_download(
+    ctx: SyncContext,
+    node: Node,
+    downloadpath: Path,
+    content_hash: str,
+) -> None:
+    record_verified_download(ctx, node, downloadpath, None, content_hash)
+    # A complete verified copy makes any older resumable transfer obsolete.
+    prepare_transfer_plan(node, downloadpath).discard_partial()
+
+
+def install_reusable_artifact(
+    ctx: SyncContext,
+    node: Node,
+    artifact: VerifiedDownloadArtifact,
+    downloadpath: Path,
+    planned: PlannedTransfer,
+    log: logging.Logger,
+) -> DownloadOutcome | None:
+    """Install a verified in-run artifact, or return None to fall back to GET."""
+    transfer = stage_reusable_artifact(artifact, downloadpath)
+    if transfer is None:
+        return None
+    ctx.output.action("Reusing", downloadpath, node.type)
+    baseline = planned.baseline
+    if baseline.digest == artifact.content_hash and baseline.still_matches(
+        downloadpath
+    ):
+        transfer.discard_partial()
+        record_reused_download(ctx, node, downloadpath, artifact.content_hash)
+        return UNCHANGED_DOWNLOAD
+
+    install_result = install_downloaded_file(
+        downloadpath,
+        transfer,
+        planned,
+        ctx.config.conflict_handling,
+        log,
+    )
+    install_outcome = noninstalled_download_outcome(install_result, 0)
+    if install_outcome is not None:
+        return install_outcome
+    record_reused_download(ctx, node, downloadpath, artifact.content_hash)
+    return completed_download(existed=baseline.exists)
+
+
+def prepare_download_or_reuse(
+    ctx: SyncContext,
+    node: Node,
+    downloadpath: Path,
+    download_origin: str | None,
+    log: logging.Logger,
+) -> PlannedTransfer | DownloadOutcome:
+    """Apply local policy and reuse a verified transfer before requesting it."""
+    key = None if ctx.config.dry_run else transfer_reuse_key(node)
+    artifact = ctx.verified_download_artifacts.get(key) if key is not None else None
+    if artifact is not None and node.remote_size not in (None, artifact.size):
+        artifact = None
+    if artifact is not None and node.remote_size is None:
+        node.remote_size = artifact.size
+
+    action_or_outcome = planned_download_action(ctx, node, downloadpath, log)
+    if isinstance(action_or_outcome, DownloadOutcome):
+        return action_or_outcome
+    planned = action_or_outcome
+
+    if artifact is not None:
+        outcome = install_reusable_artifact(
+            ctx,
+            node,
+            artifact,
+            downloadpath,
+            planned,
+            log,
+        )
+        if outcome is not None:
+            return outcome
+    if download_origin and ctx.service_outages.should_skip(download_origin):
+        return FAILED_DOWNLOAD
+    if ctx.config.dry_run and (
+        node.download_kind is DownloadKind.OPENCAST or not size_limits_configured(ctx)
+    ):
+        return report_planned_download(ctx, downloadpath, node.type)
+    return planned
 
 
 def process_download_response(
@@ -1106,8 +1332,13 @@ def process_download_response(
     local_hash = storage.file_sha256(downloadpath) if downloadpath.exists() else None
     if staged_hash == local_hash:
         transfer.discard_partial()
-        record_download_metadata(node, downloadpath, etag_header, staged_hash)
-        ctx.downloaded_paths.add(downloadpath)
+        record_verified_download(
+            ctx,
+            node,
+            downloadpath,
+            etag_header,
+            staged_hash,
+        )
         return DownloadOutcome(
             unchanged=1,
             transferred_bytes=transferred_bytes,
@@ -1125,8 +1356,7 @@ def process_download_response(
     )
     if install_outcome is not None:
         return install_outcome
-    record_download_metadata(node, downloadpath, etag_header, staged_hash)
-    ctx.downloaded_paths.add(downloadpath)
+    record_verified_download(ctx, node, downloadpath, etag_header, staged_hash)
     return completed_download(existed=existed, transferred_bytes=transferred_bytes)
 
 
@@ -1196,18 +1426,16 @@ def download_file(
     if not node.url:
         return FAILED_DOWNLOAD
     download_origin = normalized_http_origin(node.url)
-    if download_origin and ctx.service_outages.should_skip(download_origin):
-        return FAILED_DOWNLOAD
-
-    action_or_outcome = planned_download_action(ctx, node, downloadpath, log)
+    action_or_outcome = prepare_download_or_reuse(
+        ctx,
+        node,
+        downloadpath,
+        download_origin,
+        log,
+    )
     if isinstance(action_or_outcome, DownloadOutcome):
         return action_or_outcome
     planned = action_or_outcome
-
-    if ctx.config.dry_run and (
-        node.download_kind is DownloadKind.OPENCAST or not size_limits_configured(ctx)
-    ):
-        return report_planned_download(ctx, downloadpath, node.type)
 
     opencast_course_id: Any = None
     if node.download_kind is DownloadKind.OPENCAST:
@@ -1449,6 +1677,7 @@ def scan_and_download_youtube(
         link,
         "YouTube link",
         course_id=course_id,
+        inventory=False,
     ):
         return SKIPPED_DOWNLOAD
     video_id = links.youtube_video_id_from_node(node)

--- a/syncmymoodle/filters.py
+++ b/syncmymoodle/filters.py
@@ -98,6 +98,7 @@ def should_skip_url(
     context: str = "link",
     *,
     course_id: Any = None,
+    inventory: bool = True,
 ) -> bool:
     if not url:
         return False
@@ -114,6 +115,8 @@ def should_skip_url(
             f"{context}: {redact_url_secrets(url)}",
             f"matches {redact_url_secrets(pattern)!r}",
         )
+        if inventory:
+            ctx.mark_course_inventory_filtered(course_id)
         return True
 
     allowed_domains = pattern_list(config.allowed_domains, course_id=course_id)
@@ -129,6 +132,8 @@ def should_skip_url(
                     f"{context}: {redact_url_secrets(url)}",
                     f"host {parsed_url.hostname or parsed_url.netloc!r} is not allowed",
                 )
+                if inventory:
+                    ctx.mark_course_inventory_filtered(course_id)
                 return True
 
     return False
@@ -140,8 +145,15 @@ def require_url_allowed(
     context: str,
     *,
     course_id: Any = None,
+    inventory: bool = True,
 ) -> bool:
-    if should_skip_url(ctx, url, context, course_id=course_id):
+    if should_skip_url(
+        ctx,
+        url,
+        context,
+        course_id=course_id,
+        inventory=inventory,
+    ):
         raise FilteredRequestError(
             f"request excluded by configured filters: {redact_url_secrets(url)}"
         )
@@ -167,6 +179,7 @@ def should_skip_section(
             f"{section.get('name')} ({section.get('id')}) in course {course_id}",
             f"matches {pattern!r}",
         )
+        ctx.mark_course_inventory_filtered(course_id)
         return True
     return False
 
@@ -204,5 +217,6 @@ def should_skip_module(
             f"{module_name} ({module_id}) in course {course_id}",
             f"matches {redact_url_secrets(pattern)!r}",
         )
+        ctx.mark_course_inventory_filtered(course_id)
         return True
     return False

--- a/syncmymoodle/http_utils.py
+++ b/syncmymoodle/http_utils.py
@@ -1,9 +1,10 @@
 """Small helpers for interpreting HTTP responses and fetched pages."""
 
+import hashlib
 import logging
 import re
 import urllib.parse
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from enum import Enum
 from io import BytesIO
@@ -32,18 +33,48 @@ _SENSITIVE_QUERY_PARAMETER_NAMES = frozenset(
     {
         "access_token",
         "api_key",
+        "awsaccesskeyid",
+        "googleaccessid",
         "key",
+        "key-pair-id",
         "oauth_signature",
         "passport",
         "password",
+        "policy",
         "private_token",
         "privatetoken",
         "samlresponse",
         "sesskey",
         "signature",
+        "sig",
         "token",
         "wstoken",
+        "x-amz-credential",
+        "x-amz-security-token",
+        "x-amz-signature",
+        "x-goog-credential",
+        "x-goog-security-token",
+        "x-goog-signature",
     }
+)
+_ROTATING_SIGNED_QUERY_PARAMETER_NAMES = frozenset(
+    {
+        "expires",
+        "oauth_signature",
+        "se",
+        "sig",
+        "signature",
+        "st",
+        "x-amz-date",
+        "x-amz-expires",
+        "x-amz-signature",
+        "x-goog-date",
+        "x-goog-expires",
+        "x-goog-signature",
+    }
+)
+_REMOTE_IDENTITY_VOLATILE_QUERY_PARAMETER_NAMES = (
+    _SENSITIVE_QUERY_PARAMETER_NAMES | _ROTATING_SIGNED_QUERY_PARAMETER_NAMES
 )
 _QUERY_PARAMETER_RE = re.compile(r"([?&])([^=&#\s'\"]+)=([^&#\s'\"]*)")
 _URL_USERINFO_RE = re.compile(r"(\bhttps?://)[^/?#\s'\"@]+@", re.IGNORECASE)
@@ -143,6 +174,63 @@ def redact_url_secrets(value: Any) -> str:
 
     redacted = _URL_USERINFO_RE.sub(r"\1[REDACTED]@", str(value))
     return _QUERY_PARAMETER_RE.sub(redact_parameter, redacted)
+
+
+def canonical_remote_url(value: str) -> tuple[str, str]:
+    """Return a private comparison URL and a separately redacted display URL."""
+    display_url = redact_url_secrets(value).partition("#")[0]
+    try:
+        parsed = urllib.parse.urlsplit(display_url)
+        stable_query = urllib.parse.urlencode(
+            sorted(
+                (name, query_value)
+                for name, query_value in urllib.parse.parse_qsl(
+                    parsed.query,
+                    keep_blank_values=True,
+                )
+                if name.casefold()
+                not in _REMOTE_IDENTITY_VOLATILE_QUERY_PARAMETER_NAMES
+            )
+        )
+        identity_url = urllib.parse.urlunsplit(
+            (
+                parsed.scheme.casefold(),
+                parsed.netloc.casefold(),
+                parsed.path,
+                stable_query,
+                "",
+            )
+        )
+    except ValueError:
+        identity_url = display_url.partition("#")[0]
+    return identity_url, display_url
+
+
+def remote_request_scope_fingerprint(
+    value: str,
+    headers: Mapping[str, str] | None,
+) -> str:
+    """Hash request credentials that can change the resource representation."""
+    normalized_headers = sorted(
+        (name.casefold(), header_value)
+        for name, header_value in (headers or {}).items()
+    )
+    try:
+        parsed = urllib.parse.urlsplit(value)
+        userinfo, separator, _ = parsed.netloc.rpartition("@")
+        query = sorted(
+            (name.casefold(), query_value)
+            for name, query_value in urllib.parse.parse_qsl(
+                parsed.query,
+                keep_blank_values=True,
+            )
+            if name.casefold() not in _ROTATING_SIGNED_QUERY_PARAMETER_NAMES
+        )
+        url_scope = (userinfo if separator else "", query)
+    except ValueError:
+        url_scope = (value, [])
+    raw_scope = repr((normalized_headers, url_scope)).encode()
+    return hashlib.sha256(raw_scope).hexdigest()
 
 
 def safe_request_error(error: requests.RequestException) -> str:

--- a/syncmymoodle/links.py
+++ b/syncmymoodle/links.py
@@ -48,11 +48,12 @@ LINKED_RESOURCES_CACHE_FORMAT = "syncmymoodle.linked-resources.v1"
 
 @dataclass(frozen=True)
 class LinkedResourceResolution:
-    """One reusable generic-link lookup result and its failure semantics."""
+    """One reusable generic-link lookup result and its inventory semantics."""
 
     resource: LinkedResourceCacheEntry | None
     cacheable: bool = True
     failure: str | None = None
+    inventory_incomplete: bool = False
 
 
 @dataclass(frozen=True)
@@ -61,7 +62,7 @@ class _HeadResolution:
     final_url: str
     origin: str | None
     cacheable: bool = True
-    failure: str | None = None
+    failure_status: int | None = None
 
 
 def _response_header(response: Any, name: str) -> str | None:
@@ -318,18 +319,16 @@ def _head_linked_resource(
             ):
                 entry, cacheable = _response_cache_entry(response, None)
                 return _HeadResolution(entry, final_url, request_origin, cacheable)
-            failure = (
-                f"HEAD {redact_url_secrets(final_url)} returned HTTP "
-                f"{response.status_code}"
-                if not 200 <= response.status_code < 300
-                else None
-            )
             return _HeadResolution(
                 None,
                 final_url,
                 request_origin,
                 True,
-                failure,
+                (
+                    response.status_code
+                    if not 200 <= response.status_code < 300
+                    else None
+                ),
             )
 
 
@@ -366,6 +365,7 @@ def _linked_page_html(
 def _linked_http_failure(
     ctx: SyncContext,
     response_origin: str | None,
+    method: str,
     final_url: str,
     status_code: int,
     log: logging.Logger,
@@ -373,7 +373,7 @@ def _linked_http_failure(
     failure_kind = classify_http_failure(status_code)
     if failure_kind is None:
         return None
-    failure = f"GET {redact_url_secrets(final_url)} returned HTTP {status_code}"
+    failure = f"{method} {redact_url_secrets(final_url)} returned HTTP {status_code}"
     if response_origin:
         record_service_failure(
             ctx.service_outages,
@@ -384,6 +384,9 @@ def _linked_http_failure(
             log,
         )
     if failure_kind is HttpFailureKind.RESOURCE:
+        if 400 <= status_code < 500:
+            log.info("Skipping linked resource: %s", failure)
+            return LinkedResourceResolution(None, inventory_incomplete=True)
         log.warning("Skipping linked resource: %s", failure)
     return LinkedResourceResolution(None, failure=failure)
 
@@ -431,6 +434,7 @@ def _get_linked_resource(
             failure = _linked_http_failure(
                 ctx,
                 response_origin,
+                "GET",
                 final_url,
                 response.status_code,
                 log,
@@ -502,6 +506,26 @@ def _handle_link_request_error(
     )
 
 
+def _head_only_resolution(
+    ctx: SyncContext,
+    head: _HeadResolution,
+    request_origin: str | None,
+    log: logging.Logger,
+) -> LinkedResourceResolution:
+    if head.failure_status is None:
+        return LinkedResourceResolution(None)
+    failure = _linked_http_failure(
+        ctx,
+        request_origin,
+        "HEAD",
+        head.final_url,
+        head.failure_status,
+        log,
+    )
+    assert failure is not None
+    return failure
+
+
 def _resolve_linked_resource(
     ctx: SyncContext,
     url: str,
@@ -553,17 +577,13 @@ def _resolve_linked_resource(
                 ctx.service_outages.record_available(request_origin)
             return LinkedResourceResolution(head.resource, head.cacheable)
 
-        if not ctx.config.follow_links or (
-            request_origin and ctx.service_outages.should_skip(request_origin)
-        ):
-            failure = head.failure or (
-                f"link origin {request_origin} is unavailable"
-                if request_origin and ctx.service_outages.should_skip(request_origin)
-                else None
+        if not ctx.config.follow_links:
+            return _head_only_resolution(ctx, head, request_origin, log)
+        if request_origin and ctx.service_outages.should_skip(request_origin):
+            return LinkedResourceResolution(
+                None,
+                failure=f"link origin {request_origin} is unavailable",
             )
-            if failure is not None:
-                log.warning("Skipping linked resource: %s", failure)
-            return LinkedResourceResolution(None, failure=failure)
         ctx.output.sync_progress.module_status("loading linked page")
         return _get_linked_resource(
             ctx,
@@ -586,6 +606,23 @@ def _known_provider_link(url: str) -> bool:
     )
 
 
+def _retain_cached_resource_when_unavailable(
+    resolution: LinkedResourceResolution,
+    cached: LinkedResourceCacheEntry | None,
+) -> LinkedResourceResolution:
+    if (
+        resolution.inventory_incomplete
+        and resolution.resource is None
+        and cached is not None
+    ):
+        return LinkedResourceResolution(
+            cached,
+            cacheable=resolution.cacheable,
+            inventory_incomplete=True,
+        )
+    return resolution
+
+
 def _linked_resource_for_course(
     ctx: SyncContext,
     url: str,
@@ -595,7 +632,6 @@ def _linked_resource_for_course(
     course_key = str(course_id)
     cache = ctx.linked_resources_by_course.setdefault(course_key, {})
     cached_resource = cache.get(url)
-    failed = False
     if cached_resource is not None and filters.should_skip_url(
         ctx,
         cached_resource.final_url,
@@ -607,7 +643,6 @@ def _linked_resource_for_course(
     if url in ctx.linked_resource_results:
         resolution = ctx.linked_resource_results[url]
         resource = resolution.resource
-        failed = resolution.failure is not None
         if resource is not None and filters.should_skip_url(
             ctx,
             resource.final_url,
@@ -618,24 +653,28 @@ def _linked_resource_for_course(
         if resource is not None:
             cache[url] = resource
     else:
-        resolution = _resolve_linked_resource(
-            ctx,
-            url,
+        resolution = _retain_cached_resource_when_unavailable(
+            _resolve_linked_resource(
+                ctx,
+                url,
+                cached_resource,
+                course_id,
+                log,
+            ),
             cached_resource,
-            course_id,
-            log,
         )
         resource = resolution.resource
-        failed = resolution.failure is not None
         if resolution.cacheable:
             if resource is not None:
                 cache[url] = resource
             ctx.linked_resource_results[url] = resolution
         else:
             cache.pop(url, None)
-    if failed:
+    if resolution.failure is not None:
         ctx.record_course_failure_once(course_id, f"linked-resource:{url}")
-    if resource is None and cached_resource is not None and not failed:
+    elif resolution.inventory_incomplete:
+        ctx.mark_course_inventory_filtered(course_id)
+    elif resource is None and cached_resource is not None:
         ctx.mark_course_incomplete(course_id)
     return resource
 

--- a/syncmymoodle/node.py
+++ b/syncmymoodle/node.py
@@ -313,3 +313,25 @@ class Node:
             ret.insert(0, cur.name)
             cur = cur.parent
         return ret
+
+
+def match_equivalent_child(parent: Node | None, child: Node) -> Node | None:
+    """Find the structurally equivalent child below ``parent``, if any."""
+    if parent is None:
+        return None
+    candidates = [
+        candidate
+        for candidate in parent.children
+        if candidate.name == child.name and candidate.type == child.type
+    ]
+    if not candidates:
+        return None
+
+    for attr in ("url", "name_clash_id", "id"):
+        child_value = getattr(child, attr)
+        if child_value is None:
+            continue
+        for candidate in candidates:
+            if getattr(candidate, attr) == child_value:
+                return candidate
+    return candidates[0]

--- a/syncmymoodle/outcomes.py
+++ b/syncmymoodle/outcomes.py
@@ -7,6 +7,15 @@ from dataclasses import dataclass, field
 from enum import Enum
 
 
+@dataclass(frozen=True, order=True)
+class RemovedContent:
+    """One remotely absent item whose local copy is intentionally retained."""
+
+    course: str
+    old_path: str
+    remote_identity: str
+
+
 class DownloadState(Enum):
     """Whether a download node may be persisted as handled."""
 

--- a/syncmymoodle/output.py
+++ b/syncmymoodle/output.py
@@ -28,7 +28,7 @@ from rich.progress import (
 )
 from rich.text import Text
 
-from syncmymoodle.outcomes import RunStatistics
+from syncmymoodle.outcomes import RemovedContent, RunStatistics
 
 ColorMode = Literal["auto", "always", "never"]
 COLOR_MODES: tuple[ColorMode, ...] = ("auto", "always", "never")
@@ -740,6 +740,23 @@ class TerminalOutput:
                 line.append(f": {safe_terminal_text(item.item)} - ")
                 line.append(safe_terminal_text(item.reason), style="yellow")
                 self.console.print(line, soft_wrap=True)
+
+    def removed_content(self, items: Sequence[RemovedContent]) -> None:
+        """Report remote removals without implying that local files were deleted."""
+        count = len(items)
+        noun = "item" if count == 1 else "items"
+        self.print(
+            f"No longer present in Moodle ({count} {noun}; local files kept):",
+            style="yellow",
+        )
+        for item in items:
+            line = Text("  ")
+            line.append(safe_terminal_text(item.course), style="cyan")
+            line.append(f": {safe_terminal_text(item.old_path)}")
+            line.append(" [remote: ", style="magenta")
+            line.append(safe_terminal_text(item.remote_identity))
+            line.append("]", style="magenta")
+            self.console.print(line, soft_wrap=True)
 
     def transfer(
         self,

--- a/syncmymoodle/quiz.py
+++ b/syncmymoodle/quiz.py
@@ -5,6 +5,7 @@ converts LaTeX to MathML, removes network-bearing attributes, and pins a restric
 so the saved page renders offline without executing or fetching anything."""
 
 import base64
+import hashlib
 import logging
 import mimetypes
 import os
@@ -489,6 +490,16 @@ def _strip_quiz_snapshot_active_content(soup: Any) -> None:
         form.attrs.pop("method", None)
 
 
+def normalize_quiz_review_html(review_html: str) -> str:
+    """Remove volatile form state that has no purpose in an offline review."""
+    soup = parse_html(review_html)
+    for input_tag in soup.find_all("input"):
+        input_type = str(input_tag.get("type") or "").strip().lower()
+        if input_type == "hidden":
+            input_tag.decompose()
+    return str(soup)
+
+
 def _inline_quiz_snapshot_stylesheets(
     soup: Any,
     assets: _QuizAssetContext,
@@ -619,7 +630,7 @@ def build_quiz_snapshot(
     unused assets are stripped; direct quiz images and referenced inline-style
     assets are embedded as data URIs with size budgets.
     """
-    soup = parse_html(html)
+    soup = parse_html(normalize_quiz_review_html(html))
     head = _ensure_quiz_snapshot_head(soup)
     assets = _QuizAssetContext(session, base_url, log)
 
@@ -902,6 +913,8 @@ def _stage_quiz_snapshot(
     node: Node,
     html_path: Path,
     log: logging.Logger,
+    *,
+    announce: bool = True,
 ) -> Path | None:
     if node.url is None:
         log.warning("No token-derived quiz review is available for %s", node.name)
@@ -913,7 +926,8 @@ def _stage_quiz_snapshot(
             redact_url_secrets(node.url),
         )
         return None
-    ctx.output.action("Downloading", html_path, "Quiz")
+    if announce:
+        ctx.output.action("Downloading", html_path, "Quiz")
     html_path.parent.mkdir(parents=True, exist_ok=True)
     staged_path = _temporary_quiz_path(html_path)
     staged_path.unlink(missing_ok=True)
@@ -930,6 +944,64 @@ def _stage_quiz_snapshot(
         staged_path.unlink(missing_ok=True)
         return None
     return staged_path
+
+
+def _normalized_quiz_snapshot_hash(path: Path) -> str | None:
+    try:
+        normalized = normalize_quiz_review_html(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError):
+        return None
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def _adopt_matching_uncached_quiz_artifacts(
+    ctx: SyncContext,
+    node: Node,
+    old_node: Node | None,
+    html_path: Path,
+    artifacts: dict[str, Path],
+    baselines: dict[str, storage.FileSnapshot],
+    log: logging.Logger,
+) -> DownloadOutcome | None:
+    """Adopt a cacheless snapshot only when its generated HTML still matches."""
+    html_baseline = baselines["html"]
+    if (
+        ctx.config.dry_run
+        or old_node is not None
+        or node.etag is None
+        or "html" not in artifacts
+        or html_baseline.digest is None
+        or not all(
+            baselines[kind].exists and baselines[kind].digest is not None
+            for kind in artifacts
+        )
+    ):
+        return None
+
+    staged_path = _stage_quiz_snapshot(
+        ctx,
+        node,
+        html_path,
+        log,
+        announce=False,
+    )
+    if staged_path is None:
+        return None
+    try:
+        matches = _normalized_quiz_snapshot_hash(
+            staged_path
+        ) == _normalized_quiz_snapshot_hash(html_path)
+    finally:
+        staged_path.unlink(missing_ok=True)
+    if not matches:
+        return None
+
+    # The HTML proves provenance for the review. Preserve a companion PDF but
+    # leave it unhashed: a later real review change will conflict-protect any
+    # locally annotated or replaced PDF instead of treating it as generated.
+    node.artifact_hashes = {"html": html_baseline.digest}
+    ctx.downloaded_paths.add(html_path)
+    return DownloadOutcome(unchanged=len(artifacts))
 
 
 def _prepare_quiz_artifacts(
@@ -1073,6 +1145,17 @@ def download_quiz(
     existing = {
         kind for kind, baseline in artifact_baselines.items() if baseline.exists
     }
+    adopted = _adopt_matching_uncached_quiz_artifacts(
+        ctx,
+        node,
+        old_node,
+        html_path,
+        artifacts,
+        baselines,
+        log,
+    )
+    if adopted is not None:
+        return adopted
     _initialize_quiz_artifact_hashes(node, old_node, same_revision)
     known = (
         _known_quiz_artifacts(node, old_node, artifact_baselines)

--- a/syncmymoodle/sciebo.py
+++ b/syncmymoodle/sciebo.py
@@ -1,7 +1,7 @@
 import base64
 import logging
-import posixpath
 import urllib.parse
+import xml.etree.ElementTree as ET
 from typing import Any, cast
 
 import requests
@@ -20,17 +20,25 @@ from syncmymoodle.http_utils import (
     classify_http_failure,
     get_input_value,
     parse_html,
-    parse_xml,
     record_service_failure,
     request_following_safe_redirects,
     safe_request_error,
     same_origin,
 )
-from syncmymoodle.node import Node, NodeKind, RemoteMarkerKind
+from syncmymoodle.node import (
+    DownloadKind,
+    Node,
+    NodeKind,
+    RemoteMarkerKind,
+    match_equivalent_child,
+)
 
 logger = logging.getLogger(__name__)
 
 WEBDAV_LOCATION = "/public.php/webdav/"
+_DIRECT_WEBDAV_UNSUPPORTED = object()
+DAV_NAMESPACE = "{DAV:}"
+OWNCLOUD_NAMESPACE = "{http://owncloud.org/ns}"
 
 
 def sharing_token_from_link(link: str) -> str:
@@ -46,7 +54,6 @@ def sharing_token_from_link(link: str) -> str:
 PROPFIND_BODY = """<?xml version="1.0" encoding="UTF-8"?>
 <d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
   <d:prop>
-    <d:getlastmodified/>
     <d:getetag/>
     <d:getcontentlength/>
     <oc:checksums/>
@@ -75,14 +82,47 @@ def _canonical_webdav_href(value: Any) -> str | None:
         return None
     if parsed.scheme or parsed.netloc or parsed.query or parsed.fragment:
         return None
-    decoded = urllib.parse.unquote(parsed.path)
-    if not decoded.startswith("/"):
+    path = parsed.path
+    if not path.startswith("/"):
         return None
-    is_folder = decoded.endswith("/")
-    normalized = posixpath.normpath(decoded)
-    if is_folder and normalized != "/":
+    is_folder = path.endswith("/")
+    raw_parts = path.split("/")
+    if raw_parts[0] or any(not part for part in raw_parts[1:-1]):
+        return None
+
+    encoded_parts: list[str] = []
+    for raw_part in raw_parts[1:-1] if is_folder else raw_parts[1:]:
+        try:
+            decoded_part = urllib.parse.unquote_to_bytes(raw_part).decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+        if (
+            decoded_part in {"", ".", ".."}
+            or "/" in decoded_part
+            or "\0" in decoded_part
+        ):
+            return None
+        encoded_parts.append(urllib.parse.quote(decoded_part, safe=""))
+
+    normalized = "/" + "/".join(encoded_parts)
+    if is_folder:
         normalized += "/"
     return normalized if normalized.startswith(WEBDAV_LOCATION) else None
+
+
+def _webdav_child_href(
+    parent_href: str,
+    name: str,
+    *,
+    is_folder: bool,
+) -> str | None:
+    encoded_name = urllib.parse.quote(name, safe="")
+    href = parent_href + encoded_name + ("/" if is_folder else "")
+    return href if _canonical_webdav_href(href) == href else None
+
+
+def _webdav_display_name(href: str) -> str:
+    return urllib.parse.unquote(href.rstrip("/").rsplit("/", 1)[-1])
 
 
 def _record_failure(
@@ -120,10 +160,11 @@ def scan_public_shares(
         ):
             continue
         if link in ctx.sciebo_link_cache:
-            if ctx.sciebo_link_cache[link] is None:
+            cached_root = ctx.sciebo_link_cache[link]
+            if cached_root is None:
                 _record_share_failure(ctx, parent_node, course_id, link)
-            else:
-                _reuse_cached_share(ctx, link, parent_node)
+            elif match_equivalent_child(parent_node, cached_root) is None:
+                parent_node.children.append(cached_root.clone(parent_node))
             continue
         if ctx.service_outages.should_skip(SCIEBO_URL):
             _record_share_failure(ctx, parent_node, course_id, link)
@@ -144,22 +185,157 @@ def _record_share_failure(
     ctx.record_course_failure_once(affected_course, f"sciebo:{link}")
 
 
-def _reuse_cached_share(
-    ctx: SyncContext,
-    link: str,
-    parent_node: Node,
+def _cached_node_for(ctx: SyncContext, node: Node) -> Node | None:
+    """Find ``node`` in an already loaded course cache without a dependency cycle."""
+    course_node = node.ancestor(NodeKind.COURSE)
+    if course_node is None:
+        return None
+    state = ctx.course_cache_states.get(course_node)
+    if state is None or state.course_root is None:
+        return None
+
+    relative_nodes: list[Node] = []
+    current = node
+    while current is not course_node:
+        relative_nodes.append(current)
+        if current.parent is None:
+            return None
+        current = current.parent
+
+    cached: Node | None = state.course_root
+    for relative_node in reversed(relative_nodes):
+        cached = match_equivalent_child(cached, relative_node)
+        if cached is None:
+            return None
+    return cached
+
+
+def _valid_cached_marker(node: Node) -> bool:
+    return (node.etag is None and node.etag_kind is None) or (
+        isinstance(node.etag, str) and bool(node.etag) and node.etag_kind is not None
+    )
+
+
+def _cached_sciebo_url(url: str | None, expected_href: str) -> str | None:
+    if not url or not _sciebo_url_allowed(url):
+        return None
+    try:
+        parsed = urllib.parse.urlsplit(url)
+    except ValueError:
+        return None
+    if parsed.query or parsed.fragment:
+        return None
+    return (
+        SCIEBO_URL + expected_href
+        if _canonical_webdav_href(parsed.path) == expected_href
+        else None
+    )
+
+
+def _restored_sciebo_children(
+    cached_parent: Node,
+    parent: Node,
+    parent_href: str,
+    auth_headers: dict[str, str],
+) -> list[Node] | None:
+    """Rebuild a validated cached subtree as pending nodes with current auth."""
+    restored: list[Node] = []
+    seen_hrefs: set[str] = set()
+    for cached in cached_parent.children:
+        if (
+            not cached.name
+            or cached.name in {".", ".."}
+            or "/" in cached.name
+            or not _valid_cached_marker(cached)
+            or cached.download_kind is not DownloadKind.DIRECT
+        ):
+            return None
+
+        is_folder = cached.type == "Sciebo Folder"
+        expected_href = _webdav_child_href(
+            parent_href,
+            cached.name,
+            is_folder=is_folder,
+        )
+        if expected_href is None or expected_href in seen_hrefs:
+            return None
+        seen_hrefs.add(expected_href)
+
+        if is_folder:
+            if cached.url is not None:
+                return None
+            restored_node = Node(
+                cached.name,
+                cached.id,
+                cached.type,
+                parent,
+                etag=cached.etag,
+                etag_kind=cached.etag_kind,
+                remote_size=cached.remote_size,
+                name_clash_id=cached.name_clash_id,
+            )
+            children = _restored_sciebo_children(
+                cached,
+                restored_node,
+                expected_href,
+                auth_headers,
+            )
+            if children is None:
+                return None
+            restored_node.children = children
+        elif cached.type == "Sciebo File":
+            if cached.children:
+                return None
+            url = _cached_sciebo_url(cached.url, expected_href)
+            if url is None:
+                return None
+            restored_node = Node(
+                cached.name,
+                cached.id,
+                cached.type,
+                parent,
+                url=url,
+                download_headers=auth_headers,
+                etag=cached.etag,
+                etag_kind=cached.etag_kind,
+                remote_size=cached.remote_size,
+                name_clash_id=cached.name_clash_id,
+            )
+        else:
+            return None
+        restored.append(restored_node)
+    return restored
+
+
+def _restore_unchanged_sciebo_folder(
+    folder: Node,
+    cached_folder: Node | None,
+    href: str,
+    auth_headers: dict[str, str],
 ) -> bool:
-    if link not in ctx.sciebo_link_cache:
-        return False
-    cached_root = ctx.sciebo_link_cache[link]
-    if cached_root is None:
-        return True
-    if not any(
-        child.name == cached_root.name and child.type == cached_root.type
-        for child in parent_node.children
+    if (
+        cached_folder is None
+        or folder.etag is None
+        or folder.etag_kind is None
+        or folder.etag != cached_folder.etag
+        or folder.etag_kind is not cached_folder.etag_kind
     ):
-        parent_node.children.append(cached_root.clone(parent_node))
+        return False
+    children = _restored_sciebo_children(
+        cached_folder,
+        folder,
+        href,
+        auth_headers,
+    )
+    if children is None:
+        return False
+    folder.children = children
     return True
+
+
+def _share_authorization(sharing_token: str) -> str:
+    secret = base64.b64encode(f"{sharing_token}:null".encode()).decode()
+    return f"Basic {secret}"
 
 
 def _share_auth_headers(
@@ -221,9 +397,8 @@ def _share_auth_headers(
         log.warning("Sciebo link did not contain a share token; skipping this share")
         return None
 
-    base_auth_secret = base64.b64encode(f"{sharing_token}:null".encode()).decode()
     return sharing_token, {
-        "Authorization": f"Basic {base_auth_secret}",
+        "Authorization": _share_authorization(sharing_token),
         "requesttoken": request_token,
     }
 
@@ -234,25 +409,53 @@ def _scan_new_share(
     parent_node: Node,
     log: logging.Logger,
 ) -> bool:
-    share_auth = _share_auth_headers(ctx, link, log)
-    if share_auth is None:
+    sharing_token = sharing_token_from_link(link)
+    capability = ctx.sciebo_direct_webdav_supported
+    use_legacy = capability is False
+    auth_headers: dict[str, str] = {}
+    root_listing = None
+    if not use_legacy:
+        auth_headers = {
+            "Authorization": _share_authorization(sharing_token),
+            "X-Requested-With": "XMLHttpRequest",
+        }
+        root_listing = _fetch_webdav_listing(
+            ctx,
+            WEBDAV_LOCATION,
+            auth_headers,
+            log,
+            allow_legacy_fallback=True,
+        )
+        use_legacy = root_listing is _DIRECT_WEBDAV_UNSUPPORTED
+
+    if use_legacy:
+        share_auth = _share_auth_headers(ctx, link, log)
+        if share_auth is None:
+            ctx.sciebo_link_cache[link] = None
+            return False
+        sharing_token, auth_headers = share_auth
+        root_listing = None
+    elif root_listing is None:
         ctx.sciebo_link_cache[link] = None
         return False
-    sharing_token, auth_headers = share_auth
 
     sciebo_root = parent_node.add_child(
         f"sciebo-{sharing_token}", None, "Sciebo Folder"
     )
+    cached_root = _cached_node_for(ctx, sciebo_root)
 
     if _add_sciebo_files(
         ctx,
         WEBDAV_LOCATION,
         sciebo_root,
-        sharing_token,
         auth_headers,
         log,
+        listing=root_listing,
+        cached_parent=cached_root,
     ):
         ctx.service_outages.record_available(SCIEBO_URL)
+        if capability is None:
+            ctx.sciebo_direct_webdav_supported = not use_legacy
         ctx.sciebo_link_cache[link] = sciebo_root.clone()
         return True
 
@@ -266,6 +469,8 @@ def _fetch_webdav_listing(
     href: str,
     auth_header: dict[str, str],
     log: logging.Logger,
+    *,
+    allow_legacy_fallback: bool = False,
 ) -> Any | None:
     # request the URL with the PROPFIND method and a body that also asks
     # Sciebo/Nextcloud to include content checksums (oc:checksums) for each
@@ -305,6 +510,9 @@ def _fetch_webdav_listing(
 
     failure_kind = classify_http_failure(propfind_response.status_code)
     if failure_kind is not None:
+        if allow_legacy_fallback and failure_kind is HttpFailureKind.RESOURCE:
+            propfind_response.close()
+            return _DIRECT_WEBDAV_UNSUPPORTED
         _record_failure(
             ctx,
             failure_kind,
@@ -318,9 +526,20 @@ def _fetch_webdav_listing(
             )
         return None
 
-    # A maintenance proxy can return an HTML error document with HTTP 200.
-    soup_xml = parse_xml(propfind_response.text)
-    if soup_xml.find("d:multistatus") is None or soup_xml.find("d:response") is None:
+    # Reject both maintenance HTML and truncated XML. A recovering parser could
+    # turn a partial directory response into a cacheable, incomplete inventory.
+    try:
+        listing = ET.fromstring(propfind_response.text)
+    except ET.ParseError:
+        listing = None
+    if (
+        listing is None
+        or listing.tag != DAV_NAMESPACE + "multistatus"
+        or not listing.findall(DAV_NAMESPACE + "response")
+    ):
+        if allow_legacy_fallback:
+            propfind_response.close()
+            return _DIRECT_WEBDAV_UNSUPPORTED
         _record_failure(
             ctx,
             HttpFailureKind.TRANSIENT,
@@ -328,28 +547,36 @@ def _fetch_webdav_listing(
             log,
         )
         return None
-    return soup_xml
+    return listing
 
 
 def _add_sciebo_files(
     ctx: SyncContext,
     href: str,
     parent_node: Node,
-    sharing_token: str,
     auth_header: dict[str, str],
     log: logging.Logger = logger,
+    *,
+    listing: Any | None = None,
+    cached_parent: Node | None = None,
 ) -> bool:
     ctx.output.sync_progress.module_status(f"scanning Sciebo folder {parent_node.name}")
-    soup_xml = _fetch_webdav_listing(ctx, href, auth_header, log)
-    if soup_xml is None:
+    listing_result = (
+        listing
+        if listing is not None
+        else _fetch_webdav_listing(ctx, href, auth_header, log)
+    )
+    if not isinstance(listing_result, ET.Element):
         return False
 
     current_href = _canonical_webdav_href(href)
-    responses: list[tuple[Any, str]] = []
+    responses: list[tuple[ET.Element, str]] = []
     seen_hrefs: set[str] = set()
-    for resp in soup_xml.find_all("d:response"):
-        href_tag = resp.find("d:href")
-        new_href = _canonical_webdav_href(href_tag.text if href_tag else None)
+    for resp in listing_result.findall(DAV_NAMESPACE + "response"):
+        href_tag = resp.find(DAV_NAMESPACE + "href")
+        new_href = _canonical_webdav_href(
+            href_tag.text if href_tag is not None else None
+        )
         relative = (
             new_href[len(current_href) :].rstrip("/")
             if current_href is not None
@@ -377,21 +604,12 @@ def _add_sciebo_files(
             )
             continue
 
-        remote_marker = _extract_remote_marker(resp)
+        remote_marker, remote_size = _extract_remote_metadata(resp)
         etag_value = remote_marker[0] if remote_marker else None
         etag_kind = remote_marker[1] if remote_marker else None
-        remote_size = _extract_remote_size(resp)
 
         log.info(f"Sciebo response href: {new_href}")
-        # get the displayname of the response
-        displayname = (
-            new_href.split("/")[-2]
-            if new_href.endswith("/")
-            else new_href.split("/")[-1]
-        )
-        displayname = (
-            f"sciebo-{sharing_token}" if displayname == "webdav" else displayname
-        )
+        displayname = _webdav_display_name(new_href)
 
         # check if the response is a folder
         if new_href.endswith("/"):
@@ -404,9 +622,22 @@ def _add_sciebo_files(
                 etag_kind=etag_kind,
                 remote_size=remote_size,
             )
+            cached_folder = match_equivalent_child(cached_parent, folder_node)
+            if _restore_unchanged_sciebo_folder(
+                folder_node,
+                cached_folder,
+                new_href,
+                auth_header,
+            ):
+                continue
             # recursive call to get all files in the folder
             if not _add_sciebo_files(
-                ctx, new_href, folder_node, sharing_token, auth_header, log
+                ctx,
+                new_href,
+                folder_node,
+                auth_header,
+                log,
+                cached_parent=cached_folder,
             ):
                 return False
         else:
@@ -425,36 +656,57 @@ def _add_sciebo_files(
     return True
 
 
-def _extract_remote_marker(response_tag: Any) -> tuple[str, RemoteMarkerKind] | None:
+def _successful_dav_properties(response: ET.Element) -> list[ET.Element]:
+    properties: list[ET.Element] = []
+    for propstat in response.findall(DAV_NAMESPACE + "propstat"):
+        status = propstat.findtext(DAV_NAMESPACE + "status", default="")
+        fields = status.split(maxsplit=2)
+        if len(fields) < 2 or not fields[1].isdigit():
+            continue
+        if not 200 <= int(fields[1]) < 300:
+            continue
+        prop = propstat.find(DAV_NAMESPACE + "prop")
+        if prop is not None:
+            properties.append(prop)
+    return properties
+
+
+def _extract_remote_metadata(
+    response_tag: ET.Element,
+) -> tuple[tuple[str, RemoteMarkerKind] | None, int | None]:
+    properties = _successful_dav_properties(response_tag)
+    return _extract_remote_marker(properties), _extract_remote_size(properties)
+
+
+def _extract_remote_marker(
+    properties: list[ET.Element],
+) -> tuple[str, RemoteMarkerKind] | None:
     # Prefer a stable content hash from oc:checksums; fall back to the raw ETag
     # as an opaque remote-version marker.
-    prop = response_tag.find("d:prop")
-    if prop is None:
-        return None
+    for prop in properties:
+        checksums_tag = prop.find(OWNCLOUD_NAMESPACE + "checksums")
+        if checksums_tag is not None:
+            for checksum in checksums_tag.findall(OWNCLOUD_NAMESPACE + "checksum"):
+                text = (checksum.text or "").strip()
+                if text.upper().startswith("SHA1:"):
+                    return text.split(":", 1)[1], RemoteMarkerKind.CONTENT_HASH
 
-    checksums_tag = prop.find("oc:checksums")
-    if checksums_tag is not None:
-        for cs in checksums_tag.find_all("oc:checksum"):
-            text = (cs.text or "").strip()
-            if text.upper().startswith("SHA1:"):
-                return text.split(":", 1)[1], RemoteMarkerKind.CONTENT_HASH
-
-    etag_tag = prop.find("d:getetag")
-    if etag_tag and etag_tag.text:
-        return str(etag_tag.text).strip(), RemoteMarkerKind.OPAQUE
+    for prop in properties:
+        etag_tag = prop.find(DAV_NAMESPACE + "getetag")
+        if etag_tag is not None and etag_tag.text:
+            return etag_tag.text.strip(), RemoteMarkerKind.OPAQUE
 
     return None
 
 
-def _extract_remote_size(response_tag: Any) -> int | None:
-    prop = response_tag.find("d:prop")
-    if prop is None:
-        return None
-    size_tag = prop.find("d:getcontentlength")
-    if size_tag is None or not size_tag.text:
-        return None
-    try:
-        size = int(size_tag.text.strip())
-    except ValueError:
-        return None
-    return size if size >= 0 else None
+def _extract_remote_size(properties: list[ET.Element]) -> int | None:
+    for prop in properties:
+        size_tag = prop.find(DAV_NAMESPACE + "getcontentlength")
+        if size_tag is None or not size_tag.text:
+            continue
+        try:
+            size = int(size_tag.text.strip())
+        except ValueError:
+            continue
+        return size if size >= 0 else None
+    return None

--- a/syncmymoodle/sync.py
+++ b/syncmymoodle/sync.py
@@ -1,13 +1,18 @@
+import hashlib
+import json
 import logging
 import time
 from dataclasses import dataclass
+from pathlib import PurePosixPath
 from typing import Any
 
-from syncmymoodle import course_cache, filters, pathing, sync_handlers
+from syncmymoodle import course_cache, filters, links, pathing, sync_handlers
 from syncmymoodle import moodle as moodle_api
 from syncmymoodle.context import SyncContext
-from syncmymoodle.http_utils import redact_url_secrets
-from syncmymoodle.node import Node, NodeKind
+from syncmymoodle.http_utils import canonical_remote_url, redact_url_secrets
+from syncmymoodle.node import DownloadKind, Node, NodeKind
+from syncmymoodle.outcomes import RemovedContent
+from syncmymoodle.pathing import sanitized_node_path_parts
 
 logger = logging.getLogger(__name__)
 SLOW_MODULE_SECONDS = 1.0
@@ -25,6 +30,110 @@ class _PreparedCourse:
     name: str
     course_id: int
     node: Node
+
+
+def _course_inventory_scope(ctx: SyncContext, course_id: int) -> str:
+    """Describe configured policy that controls which remote nodes enter a tree."""
+
+    def patterns(value: dict[str, list[str]]) -> list[str]:
+        return sorted(set(filters.pattern_list(value, course_id)))
+
+    config = ctx.config
+    scope = {
+        "version": 1,
+        "filters": {
+            "allowed_domains": patterns(config.allowed_domains),
+            "exclude_links": patterns(config.exclude_links),
+            "exclude_modules": patterns(config.exclude_modules),
+            "exclude_sections": patterns(config.exclude_sections),
+        },
+        "links": {
+            "follow": config.follow_links,
+            "youtube": config.link_youtube,
+            "opencast": config.link_opencast,
+            "sciebo": config.link_sciebo,
+            "emedia": config.link_emedia,
+        },
+        "modules": {
+            "assignment": config.module_assignment,
+            "resource": config.module_resource,
+            "folder": config.module_folder,
+            "quiz": config.quiz_mode,
+        },
+    }
+    encoded = json.dumps(scope, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _remote_content_identity(node: Node) -> tuple[str, str] | None:
+    """Return a stable comparison key and a safe user-visible identity."""
+    if not node.url:
+        return None
+    youtube_id = links.youtube_video_id_from_node(node)
+    if youtube_id is not None:
+        identity = f"youtube:{youtube_id}"
+        return identity, identity
+    identity_url, display_url = canonical_remote_url(node.url)
+    if node.download_kind is DownloadKind.OPENCAST:
+        identity = f"opencast:{node.id}:{identity_url.partition('?')[0]}"
+        return identity, identity
+    if node.download_kind in {DownloadKind.EMEDIA, DownloadKind.QUIZ} and node.id:
+        identity = f"{node.download_kind}:{node.id}"
+        return identity, identity
+    return f"{node.download_kind}:{identity_url}", display_url
+
+
+def _remote_content_nodes(root: Node) -> dict[str, list[tuple[Node, str]]]:
+    nodes: dict[str, list[tuple[Node, str]]] = {}
+    pending = [root]
+    while pending:
+        node = pending.pop()
+        pending.extend(node.children)
+        identity = _remote_content_identity(node)
+        if identity is not None:
+            key, display = identity
+            nodes.setdefault(key, []).append((node, display))
+    return nodes
+
+
+def _old_course_relative_path(node: Node) -> str:
+    parts = sanitized_node_path_parts(node)[1:]
+    return PurePosixPath(*parts).as_posix()
+
+
+def _removed_course_content(
+    course: _PreparedCourse,
+    old_course_root: Node,
+) -> set[RemovedContent]:
+    """Find unambiguous remote identities absent from the current course tree."""
+    old_nodes = _remote_content_nodes(old_course_root)
+    current_identities = _remote_content_nodes(course.node)
+    course_label = f"{course.name} ({course.course_id})"
+    return {
+        RemovedContent(course_label, _old_course_relative_path(node), display)
+        for identity, candidates in old_nodes.items()
+        if identity not in current_identities and len(candidates) == 1
+        for node, display in candidates
+    }
+
+
+def _record_removed_content(
+    ctx: SyncContext,
+    courses: list[_PreparedCourse],
+) -> None:
+    for course in courses:
+        if course.course_id in ctx.incomplete_course_ids:
+            continue
+        old_course_root = course_cache.comparable_course_cache_root(
+            ctx,
+            course.node,
+            _course_inventory_scope(ctx, course.course_id),
+            logger,
+        )
+        if course.course_id in ctx.inventory_filtered_course_ids:
+            continue
+        if old_course_root is not None:
+            ctx.removed_content.update(_removed_course_content(course, old_course_root))
 
 
 @dataclass
@@ -382,7 +491,11 @@ def _folders_by_coursemodule(
     module_names: set[Any],
 ) -> dict[int, dict[str, Any]]:
     folders: list[dict[str, Any]] | None = []
-    if ctx.config.module_folder and "folder" in module_names:
+    if (
+        ctx.config.module_folder
+        and ctx.config.follow_links
+        and "folder" in module_names
+    ):
         account = ctx.require_moodle_account()
         folders = moodle_api.get_folders_by_courses(
             ctx.require_session(), account.wstoken, course.course_id
@@ -530,3 +643,4 @@ def sync(ctx: SyncContext) -> None:
         progress.start_course(course_index, course.name)
         _sync_course_safely(ctx, root_node, course, course_index)
     pathing.resolve_node_path_clashes(root_node)
+    _record_removed_content(ctx, prepared_courses)

--- a/syncmymoodle/sync_handlers.py
+++ b/syncmymoodle/sync_handlers.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, cast
 
 import requests
 
-from syncmymoodle import course_cache, filters, moodle_files
+from syncmymoodle import course_cache, filters, moodle_files, quiz
 from syncmymoodle import links as links_api
 from syncmymoodle import moodle as moodle_api
 from syncmymoodle import opencast as opencast_api
@@ -485,17 +485,31 @@ def _assignment_submission_files(
 def _add_moodle_file_nodes(
     ctx: SyncContext,
     parent_node: Node,
-    files: list[Any],
+    files: object,
     file_type: str,
     filter_context: str,
     course_id: Any,
-) -> None:
+) -> bool:
+    if not isinstance(files, list):
+        return False
+    complete = True
     for item in files:
         if not isinstance(item, dict):
+            complete = False
+            continue
+        filename = item.get("filename")
+        file_url = item.get("fileurl")
+        if (
+            not isinstance(filename, str)
+            or not filename
+            or not isinstance(file_url, str)
+            or not file_url
+        ):
+            complete = False
             continue
         if filters.should_skip_url(
             ctx,
-            item.get("fileurl"),
+            file_url,
             filter_context,
             course_id=course_id,
         ):
@@ -503,14 +517,15 @@ def _add_moodle_file_nodes(
         moodle_files.add_moodle_file_node(
             parent_node,
             item.get("filepath", "/"),
-            item["filename"],
-            item["fileurl"],
+            filename,
+            file_url,
             file_type,
-            item["fileurl"],
+            file_url,
             timemodified=item.get("timemodified"),
             remote_size=item.get("filesize"),
             remote_content_hash=item.get("contenthash"),
         )
+    return complete
 
 
 def handle_assignment_module(
@@ -526,7 +541,13 @@ def handle_assignment_module(
     if not ctx.config.module_assignment:
         return
     ass = assignments_by_cmid.get(module["id"])
-    if not ass:
+    if ass is None:
+        if course_id not in ctx.incomplete_course_ids:
+            module_context.log.error(
+                "Moodle assignment inventory omitted module %s",
+                module["id"],
+            )
+            module_context.fail_once(f"assignment-instance:{module['id']}")
         return
     assignment_id = ass["id"]
     module_id = module["id"]
@@ -561,14 +582,20 @@ def handle_assignment_module(
         return
 
     intro_attachments = ass.get("introattachments") or []
-    _add_moodle_file_nodes(
+    if not _add_moodle_file_nodes(
         ctx,
         assignment_node,
         [*intro_attachments, *submission_files],
         "Assignment File",
         "assignment file",
         course_id,
-    )
+    ):
+        module_context.log.error(
+            "Moodle returned a malformed assignment file inventory for module %s",
+            module_id,
+        )
+        module_context.fail_once(f"assignment-files:{module_id}")
+        return
     if cache_allowed:
         course_cache.store_assignment_cache_entry(
             ctx,
@@ -586,6 +613,45 @@ def handle_assignment_module(
         )
 
 
+def _resource_like_contents(
+    module_context: ModuleContext,
+    module: dict[str, Any],
+) -> list[dict[str, Any]] | None:
+    module_kind = module["modname"]
+    raw_contents = module.get("contents", [])
+    if (
+        module_kind == "resource"
+        and module.get("uservisible") is False
+        and raw_contents == []
+    ):
+        module_context.log.info(
+            "Skipping unavailable resource module %s because Moodle did not "
+            "expose its contents",
+            module["id"],
+        )
+        module_context.ctx.mark_course_inventory_filtered(module_context.course_id)
+        return []
+    malformed = (
+        not isinstance(raw_contents, list)
+        or (module_kind == "resource" and not raw_contents)
+        or any(
+            not isinstance(item, dict)
+            or not isinstance(item.get("fileurl"), str)
+            or not item["fileurl"]
+            for item in raw_contents
+        )
+    )
+    if malformed:
+        module_context.log.error(
+            "Moodle returned a malformed %s content inventory for module %s",
+            module_kind,
+            module["id"],
+        )
+        module_context.fail_once(f"{module_kind}-contents:{module['id']}")
+        return None
+    return [item for item in raw_contents if isinstance(item, dict)]
+
+
 def handle_resource_like_module(
     module_context: ModuleContext,
     module: dict[str, Any],
@@ -597,10 +663,12 @@ def handle_resource_like_module(
     # Get Resources or URLs
     if module["modname"] == "resource" and not ctx.config.module_resource:
         return
-    for c in module.get("contents", []):
-        file_url = c.get("fileurl")
-        if not file_url:
-            continue
+    contents = _resource_like_contents(module_context, module)
+    if contents is None:
+        return
+    for c in contents:
+        file_url = c["fileurl"]
+        assert isinstance(file_url, str)
         if filters.should_skip_url(
             ctx,
             file_url,
@@ -637,18 +705,33 @@ def handle_folder_module(
     folder_node = section_node.add_child(module["name"], module["id"], "Folder")
 
     folder_info = folders_by_coursemodule.get(module["id"])
-    if folder_info and folder_info.get("intro"):
+    if (
+        ctx.config.follow_links
+        and folder_info is None
+        and course_id not in ctx.incomplete_course_ids
+    ):
+        module_context.log.error(
+            "Moodle folder inventory omitted module %s",
+            module["id"],
+        )
+        module_context.fail_once(f"folder-instance:{module['id']}")
+    elif folder_info and folder_info.get("intro"):
         module_context.status("scanning folder links")
         links_api.scan_for_links(ctx, folder_info["intro"], folder_node, course_id)
 
-    _add_moodle_file_nodes(
+    if not _add_moodle_file_nodes(
         ctx,
         folder_node,
         module.get("contents", []),
         "Folder File",
         "folder file",
         course_id,
-    )
+    ):
+        module_context.log.error(
+            "Moodle returned a malformed folder file inventory for module %s",
+            module["id"],
+        )
+        module_context.fail_once(f"folder-files:{module['id']}")
 
 
 def handle_embedded_link_module(
@@ -910,9 +993,20 @@ def _handle_h5p_links(
         moodle_api.get_h5pactivities_by_course,
     )
     if not isinstance(activity, dict):
+        if module_context.course_id not in ctx.incomplete_course_ids:
+            module_context.log.error(
+                "Moodle H5P inventory omitted module %s",
+                module["id"],
+            )
+            module_context.fail_once(f"h5p-instance:{module['id']}")
         return
     package_file = _h5p_package_file(activity)
     if package_file is None:
+        module_context.log.error(
+            "Moodle returned H5P activity %s without a valid package file",
+            module["id"],
+        )
+        module_context.fail_once(f"h5p-package:{module['id']}")
         return
     package_url = package_file["fileurl"]
     assert isinstance(package_url, str)
@@ -995,6 +1089,8 @@ def _opencast_lti_launch(
         module_context.log.warning(
             "Opencast: LTI module %s has no tool instance id", module["id"]
         )
+        if module_context.course_id not in ctx.incomplete_course_ids:
+            module_context.fail_once(f"opencast-lti:{module['id']}")
         return None
     module_context.status("loading Opencast launch data")
     launch_data = moodle_api.get_lti_launch_data(
@@ -1153,10 +1249,11 @@ def _quiz_review_html(name: str, review: dict[str, Any]) -> str:
         if title not in (None, ""):
             parts.append(f"<h2>{html.escape(str(title))}</h2>")
         parts.append(str(item.get("content") or ""))
-    return (
+    review_html = (
         "<!doctype html><html><head><title>"
         f"{html.escape(name)}</title></head><body>{''.join(parts)}</body></html>"
     )
+    return quiz.normalize_quiz_review_html(review_html)
 
 
 def _quiz_cache_timing(
@@ -1324,6 +1421,12 @@ def handle_quiz_module(
     )
     quiz_id = instance.get("id") if instance else module.get("instance")
     if not isinstance(quiz_id, int) or isinstance(quiz_id, bool):
+        module_context.log.error(
+            "Moodle quiz inventory omitted module %s and no fallback instance is valid",
+            module_id,
+        )
+        if module_context.course_id not in ctx.incomplete_course_ids:
+            module_context.fail_once(f"quiz-instance:{module_id}")
         return
     cached_data = _cached_quiz_data(module_context, module_id, instance)
     timing: QuizCacheTiming | None

--- a/tests/fixtures/sciebo/propfind_root.xml
+++ b/tests/fixtures/sciebo/propfind_root.xml
@@ -6,6 +6,7 @@
       <d:prop>
         <d:getetag>"folder-root"</d:getetag>
       </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
     </d:propstat>
   </d:response>
   <d:response>
@@ -18,6 +19,7 @@
           <oc:checksum>SHA1:1111111111111111111111111111111111111111</oc:checksum>
         </oc:checksums>
       </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
     </d:propstat>
   </d:response>
   <d:response>
@@ -26,6 +28,7 @@
       <d:prop>
         <d:getetag>"folder-slides"</d:getetag>
       </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
     </d:propstat>
   </d:response>
 </d:multistatus>

--- a/tests/fixtures/sciebo/propfind_slides.xml
+++ b/tests/fixtures/sciebo/propfind_slides.xml
@@ -6,6 +6,7 @@
       <d:prop>
         <d:getetag>"folder-slides"</d:getetag>
       </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
     </d:propstat>
   </d:response>
   <d:response>
@@ -18,6 +19,7 @@
           <oc:checksum>SHA1:2222222222222222222222222222222222222222</oc:checksum>
         </oc:checksums>
       </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
     </d:propstat>
   </d:response>
 </d:multistatus>

--- a/tests/test_download_behavior.py
+++ b/tests/test_download_behavior.py
@@ -1,6 +1,7 @@
 import hashlib
 import logging
 import os
+from pathlib import Path
 
 import pytest
 import requests
@@ -180,8 +181,137 @@ def test_moodle_content_hash_skips_identical_untracked_file(tmp_path):
     assert outcome.unchanged == 1
     assert file_node.etag == sha1(content)
     assert file_node.etag_kind is RemoteMarkerKind.CONTENT_HASH
+    assert file_node.content_hash == sha256(content)
     assert ctx.session.calls == []
     assert list(download_path.parent.glob("*.syncconflict.*")) == []
+
+
+def _uncached_local_file(
+    tmp_path,
+    *,
+    timemodified=1710000300,
+    local_mtime=1710000300,
+    etag=None,
+    content=b"local content",
+    dry_run=False,
+):
+    ctx = make_context(
+        {
+            "paths.sync_directory": str(tmp_path),
+            "downloads.update_files": True,
+            "downloads.dry_run": dry_run,
+        }
+    )
+    ctx.session = FakeSession()
+    ctx.root_node, file_node = build_single_file_tree(
+        "slides.pdf",
+        URL,
+        timemodified=timemodified,
+        etag=etag,
+    )
+    assert file_node is not None
+    download_path = node_path(ctx, file_node)
+    download_path.parent.mkdir(parents=True)
+    download_path.write_bytes(content)
+    os.utime(download_path, (local_mtime, local_mtime))
+    return ctx, file_node, download_path
+
+
+def test_matching_remote_timestamp_adopts_uncached_file_and_persists_hash(tmp_path):
+    content = b"already downloaded content without a remote checksum"
+    ctx, file_node, _ = _uncached_local_file(tmp_path, content=content)
+
+    assert ctx.root_node is not None
+    downloader.download_node_tree(ctx, ctx.root_node)
+    course_cache.cache_root_node(ctx)
+
+    assert ctx.stats.unchanged == 1
+    assert ctx.stats.planned == 0
+    assert file_node.content_hash == sha256(content)
+    assert ctx.session.calls == []
+
+    loaded = make_context({"paths.sync_directory": str(tmp_path)})
+    cached_file = course_cache.get_old_node_for(loaded, file_node)
+    assert cached_file is not None
+    assert cached_file.is_verified
+    assert cached_file.content_hash == sha256(content)
+
+
+def test_dry_run_reports_matching_uncached_timestamp_as_unchanged(tmp_path):
+    ctx, file_node, _ = _uncached_local_file(tmp_path, dry_run=True)
+    course = course_cache.get_course_node(file_node)
+
+    outcome = download_file(ctx, file_node)
+
+    assert outcome.unchanged == 1
+    assert outcome.planned == 0
+    assert ctx.session.calls == []
+    assert not course_cache.course_cache_path(ctx, course).exists()
+
+
+@pytest.mark.parametrize("marker", [sha1(b"different remote content"), "not-a-hash"])
+def test_current_content_hash_blocks_timestamp_adoption(tmp_path, marker):
+    ctx, file_node, download_path = _uncached_local_file(tmp_path, etag=marker)
+    file_node.etag_kind = RemoteMarkerKind.CONTENT_HASH
+
+    assert (
+        downloader.decide_download(ctx, file_node, download_path)
+        is downloader.DownloadDecision.CONFLICT
+    )
+
+
+def test_conflicting_remote_markers_block_timestamp_adoption(tmp_path):
+    ctx, file_node, download_path = _uncached_local_file(
+        tmp_path,
+        etag=sha1(b"first remote content"),
+    )
+    file_node.etag_kind = RemoteMarkerKind.CONTENT_HASH
+    assert file_node.parent is not None
+    file_node.parent.add_download_child(
+        file_node.name,
+        file_node.id,
+        file_node.type,
+        url=URL,
+        timemodified=1710000300,
+        etag=sha1(b"second remote content"),
+        etag_kind=RemoteMarkerKind.CONTENT_HASH,
+    )
+
+    assert file_node.has_remote_marker_conflict
+    assert (
+        downloader.decide_download(ctx, file_node, download_path)
+        is downloader.DownloadDecision.CONFLICT
+    )
+
+
+@pytest.mark.parametrize(
+    "timemodified",
+    [1710000301, True, -1, "1710000300", 1710000300.0],
+)
+def test_nonmatching_or_invalid_remote_timestamp_is_not_adopted(tmp_path, timemodified):
+    ctx, file_node, download_path = _uncached_local_file(
+        tmp_path,
+        timemodified=timemodified,
+    )
+
+    assert (
+        downloader.decide_download(ctx, file_node, download_path)
+        is downloader.DownloadDecision.CONFLICT
+    )
+
+
+def test_unreadable_snapshot_is_not_adopted_by_timestamp(tmp_path):
+    ctx, file_node, download_path = _uncached_local_file(tmp_path)
+
+    assert (
+        downloader.decide_download(
+            ctx,
+            file_node,
+            download_path,
+            baseline=downloader.storage.FileSnapshot(True),
+        )
+        is downloader.DownloadDecision.CONFLICT
+    )
 
 
 def test_transfer_plan_applies_windows_prefix_to_appended_temp_paths(
@@ -197,6 +327,30 @@ def test_transfer_plan_applies_windows_prefix_to_appended_temp_paths(
 
     assert os.fspath(plan.tmp_path).startswith("\\\\?\\")
     assert os.fspath(plan.etag_sidecar).startswith("\\\\?\\")
+
+
+def test_discard_partial_tolerates_a_windows_style_file_lock(tmp_path, monkeypatch):
+    plan = downloader.prepare_transfer_plan(
+        Node("file.pdf", "id", "Linked file [application/pdf]", None),
+        tmp_path / "file.pdf",
+    )
+    plan.tmp_path.write_bytes(b"partial")
+    plan.etag_sidecar.write_text('"revision-1"', encoding="utf-8")
+    original_unlink = Path.unlink
+
+    def locked_unlink(path, *args, **kwargs):
+        if path == plan.tmp_path:
+            raise PermissionError("simulated Windows file lock")
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", locked_unlink)
+
+    plan.discard_partial()
+
+    assert plan.tmp_path.exists()
+    assert not plan.etag_sidecar.exists()
+    assert plan.resume_size == 0
+    assert plan.partial_etag is None
 
 
 def test_youtube_outtmpl_applies_windows_prefix_after_template_suffix(
@@ -1470,6 +1624,7 @@ def test_failed_previous_download_is_retried_not_skipped(tmp_path):
     download_path = node_path(syncer, file_node)
     download_path.parent.mkdir(parents=True, exist_ok=True)
     download_path.write_bytes(b"OLD STALE VERSION")
+    os.utime(download_path, (1710000300, 1710000300))
     syncer.session.add(
         "GET",
         URL,
@@ -2201,6 +2356,297 @@ def _sciebo_tree(etag, handled=False, content_hash=None, etag_kind=None):
         file_node.mark_handled()
     file_node.content_hash = content_hash
     return root, file_node
+
+
+def _duplicate_sciebo_destinations(
+    first_url,
+    second_url,
+    first_etag,
+    second_etag=None,
+):
+    root, first = _sciebo_tree(
+        first_etag,
+        etag_kind=RemoteMarkerKind.OPAQUE,
+    )
+    first.url = first_url
+    semester = root.children[0]
+    second_course = semester.add_child("Other Course", 302, "Course")
+    second_section = second_course.add_child("General", 402, "Section")
+    second = second_section.add_download_child(
+        "notes.pdf",
+        None,
+        "Sciebo File",
+        url=second_url,
+        download_headers={"Authorization": "Basic x"},
+        etag=second_etag or first_etag,
+        etag_kind=RemoteMarkerKind.OPAQUE,
+    )
+    return root, first, second
+
+
+def test_duplicate_sciebo_destinations_reuse_one_verified_transfer(tmp_path):
+    content = b"shared sciebo notes"
+    first_url = SCIEBO_URL + "?X-Amz-Date=20260716T100000Z&sig=first-secret"
+    second_url = SCIEBO_URL + "?sig=second-secret&X-Amz-Date=20260716T110000Z"
+    _, first, second = _duplicate_sciebo_destinations(
+        first_url,
+        second_url,
+        '"revision-1"',
+    )
+    syncer = make_context({"paths.sync_directory": str(tmp_path)})
+    syncer.session = FakeSession()
+    second_path = node_path(syncer, second)
+    second_path.parent.mkdir(parents=True)
+    for suffix in ("smmpart", "smmpart.etag"):
+        (second_path.parent / f".{second_path.name}.{suffix}").write_bytes(b"stale")
+    syncer.session.add(
+        "GET",
+        first_url,
+        FakeResponse(
+            headers={
+                "Content-Type": "application/pdf",
+                "Content-Length": str(len(content)),
+            },
+            chunks=[content],
+        ),
+    )
+
+    first_outcome = download_file(syncer, first)
+    second_outcome = download_file(syncer, second)
+
+    assert first_outcome.downloaded == 1
+    assert first_outcome.transferred_bytes == len(content)
+    assert second_outcome.downloaded == 1
+    assert second_outcome.transferred_bytes == 0
+    assert syncer.session.count("GET") == 1
+    assert node_path(syncer, first).read_bytes() == content
+    assert second_path.read_bytes() == content
+    assert first.content_hash == second.content_hash == sha256(content)
+    assert not list(second_path.parent.glob(".*.smm*"))
+
+
+def test_reuse_succeeds_when_a_stale_partial_is_windows_locked(
+    tmp_path,
+    monkeypatch,
+):
+    content = b"shared sciebo notes"
+    _, first, second = _duplicate_sciebo_destinations(
+        SCIEBO_URL,
+        SCIEBO_URL,
+        '"revision-1"',
+    )
+    syncer = make_context({"paths.sync_directory": str(tmp_path)})
+    syncer.session = FakeSession()
+    syncer.session.add(
+        "GET",
+        SCIEBO_URL,
+        FakeResponse(headers={"Content-Type": "application/pdf"}, chunks=[content]),
+    )
+    assert download_file(syncer, first).is_handled
+
+    second_path = node_path(syncer, second)
+    second_path.parent.mkdir(parents=True)
+    partial = second_path.parent / f".{second_path.name}.smmpart"
+    sidecar = partial.with_name(partial.name + ".etag")
+    partial.write_bytes(b"stale partial")
+    sidecar.write_text('"stale-revision"', encoding="utf-8")
+    original_unlink = Path.unlink
+
+    def locked_unlink(path, *args, **kwargs):
+        if path == partial:
+            raise PermissionError("simulated Windows file lock")
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", locked_unlink)
+
+    assert download_file(syncer, second).downloaded == 1
+
+    assert syncer.session.count("GET", SCIEBO_URL) == 1
+    assert second_path.read_bytes() == content
+    assert partial.read_bytes() == b"stale partial"
+    assert not sidecar.exists()
+    assert not list(second_path.parent.glob(".*.smmreuse*"))
+
+
+def test_reused_transfer_preserves_a_target_created_while_staging(
+    tmp_path,
+    monkeypatch,
+):
+    content = b"shared sciebo notes"
+    local_edit = b"created while staging"
+    _, first, second = _duplicate_sciebo_destinations(
+        SCIEBO_URL,
+        SCIEBO_URL,
+        '"revision-1"',
+    )
+    syncer = make_context(
+        {
+            "paths.sync_directory": str(tmp_path),
+            "downloads.conflict_handling": "keep",
+        }
+    )
+    syncer.session = FakeSession()
+    syncer.session.add(
+        "GET",
+        SCIEBO_URL,
+        FakeResponse(headers={"Content-Type": "application/pdf"}, chunks=[content]),
+    )
+    assert download_file(syncer, first).is_handled
+
+    second_path = node_path(syncer, second)
+    original_copyfile = downloader.shutil.copyfile
+
+    def create_target_while_staging(source, destination):
+        result = original_copyfile(source, destination)
+        second_path.parent.mkdir(parents=True, exist_ok=True)
+        second_path.write_bytes(local_edit)
+        return result
+
+    monkeypatch.setattr(downloader.shutil, "copyfile", create_target_while_staging)
+
+    outcome = download_file(syncer, second)
+
+    assert outcome.unchanged == 1
+    assert not outcome.cache_verified
+    assert syncer.session.count("GET", SCIEBO_URL) == 1
+    assert second_path.read_bytes() == local_edit
+    assert not list(second_path.parent.glob(".*.smmreuse*"))
+
+
+def test_duplicate_sciebo_url_does_not_cross_authorization_scopes(tmp_path):
+    content = b"shared sciebo notes"
+    _, first, second = _duplicate_sciebo_destinations(
+        SCIEBO_URL,
+        SCIEBO_URL,
+        '"revision-1"',
+    )
+    first.download_headers = {
+        "Authorization": "Basic first-secret",
+        "requesttoken": "first-request-token",
+    }
+    second.download_headers = {
+        "Authorization": "Basic second-secret",
+        "requesttoken": "second-request-token",
+    }
+    syncer = make_context({"paths.sync_directory": str(tmp_path)})
+    syncer.session = FakeSession()
+    syncer.session.add(
+        "GET",
+        SCIEBO_URL,
+        FakeResponse(headers={"Content-Type": "application/pdf"}, chunks=[content]),
+    )
+
+    assert download_file(syncer, first).is_handled
+    assert download_file(syncer, second).is_handled
+
+    assert syncer.session.count("GET", SCIEBO_URL) == 2
+    assert len(syncer.verified_download_artifacts) == 2
+    cached_keys = repr(tuple(syncer.verified_download_artifacts))
+    assert "first-secret" not in cached_keys
+    assert "second-secret" not in cached_keys
+    assert "request-token" not in cached_keys
+
+
+def test_duplicate_transfer_falls_back_to_get_if_source_was_edited(tmp_path):
+    content = b"shared sciebo notes"
+    first_url = SCIEBO_URL + "?sig=first-secret"
+    second_url = SCIEBO_URL + "?sig=second-secret"
+    _, first, second = _duplicate_sciebo_destinations(
+        first_url,
+        second_url,
+        '"revision-1"',
+    )
+    syncer = make_context({"paths.sync_directory": str(tmp_path)})
+    syncer.session = FakeSession()
+    for url in (first_url, second_url):
+        syncer.session.add(
+            "GET",
+            url,
+            FakeResponse(
+                headers={"Content-Type": "application/pdf"},
+                chunks=[content],
+            ),
+        )
+
+    assert download_file(syncer, first).is_handled
+    first_path = node_path(syncer, first)
+    local_edit = b"x" * len(content)
+    first_path.write_bytes(local_edit)
+    assert download_file(syncer, second).is_handled
+
+    assert syncer.session.count("GET") == 2
+    assert first_path.read_bytes() == local_edit
+    assert node_path(syncer, second).read_bytes() == content
+    assert not list(tmp_path.rglob("*.smmreuse*"))
+
+
+def test_duplicate_url_with_different_remote_marker_is_downloaded_again(tmp_path):
+    first_url = SCIEBO_URL + "?sig=first-secret"
+    second_url = SCIEBO_URL + "?sig=second-secret"
+    _, first, second = _duplicate_sciebo_destinations(
+        first_url,
+        second_url,
+        '"revision-1"',
+        '"revision-2"',
+    )
+    syncer = make_context({"paths.sync_directory": str(tmp_path)})
+    syncer.session = FakeSession()
+    syncer.session.add(
+        "GET",
+        first_url,
+        FakeResponse(headers={"Content-Type": "application/pdf"}, chunks=[b"v1"]),
+    )
+    syncer.session.add(
+        "GET",
+        second_url,
+        FakeResponse(headers={"Content-Type": "application/pdf"}, chunks=[b"v2"]),
+    )
+
+    assert download_file(syncer, first).is_handled
+    assert download_file(syncer, second).is_handled
+
+    assert syncer.session.count("GET") == 2
+    assert node_path(syncer, first).read_bytes() == b"v1"
+    assert node_path(syncer, second).read_bytes() == b"v2"
+
+
+def test_reused_transfer_preserves_rename_conflict_policy(tmp_path):
+    content = b"shared sciebo notes"
+    first_url = SCIEBO_URL + "?sig=first-secret"
+    second_url = SCIEBO_URL + "?sig=second-secret"
+    _, first, second = _duplicate_sciebo_destinations(
+        first_url,
+        second_url,
+        '"revision-1"',
+    )
+    syncer = make_context(
+        {
+            "paths.sync_directory": str(tmp_path),
+            "downloads.update_files": True,
+            "downloads.conflict_handling": "rename",
+        }
+    )
+    syncer.session = FakeSession()
+    syncer.session.add(
+        "GET",
+        first_url,
+        FakeResponse(
+            headers={"Content-Type": "application/pdf"},
+            chunks=[content],
+        ),
+    )
+    second_path = node_path(syncer, second)
+    second_path.parent.mkdir(parents=True)
+    second_path.write_bytes(b"local edit")
+
+    assert download_file(syncer, first).is_handled
+    assert download_file(syncer, second).updated == 1
+
+    assert syncer.session.count("GET") == 1
+    assert second_path.read_bytes() == content
+    conflicts = list(second_path.parent.glob("*.syncconflict.*"))
+    assert len(conflicts) == 1
+    assert conflicts[0].read_bytes() == b"local edit"
 
 
 def _seed_sciebo_cache(config, etag, content, content_hash=None, etag_kind=None):

--- a/tests/test_http_utils.py
+++ b/tests/test_http_utils.py
@@ -7,12 +7,14 @@ from syncmymoodle.http_utils import (
     HttpFailureKind,
     RequestPolicyError,
     ServiceOutageTracker,
+    canonical_remote_url,
     classify_http_failure,
     classify_request_failure,
     moodle_url_allowed,
     normalized_http_origin,
     record_service_failure,
     redact_url_secrets,
+    remote_request_scope_fingerprint,
     request_following_safe_redirects,
 )
 
@@ -135,6 +137,94 @@ def test_url_redaction_covers_userinfo_and_encoded_sensitive_names():
     assert "signed" not in redacted
     assert "safe=visible" in redacted
     assert redacted.count("[REDACTED]") == 3
+
+
+def test_url_redaction_covers_aws_and_google_signed_query_credentials():
+    value = (
+        "https://cdn.example.test/video.mp4?"
+        "X-Amz-Credential=aws-credential&X-Amz-Signature=aws-signature&"
+        "X-Amz-Security-Token=aws-session-token&GoogleAccessId=google-id&"
+        "X-Goog-Credential=google-credential&X-Goog-Signature=google-signature&"
+        "X-Goog-Security-Token=google-session-token&X-Amz-Expires=300"
+    )
+
+    redacted = redact_url_secrets(value)
+
+    for secret in (
+        "aws-credential",
+        "aws-signature",
+        "aws-session-token",
+        "google-id",
+        "google-credential",
+        "google-signature",
+        "google-session-token",
+    ):
+        assert secret not in redacted
+    assert redacted.count("[REDACTED]") == 7
+    assert "X-Amz-Expires=300" in redacted
+
+
+def test_canonical_remote_url_ignores_rotating_signed_fields_and_sorts_query():
+    old = (
+        "HTTPS://CDN.EXAMPLE.TEST/video.mp4?quality=hd&sig=azure-secret&"
+        "se=2026-07-16T10%3A00Z&X-Amz-Date=20260716T100000Z&"
+        "X-Amz-Credential=aws-secret#chapter"
+    )
+    new = (
+        "https://cdn.example.test/video.mp4?X-Amz-Credential=new-aws-secret&"
+        "X-Amz-Date=20260716T110000Z&se=2026-07-16T11%3A00Z&"
+        "sig=new-azure-secret&quality=hd"
+    )
+
+    old_identity, old_display = canonical_remote_url(old)
+    new_identity, new_display = canonical_remote_url(new)
+
+    assert (
+        old_identity
+        == new_identity
+        == ("https://cdn.example.test/video.mp4?quality=hd")
+    )
+    assert "azure-secret" not in old_display
+    assert "aws-secret" not in old_display
+    assert "new-azure-secret" not in new_display
+    assert "new-aws-secret" not in new_display
+
+
+def test_canonical_remote_url_does_not_display_fragment_secrets():
+    identity, display = canonical_remote_url(
+        "https://files.example.test/report.pdf#access_token=fragment-secret"
+    )
+
+    assert identity == "https://files.example.test/report.pdf"
+    assert display == "https://files.example.test/report.pdf"
+    assert "fragment-secret" not in display
+
+
+def test_remote_request_scope_hashes_credentials_but_allows_signature_rotation():
+    first_url = (
+        "https://cdn.example.test/report.pdf?token=share-secret&"
+        "X-Amz-Credential=account-scope&X-Amz-Date=20260716T100000Z&sig=first"
+    )
+    rotated_url = (
+        "https://cdn.example.test/report.pdf?sig=second&"
+        "X-Amz-Date=20260716T110000Z&X-Amz-Credential=account-scope&"
+        "token=share-secret"
+    )
+    headers = {"Authorization": "Basic header-secret"}
+
+    fingerprint = remote_request_scope_fingerprint(first_url, headers)
+
+    assert fingerprint == remote_request_scope_fingerprint(rotated_url, headers)
+    assert fingerprint != remote_request_scope_fingerprint(
+        rotated_url,
+        {"Authorization": "Basic other-secret"},
+    )
+    assert fingerprint != remote_request_scope_fingerprint(
+        rotated_url.replace("share-secret", "other-share"),
+        headers,
+    )
+    assert "secret" not in fingerprint
+    assert "account-scope" not in fingerprint
 
 
 def test_safe_redirect_changes_post_to_get_without_resending_body():

--- a/tests/test_link_cache.py
+++ b/tests/test_link_cache.py
@@ -1,12 +1,20 @@
+import logging
+
 import pytest
 
-from syncmymoodle import course_cache, links
+from syncmymoodle import course_cache, downloader, links
 from syncmymoodle.constants import LINKED_PAGE_MAX_BYTES
 from syncmymoodle.context import MoodleAccount
 from syncmymoodle.moodle_tokens import MoodleTokens
-from syncmymoodle.node import Node
+from syncmymoodle.node import Node, RemoteMarkerKind
 
-from .helpers import FakeResponse, FakeSession, make_context, two_course_tree
+from .helpers import (
+    FakeResponse,
+    FakeSession,
+    make_context,
+    node_path,
+    two_course_tree,
+)
 
 LINK_URL = "https://links.example.test/overview"
 YOUTUBE_ONE = "https://youtu.be/abcdefghijk"
@@ -168,6 +176,29 @@ def test_cached_html_without_validators_is_fetched_without_a_head(tmp_path):
     assert _youtube_ids(section) == ["abcdefghijk"]
 
 
+def test_cached_html_resource_error_reuses_previous_page(tmp_path):
+    _seed_html(tmp_path, {"ETag": '"page-v1"'})
+    ctx, _, section = _context(tmp_path)
+    session = FakeSession()
+    session.add("GET", LINK_URL, FakeResponse(status_code=403))
+    ctx.session = session
+
+    links.scan_for_links(ctx, LINK_URL, section, 101, single=True)
+    course_cache.cache_root_node(ctx)
+
+    assert session.calls == [("GET", LINK_URL)]
+    assert _youtube_ids(section) == ["abcdefghijk"]
+    assert ctx.stats.failed == 0
+    assert ctx.incomplete_course_ids == set()
+    assert ctx.inventory_filtered_course_ids == {101}
+    assert LINK_URL in ctx.linked_resources_by_course["101"]
+
+    reloaded, reloaded_course, _ = _context(tmp_path)
+    cached_root = course_cache.get_course_cache_root(reloaded, reloaded_course)
+    assert cached_root is not None
+    assert _youtube_ids(cached_root.children[0]) == ["abcdefghijk"]
+
+
 def test_identical_links_are_requested_once_per_run(tmp_path):
     ctx, course, first_section = _context(tmp_path)
     second_section = course.add_child("More", 202, "Section")
@@ -230,6 +261,97 @@ def test_failed_link_result_marks_each_course_and_preserves_both_caches(tmp_path
     assert {
         course_id: path.read_bytes() for course_id, path in cached_files.items()
     } == cached_bytes
+
+
+def test_resource_error_allows_unrelated_course_cache_progress(
+    tmp_path,
+    caplog,
+):
+    current_url = "https://files.example.test/current.pdf"
+    current_body = b"current linked file"
+    config = {
+        "downloads.update_files": True,
+        "downloads.conflict_handling": "rename",
+    }
+
+    def add_current_link(section):
+        return section.add_download_child(
+            "Current link",
+            "current-link",
+            "Linked file",
+            url=current_url,
+            etag='"current-v1"',
+            etag_kind=RemoteMarkerKind.OPAQUE,
+        )
+
+    seeded, seeded_course, seeded_section = _context(tmp_path)
+    cached_link = seeded_section.add_download_child(
+        "Previously discovered link",
+        "old-link",
+        "Linked file",
+        url="https://files.example.test/previous.pdf",
+    )
+    cached_link.mark_handled()
+    course_cache.cache_root_node(seeded)
+    cache_path = course_cache.course_cache_path(seeded, seeded_course)
+    cached_bytes = cache_path.read_bytes()
+
+    ctx, _, section = _context(tmp_path, extra_config=config)
+    assert ctx.linked_resources_by_course.get("101", {}) == {}
+    session = FakeSession()
+    session.add("HEAD", LINK_URL, FakeResponse(status_code=403))
+    session.add("GET", LINK_URL, FakeResponse(status_code=403))
+    session.add("GET", current_url, FakeResponse(content=current_body))
+    ctx.session = session
+    caplog.set_level(logging.WARNING, logger="syncmymoodle.links")
+
+    links.scan_for_links(ctx, LINK_URL, section, 101, single=True)
+    add_current_link(section)
+    downloader.download_node_tree(ctx, ctx.root_node)
+    course_cache.cache_root_node(ctx)
+
+    assert session.calls == [
+        ("HEAD", LINK_URL),
+        ("GET", LINK_URL),
+        ("GET", current_url),
+    ]
+    assert ctx.stats.downloaded == 1
+    assert ctx.stats.failed == 0
+    assert ctx.incomplete_course_ids == set()
+    assert ctx.inventory_filtered_course_ids == {101}
+    assert cache_path.read_bytes() != cached_bytes
+    assert caplog.messages == []
+
+    reloaded, reloaded_course, reloaded_section = _context(
+        tmp_path,
+        extra_config=config,
+    )
+    cached_root = course_cache.get_course_cache_root(reloaded, reloaded_course)
+    assert cached_root is not None
+    assert [child.name for child in cached_root.children[0].children] == [
+        "Current link"
+    ]
+    second_session = FakeSession()
+    second_session.add("HEAD", LINK_URL, FakeResponse(status_code=403))
+    second_session.add("GET", LINK_URL, FakeResponse(status_code=403))
+    reloaded.session = second_session
+
+    links.scan_for_links(
+        reloaded,
+        LINK_URL,
+        reloaded_section,
+        101,
+        single=True,
+    )
+    reloaded_link = add_current_link(reloaded_section)
+    downloader.download_node_tree(reloaded, reloaded.root_node)
+
+    artifact_path = node_path(reloaded, reloaded_link)
+    assert reloaded.stats.unchanged == 1
+    assert reloaded.stats.downloaded == 0
+    assert artifact_path.read_bytes() == current_body
+    assert list(artifact_path.parent.glob("*.syncconflict.*")) == []
+    assert second_session.calls == [("HEAD", LINK_URL), ("GET", LINK_URL)]
 
 
 def test_reused_link_result_obeys_per_course_domain_filter(tmp_path):

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -7,7 +7,7 @@ import time
 import pytest
 from rich.progress import Progress
 
-from syncmymoodle.outcomes import RunStatistics
+from syncmymoodle.outcomes import RemovedContent, RunStatistics
 from syncmymoodle.output import TerminalOutput, safe_terminal_text
 
 
@@ -344,3 +344,26 @@ def test_run_summary_reports_outcomes_and_transferred_size(monkeypatch):
     stats.planned = 7
     TerminalOutput().summary(stats, filtered=5, dry_run=True)
     assert "7 would download, 4 unchanged, 5 filtered, 1 failed" in stdout.getvalue()
+
+
+def test_removed_content_report_states_that_local_files_are_kept(
+    monkeypatch,
+):
+    stdout = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", stdout)
+
+    TerminalOutput().removed_content(
+        [
+            RemovedContent(
+                "Operating Systems (123)",
+                "Week 1/notes.pdf",
+                "https://moodle.example/file.php?id=456",
+            )
+        ]
+    )
+
+    assert stdout.getvalue() == (
+        "No longer present in Moodle (1 item; local files kept):\n"
+        "  Operating Systems (123): Week 1/notes.pdf "
+        "[remote: https://moodle.example/file.php?id=456]\n"
+    )

--- a/tests/test_quiz.py
+++ b/tests/test_quiz.py
@@ -3,7 +3,7 @@ import subprocess
 from dataclasses import replace
 from types import SimpleNamespace
 
-from syncmymoodle import course_cache, quiz, sync_handlers
+from syncmymoodle import course_cache, downloader, quiz, sync_handlers
 from syncmymoodle.node import DownloadKind, Node, RemoteMarkerKind
 
 from .helpers import FakeResponse, FakeSession, make_context
@@ -182,6 +182,53 @@ def test_quiz_api_review_preserves_grade_and_feedback_titles(monkeypatch, tmp_pa
     assert quiz_attempt.etag_kind is RemoteMarkerKind.OPAQUE
 
 
+def test_quiz_revision_ignores_volatile_hidden_form_state(monkeypatch):
+    install_quiz_activity(monkeypatch)
+    monkeypatch.setattr(
+        sync_handlers.moodle_api,
+        "get_quiz_attempts",
+        lambda session, wstoken, quiz_id: [{"id": 5}],
+    )
+    hidden_values = iter(("first-secret", "second-secret"))
+
+    def quiz_review(session, wstoken, attempt_id):
+        secret = next(hidden_values)
+        return {
+            "questions": [
+                {
+                    "html": (
+                        "<p>Stable review</p>"
+                        f'<input type="hidden" name="sesskey" value="{secret}">'
+                    )
+                }
+            ]
+        }
+
+    monkeypatch.setattr(
+        sync_handlers.moodle_api,
+        "get_quiz_attempt_review",
+        quiz_review,
+    )
+
+    contexts = []
+    quiz_nodes = []
+    for _ in range(2):
+        ctx, module_context = quiz_module_context()
+        sync_handlers.handle_quiz_module(
+            module_context,
+            {"id": 42, "instance": 7, "modname": "quiz", "name": "My Quiz"},
+        )
+        contexts.append(ctx)
+        quiz_nodes.append(module_context.section_node.children[0])
+
+    first_html = contexts[0].quiz_review_cache[QUIZ_URL]
+    second_html = contexts[1].quiz_review_cache[QUIZ_URL]
+    assert first_html == second_html
+    assert "first-secret" not in first_html
+    assert "second-secret" not in second_html
+    assert quiz_nodes[0].etag == quiz_nodes[1].etag
+
+
 def test_quiz_node_keeps_remote_name_until_path_materialization(monkeypatch):
     install_quiz_activity(monkeypatch)
     ctx, module_context = quiz_module_context()
@@ -258,6 +305,22 @@ def test_build_quiz_snapshot_is_self_contained_and_network_silent(tmp_path):
     assert ctx.session.count("GET", CSS_ONLY_ASSET_URL) == 0
     assert ctx.session.count("GET", FONT_URL) == 1
     assert ctx.session.count("GET", TEXT_FONT_URL) == 0
+
+
+def test_build_quiz_snapshot_discards_hidden_form_state(tmp_path):
+    ctx = quiz_context(tmp_path, "html")
+    source = (
+        "<html><body><p>Visible review</p>"
+        '<input type="hidden" name="sesskey" value="private-session-key">'
+        '<input type="text" value="visible-answer">'
+        "</body></html>"
+    )
+
+    snapshot = quiz.build_quiz_snapshot(source, ctx.session, QUIZ_URL)
+
+    assert "private-session-key" not in snapshot
+    assert 'type="hidden"' not in snapshot
+    assert "visible-answer" in snapshot
 
 
 def test_quiz_asset_redirect_cannot_escape_moodle_origin():
@@ -347,6 +410,61 @@ def test_html_mode_is_idempotent(tmp_path, capsys):
     assert capsys.readouterr().out == ""
     # The token-derived review is consumed only on the first run; the second is a no-op.
     assert ctx.session.count("GET", QUIZ_URL) == 0
+
+
+def test_matching_cacheless_quiz_is_adopted_without_conflicts(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    first = quiz_context(tmp_path, "both")
+    first.config = replace(
+        first.config,
+        update_files=True,
+        conflict_handling="rename",
+    )
+    first.root_node, first_node = versioned_quiz_tree(QUIZ_HTML)
+    html_path = tmp_path / "26ss" / "Course" / "General" / "My Quiz, Versuch 1.html"
+    pdf_path = html_path.with_suffix(".pdf")
+    html_path.parent.mkdir(parents=True)
+    snapshot = quiz.build_quiz_snapshot(QUIZ_HTML, first.session, QUIZ_URL)
+    legacy_snapshot = snapshot.replace(
+        "</body>",
+        '<input type="hidden" name="sesskey" value="expired-secret"></body>',
+    )
+    assert legacy_snapshot != snapshot
+    html_path.write_text(legacy_snapshot, encoding="utf-8")
+    pdf_path.write_bytes(b"%PDF-1.4 existing quiz")
+    monkeypatch.setattr(
+        quiz,
+        "render_quiz_pdf",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError),
+    )
+
+    downloader.download_node_tree(first, first.root_node)
+    course_cache.cache_root_node(first)
+
+    assert first.stats.unchanged == 2
+    assert first.stats.updated == 0
+    assert first_node.artifact_hashes == {
+        "html": hashlib.sha256(legacy_snapshot.encode("utf-8")).hexdigest()
+    }
+    assert html_path.read_text(encoding="utf-8") == legacy_snapshot
+    assert pdf_path.read_bytes() == b"%PDF-1.4 existing quiz"
+    assert list(html_path.parent.glob("*.syncconflict.*")) == []
+    first_output = capsys.readouterr().out
+    assert "Downloading" not in first_output
+    assert "Rendering" not in first_output
+
+    second = quiz_context(tmp_path, "both")
+    second.root_node, _ = versioned_quiz_tree(QUIZ_HTML)
+    downloader.download_node_tree(second, second.root_node)
+
+    assert second.stats.unchanged == 2
+    assert second.session.calls == []
+    second_output = capsys.readouterr().out
+    assert "Downloading" not in second_output
+    assert "Rendering" not in second_output
 
 
 def test_changed_quiz_review_replaces_an_unmodified_snapshot(tmp_path):

--- a/tests/test_removed_content.py
+++ b/tests/test_removed_content.py
@@ -1,0 +1,662 @@
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from syncmymoodle import course_cache, downloader, moodle, sync, sync_handlers
+from syncmymoodle.context import SyncContext
+from syncmymoodle.node import DownloadKind, Node
+from syncmymoodle.outcomes import RemovedContent
+from syncmymoodle.storage import read_private_gzip_json
+
+from .helpers import FakeSession, make_context, node_path
+
+COURSE_ID = 301
+MODULE_ID = 501
+RESOURCE_URL = "https://files.example.test/notes.pdf?token=private-token&item=456"
+EXPECTED_REMOVAL = RemovedContent(
+    "Download Course (301)",
+    "General/notes.pdf",
+    "https://files.example.test/notes.pdf?token=[REDACTED]&item=456",
+)
+MISSING = object()
+
+
+def resource_module() -> dict[str, Any]:
+    return {
+        "id": MODULE_ID,
+        "modname": "resource",
+        "name": "Lecture notes",
+        "contents": [
+            {
+                "type": "file",
+                "filename": "notes.pdf",
+                "fileurl": RESOURCE_URL,
+                "mimetype": "application/pdf",
+            }
+        ],
+    }
+
+
+def folder_module(contents: object) -> dict[str, Any]:
+    return {
+        "id": MODULE_ID,
+        "modname": "folder",
+        "name": "Materials",
+        "contents": contents,
+    }
+
+
+def assignment_module() -> dict[str, Any]:
+    return {
+        "id": MODULE_ID,
+        "instance": 601,
+        "modname": "assign",
+        "name": "Homework",
+    }
+
+
+def module_context(
+    config: dict[str, Any] | None = None,
+) -> tuple[SyncContext, sync_handlers.ModuleContext]:
+    context = make_context(config)
+    context.session = FakeSession()
+    course = Node("Download Course", COURSE_ID, "Course", None)
+    section = course.add_child("General", 401, "Section")
+    return context, sync_handlers.ModuleContext(
+        context,
+        COURSE_ID,
+        course,
+        section,
+        {},
+        {},
+    )
+
+
+def install_course_inventory(
+    monkeypatch,
+    modules: list[dict[str, Any]],
+    *,
+    section_name: str = "General",
+) -> None:
+    monkeypatch.setattr(
+        moodle,
+        "get_all_courses",
+        lambda *args: [
+            {
+                "id": COURSE_ID,
+                "shortname": "Download Course",
+                "idnumber": "26ss",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        moodle,
+        "get_course",
+        lambda *args: [{"id": 401, "name": section_name, "modules": modules}],
+    )
+
+
+def seed_resource_cache(tmp_path, monkeypatch) -> tuple[dict[str, Any], Path]:
+    config = {"paths.sync_directory": str(tmp_path)}
+    install_course_inventory(monkeypatch, [resource_module()])
+    context = make_context(config)
+    context.session = FakeSession()
+    sync.sync(context)
+    assert context.root_node is not None
+    resource = context.root_node.children[0].children[0].children[0].children[0]
+    local_file = node_path(context, resource)
+    local_file.parent.mkdir(parents=True)
+    local_file.write_bytes(b"local copy")
+    course_cache.cache_root_node(context)
+    return config, local_file
+
+
+def cached_course_payload(config: dict[str, Any]) -> dict[str, Any]:
+    lookup = make_context(config)
+    course = Node("Download Course", COURSE_ID, "Course", None)
+    payload = read_private_gzip_json(
+        course_cache.course_cache_path(lookup, course),
+        "course cache",
+    )
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_authoritative_removal_is_reported_without_deleting_local_copy(
+    tmp_path,
+    monkeypatch,
+):
+    config, local_file = seed_resource_cache(tmp_path, monkeypatch)
+    install_course_inventory(monkeypatch, [])
+
+    current = make_context(config)
+    current.session = FakeSession()
+    sync.sync(current)
+
+    assert current.removed_content == {EXPECTED_REMOVAL}
+    assert local_file.read_bytes() == b"local copy"
+
+
+def test_complete_inventory_persists_scope_fingerprint(tmp_path, monkeypatch):
+    config, _ = seed_resource_cache(tmp_path, monkeypatch)
+    payload = cached_course_payload(config)
+
+    scope = payload[course_cache.INVENTORY_SCOPE_CACHE_KEY]
+    assert isinstance(scope, str)
+    assert len(scope) == 64
+    assert all(character in "0123456789abcdef" for character in scope)
+
+
+def test_same_remote_identity_at_a_new_name_is_not_reported_removed(
+    tmp_path,
+    monkeypatch,
+):
+    config, _ = seed_resource_cache(tmp_path, monkeypatch)
+    install_course_inventory(
+        monkeypatch,
+        [resource_module()],
+        section_name="Renamed section",
+    )
+
+    current = make_context(config)
+    current.session = FakeSession()
+    sync.sync(current)
+
+    assert current.removed_content == set()
+
+
+def test_failed_module_scan_does_not_report_cached_content_removed(
+    tmp_path,
+    monkeypatch,
+):
+    config, _ = seed_resource_cache(tmp_path, monkeypatch)
+    install_course_inventory(monkeypatch, [resource_module()])
+
+    def fail_module(*args):
+        raise RuntimeError("temporary provider failure")
+
+    monkeypatch.setattr(sync_handlers, "handle_module", fail_module)
+    current = make_context(config)
+    current.session = FakeSession()
+    sync.sync(current)
+
+    assert current.stats.failed == 1
+    assert current.incomplete_course_ids == {COURSE_ID}
+    assert current.removed_content == set()
+
+    course_cache.cache_root_node(current)
+    install_course_inventory(monkeypatch, [])
+    recovered = make_context(config)
+    recovered.session = FakeSession()
+    sync.sync(recovered)
+
+    assert recovered.removed_content == {EXPECTED_REMOVAL}
+
+
+def test_malformed_course_inventory_does_not_report_cached_content_removed(
+    tmp_path,
+    monkeypatch,
+):
+    config, _ = seed_resource_cache(tmp_path, monkeypatch)
+    install_course_inventory(monkeypatch, [])
+    monkeypatch.setattr(
+        moodle,
+        "get_course",
+        lambda *args: [{"id": 401, "name": "General", "modules": None}],
+    )
+
+    current = make_context(config)
+    current.session = FakeSession()
+    sync.sync(current)
+
+    assert current.stats.failed == 1
+    assert current.incomplete_course_ids == {COURSE_ID}
+    assert current.removed_content == set()
+
+
+@pytest.mark.parametrize(
+    "contents",
+    [MISSING, None, [], ["malformed-content"]],
+    ids=["missing", "null", "empty", "malformed-entry"],
+)
+def test_non_authoritative_resource_contents_suppress_removal(
+    tmp_path,
+    monkeypatch,
+    contents,
+):
+    config, _ = seed_resource_cache(tmp_path, monkeypatch)
+    module = resource_module()
+    if contents is MISSING:
+        del module["contents"]
+    else:
+        module["contents"] = contents
+    install_course_inventory(monkeypatch, [module])
+
+    current = make_context(config)
+    current.session = FakeSession()
+    sync.sync(current)
+
+    assert current.stats.failed == 1
+    assert current.incomplete_course_ids == {COURSE_ID}
+    assert current.removed_content == set()
+
+
+@pytest.mark.parametrize("contents", [MISSING, []], ids=["missing", "empty"])
+def test_unavailable_resource_without_contents_is_not_a_failure(
+    tmp_path,
+    monkeypatch,
+    contents,
+    caplog,
+):
+    config, _ = seed_resource_cache(tmp_path, monkeypatch)
+    cached_payload = cached_course_payload(config)
+    module = resource_module()
+    module["uservisible"] = False
+    module["availabilityinfo"] = "Available later"
+    if contents is MISSING:
+        del module["contents"]
+    else:
+        module["contents"] = contents
+    install_course_inventory(monkeypatch, [module])
+
+    current = make_context(config)
+    current.session = FakeSession()
+    sync.sync(current)
+    course_cache.cache_root_node(current)
+
+    assert current.stats.failed == 0
+    assert current.incomplete_course_ids == set()
+    assert current.inventory_filtered_course_ids == {COURSE_ID}
+    assert current.removed_content == set()
+    assert cached_course_payload(config) != cached_payload
+    assert "malformed resource content inventory" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("contents", "expected_failures"),
+    [(MISSING, 0), (["malformed-content"], 1)],
+    ids=["missing-is-valid", "malformed-entry"],
+)
+def test_url_module_contents_validate_only_entries(
+    monkeypatch,
+    contents,
+    expected_failures,
+):
+    module = {"id": MODULE_ID, "modname": "url", "name": "External link"}
+    if contents is not MISSING:
+        module["contents"] = contents
+    install_course_inventory(monkeypatch, [module])
+    current = make_context()
+    current.session = FakeSession()
+
+    sync.sync(current)
+
+    assert current.stats.failed == expected_failures
+    assert current.incomplete_course_ids == (
+        {COURSE_ID} if expected_failures else set()
+    )
+
+
+def test_assignment_inventory_cross_source_mismatch_suppresses_removal(
+    tmp_path,
+    monkeypatch,
+):
+    config = {"paths.sync_directory": str(tmp_path)}
+    install_course_inventory(monkeypatch, [assignment_module()])
+    monkeypatch.setattr(
+        moodle,
+        "get_assignment",
+        lambda *args: {
+            "assignments": [
+                {
+                    "id": 601,
+                    "cmid": MODULE_ID,
+                    "introattachments": resource_module()["contents"],
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        moodle,
+        "get_assignment_submission_files",
+        lambda *args: [],
+    )
+    baseline = make_context(config)
+    baseline.session = FakeSession()
+    sync.sync(baseline)
+    course_cache.cache_root_node(baseline)
+
+    monkeypatch.setattr(
+        moodle,
+        "get_assignment",
+        lambda *args: {"assignments": []},
+    )
+    current = make_context(config)
+    current.session = FakeSession()
+    sync.sync(current)
+
+    assert current.stats.failed == 1
+    assert current.incomplete_course_ids == {COURSE_ID}
+    assert current.removed_content == set()
+
+
+@pytest.mark.parametrize("activity", [None, {"coursemodule": MODULE_ID, "package": []}])
+def test_h5p_missing_activity_or_package_fails_once(monkeypatch, activity):
+    context, handler_context = module_context()
+    monkeypatch.setattr(
+        moodle,
+        "get_h5pactivities_by_course",
+        lambda *args: [] if activity is None else [activity],
+    )
+
+    sync_handlers.handle_embedded_link_module(
+        handler_context,
+        {"id": MODULE_ID, "modname": "h5pactivity", "name": "Interactive"},
+    )
+
+    assert context.stats.failed == 1
+    assert context.incomplete_course_ids == {COURSE_ID}
+
+
+def test_lti_missing_api_and_core_instance_fails_once(monkeypatch):
+    context, handler_context = module_context({"links.opencast": True})
+    monkeypatch.setattr(moodle, "get_ltis_by_course", lambda *args: [])
+
+    launch = sync_handlers._opencast_lti_launch(
+        handler_context,
+        {"id": MODULE_ID, "modname": "lti", "name": "Recording"},
+    )
+
+    assert launch is None
+    assert context.stats.failed == 1
+    assert context.incomplete_course_ids == {COURSE_ID}
+
+
+def test_quiz_missing_api_and_core_instance_fails_once(monkeypatch):
+    context, handler_context = module_context({"modules.quiz": "html"})
+    monkeypatch.setattr(moodle, "get_quizzes_by_course", lambda *args: [])
+
+    sync_handlers.handle_quiz_module(
+        handler_context,
+        {"id": MODULE_ID, "modname": "quiz", "name": "Exam"},
+    )
+
+    assert context.stats.failed == 1
+    assert context.incomplete_course_ids == {COURSE_ID}
+
+
+def test_new_module_filter_does_not_report_cached_content_removed(
+    tmp_path,
+    monkeypatch,
+):
+    config, _ = seed_resource_cache(tmp_path, monkeypatch)
+    install_course_inventory(monkeypatch, [resource_module()])
+    filtered_config = {
+        **config,
+        "filters.exclude_modules": [str(MODULE_ID)],
+    }
+
+    current = make_context(filtered_config)
+    current.session = FakeSession()
+    sync.sync(current)
+
+    assert current.stats.failed == 0
+    assert current.removed_content == set()
+
+
+def test_unchanged_filter_newly_matching_content_suppresses_removal(
+    tmp_path,
+    monkeypatch,
+):
+    config = {
+        "paths.sync_directory": str(tmp_path),
+        "filters.exclude_modules": ["Secret*"],
+    }
+    install_course_inventory(monkeypatch, [resource_module()])
+    baseline = make_context(config)
+    baseline.session = FakeSession()
+    sync.sync(baseline)
+    course_cache.cache_root_node(baseline)
+    baseline_scope = cached_course_payload(config)[
+        course_cache.INVENTORY_SCOPE_CACHE_KEY
+    ]
+
+    renamed = resource_module()
+    renamed["name"] = "Secret notes"
+    install_course_inventory(monkeypatch, [renamed])
+    current = make_context(config)
+    current.session = FakeSession()
+    sync.sync(current)
+
+    assert current.inventory_filtered_course_ids == {COURSE_ID}
+    assert current.removed_content == set()
+    course_cache.cache_root_node(current)
+    assert (
+        cached_course_payload(config)[course_cache.INVENTORY_SCOPE_CACHE_KEY]
+        == baseline_scope
+    )
+
+
+def test_malformed_nested_folder_inventory_suppresses_removal(
+    tmp_path,
+    monkeypatch,
+):
+    config = {"paths.sync_directory": str(tmp_path)}
+    valid_file = resource_module()["contents"]
+    install_course_inventory(monkeypatch, [folder_module(valid_file)])
+    monkeypatch.setattr(
+        moodle,
+        "get_folders_by_courses",
+        lambda *args: [{"coursemodule": MODULE_ID}],
+    )
+    baseline = make_context(config)
+    baseline.session = FakeSession()
+    sync.sync(baseline)
+    course_cache.cache_root_node(baseline)
+
+    install_course_inventory(monkeypatch, [folder_module(["malformed-file"])])
+    current = make_context(config)
+    current.session = FakeSession()
+    sync.sync(current)
+
+    assert current.stats.failed == 1
+    assert current.incomplete_course_ids == {COURSE_ID}
+    assert current.removed_content == set()
+
+
+def test_missing_folder_details_suppress_intro_link_removal(tmp_path, monkeypatch):
+    config = {"paths.sync_directory": str(tmp_path)}
+    valid_file = resource_module()["contents"]
+    install_course_inventory(monkeypatch, [folder_module(valid_file)])
+    monkeypatch.setattr(
+        moodle,
+        "get_folders_by_courses",
+        lambda *args: [
+            {
+                "coursemodule": MODULE_ID,
+                "intro": "https://youtu.be/abcdefghijk",
+            }
+        ],
+    )
+    baseline = make_context(config)
+    baseline.session = FakeSession()
+    sync.sync(baseline)
+    course_cache.cache_root_node(baseline)
+
+    monkeypatch.setattr(moodle, "get_folders_by_courses", lambda *args: [])
+    current = make_context(config)
+    current.session = FakeSession()
+    sync.sync(current)
+
+    assert current.stats.failed == 1
+    assert current.incomplete_course_ids == {COURSE_ID}
+    assert current.removed_content == set()
+
+
+def test_folder_details_are_not_required_when_link_following_is_disabled(
+    tmp_path,
+    monkeypatch,
+):
+    install_course_inventory(
+        monkeypatch,
+        [folder_module(resource_module()["contents"])],
+    )
+    folder_calls = []
+    monkeypatch.setattr(
+        moodle,
+        "get_folders_by_courses",
+        lambda *args: folder_calls.append(args) or None,
+    )
+    current = make_context(
+        {
+            "paths.sync_directory": str(tmp_path),
+            "links.follow_links": False,
+        }
+    )
+    current.session = FakeSession()
+
+    sync.sync(current)
+
+    assert folder_calls == []
+    assert current.stats.failed == 0
+    assert current.incomplete_course_ids == set()
+
+
+def _prepared_course_with_download(
+    url: str | None,
+    *,
+    download_kind: DownloadKind = DownloadKind.DIRECT,
+) -> tuple[sync._PreparedCourse, Node]:
+    course = Node("Download Course", COURSE_ID, "Course", None)
+    section = course.add_child("General", 401, "Section")
+    if url is not None:
+        section.add_download_child(
+            "recording.mp4",
+            "episode-123" if download_kind is DownloadKind.OPENCAST else url,
+            "Opencast" if download_kind is DownloadKind.OPENCAST else "Resource",
+            url=url,
+            download_kind=download_kind,
+        )
+    return sync._PreparedCourse("Download Course", COURSE_ID, course), course
+
+
+@pytest.mark.parametrize(
+    "download_kind",
+    [DownloadKind.DIRECT, DownloadKind.OPENCAST],
+)
+def test_signed_url_rotation_preserves_remote_identity(download_kind):
+    old_url = (
+        "https://cdn.example.test/tracks/presentation.mp4?quality=hd&"
+        "X-Amz-Credential=old-credential&X-Amz-Date=20260716T100000Z&"
+        "X-Amz-Expires=60&X-Amz-Signature=old-signature"
+    )
+    new_url = (
+        "https://cdn.example.test/tracks/presentation.mp4?"
+        "X-Amz-Signature=new-signature&X-Amz-Expires=120&quality=hd&"
+        "X-Amz-Date=20260716T110000Z&X-Amz-Credential=new-credential"
+    )
+    _, old_course = _prepared_course_with_download(
+        old_url,
+        download_kind=download_kind,
+    )
+    current, _ = _prepared_course_with_download(
+        new_url,
+        download_kind=download_kind,
+    )
+
+    assert sync._removed_course_content(current, old_course) == set()
+
+
+def test_opencast_identity_distinguishes_tracks_within_one_episode():
+    presentation_url = (
+        "https://cdn.example.test/tracks/presentation.mp4?X-Amz-Signature=old"
+    )
+    presenter_url = "https://cdn.example.test/tracks/presenter.mp4?X-Amz-Signature=old"
+    _, old_course = _prepared_course_with_download(
+        presentation_url,
+        download_kind=DownloadKind.OPENCAST,
+    )
+    old_course.children[0].add_download_child(
+        "recording (presenter).mp4",
+        "episode-123",
+        "Opencast",
+        url=presenter_url,
+        download_kind=DownloadKind.OPENCAST,
+    )
+    current, _ = _prepared_course_with_download(
+        "https://cdn.example.test/tracks/presentation.mp4?X-Amz-Signature=new",
+        download_kind=DownloadKind.OPENCAST,
+    )
+
+    (removed,) = sync._removed_course_content(current, old_course)
+
+    assert removed.remote_identity.endswith(
+        ":https://cdn.example.test/tracks/presenter.mp4"
+    )
+
+
+def test_reported_signed_url_identity_does_not_leak_credentials():
+    signed_url = (
+        "https://cdn.example.test/file.pdf?X-Amz-Credential=aws-secret&"
+        "X-Amz-Signature=signature-secret&"
+        "X-Amz-Security-Token=session-secret&X-Amz-Expires=60"
+    )
+    _, old_course = _prepared_course_with_download(signed_url)
+    current, _ = _prepared_course_with_download(None)
+
+    (removed,) = sync._removed_course_content(current, old_course)
+
+    assert "aws-secret" not in removed.remote_identity
+    assert "signature-secret" not in removed.remote_identity
+    assert "session-secret" not in removed.remote_identity
+    assert removed.remote_identity.count("[REDACTED]") == 3
+
+
+def test_downloader_only_url_filter_does_not_truncate_inventory(tmp_path):
+    context = make_context({"filters.exclude_links": ["*notes.pdf*"]})
+    root = Node("", -1, "Root", None)
+    semester = root.add_child("26ss", None, "Semester")
+    course = semester.add_child("Download Course", COURSE_ID, "Course")
+    file_node = course.add_download_child(
+        "notes.pdf",
+        RESOURCE_URL,
+        "Resource",
+        url=RESOURCE_URL,
+    )
+
+    outcome = downloader.should_skip_before_decision(
+        context,
+        file_node,
+        tmp_path / "notes.pdf",
+    )
+
+    assert outcome is not None
+    assert context.inventory_filtered_course_ids == set()
+
+
+def test_cache_without_inventory_scope_is_not_guessed_authoritative(
+    tmp_path,
+    monkeypatch,
+):
+    config = {"paths.sync_directory": str(tmp_path)}
+    seeded = make_context(config)
+    root = Node("", -1, "Root", None)
+    semester = root.add_child("26ss", None, "Semester")
+    course = semester.add_child("Download Course", COURSE_ID, "Course")
+    section = course.add_child("General", 401, "Section")
+    section.add_download_child(
+        "notes.pdf",
+        RESOURCE_URL,
+        "Resource",
+        url=RESOURCE_URL,
+    )
+    seeded.root_node = root
+    course_cache.cache_root_node(seeded)
+    install_course_inventory(monkeypatch, [])
+
+    current = make_context(config)
+    current.session = FakeSession()
+    sync.sync(current)
+
+    assert current.removed_content == set()

--- a/tests/test_sync_fixtures.py
+++ b/tests/test_sync_fixtures.py
@@ -176,7 +176,21 @@ def h5p_package(content: str) -> bytes:
     return package.getvalue()
 
 
-def sciebo_share_context(page_fixture: str):
+def _legacy_webdav_after_probe(response):
+    probe_pending = True
+
+    def dispatch(url, kwargs):
+        nonlocal probe_pending
+        if probe_pending:
+            probe_pending = False
+            return FakeResponse(status_code=404)
+        probe_pending = True
+        return response(url, kwargs) if callable(response) else response
+
+    return dispatch
+
+
+def sciebo_share_context(page_fixture: str, *, direct: bool = True):
     syncer = make_context(
         {
             "modules.assignment": False,
@@ -188,23 +202,102 @@ def sciebo_share_context(page_fixture: str):
         }
     )
     session = FakeSession()
-    session.add(
-        "GET",
-        SCIEBO_SHARE_LINK,
-        FakeResponse(text=load_fixture("sciebo", page_fixture)),
-    )
-    session.add(
-        "PROPFIND",
-        SCIEBO_PUBLIC_ROOT,
-        FakeResponse(text=load_fixture("sciebo", "propfind_root.xml")),
-    )
-    session.add(
-        "PROPFIND",
-        SCIEBO_PUBLIC_SLIDES,
-        FakeResponse(text=load_fixture("sciebo", "propfind_slides.xml")),
-    )
+    if direct:
+
+        def direct_listing(name):
+            def respond(url, kwargs):
+                del url
+                assert kwargs["headers"]["X-Requested-With"] == "XMLHttpRequest"
+                assert kwargs["headers"]["Authorization"].startswith("Basic ")
+                assert "requesttoken" not in kwargs["headers"]
+                return FakeResponse(text=load_fixture("sciebo", name))
+
+            return respond
+
+        session.add("PROPFIND", SCIEBO_PUBLIC_ROOT, direct_listing("propfind_root.xml"))
+        session.add(
+            "PROPFIND",
+            SCIEBO_PUBLIC_SLIDES,
+            direct_listing("propfind_slides.xml"),
+        )
+    else:
+        session.add(
+            "GET",
+            SCIEBO_SHARE_LINK,
+            FakeResponse(text=load_fixture("sciebo", page_fixture)),
+        )
+        session.add(
+            "PROPFIND",
+            SCIEBO_PUBLIC_ROOT,
+            _legacy_webdav_after_probe(
+                FakeResponse(text=load_fixture("sciebo", "propfind_root.xml"))
+            ),
+        )
+        session.add(
+            "PROPFIND",
+            SCIEBO_PUBLIC_SLIDES,
+            FakeResponse(text=load_fixture("sciebo", "propfind_slides.xml")),
+        )
     syncer.session = session
     return syncer, session
+
+
+def cached_sciebo_context(sync_directory):
+    context = make_context(
+        {
+            "paths.sync_directory": str(sync_directory),
+            "links.sciebo": True,
+        }
+    )
+    context.root_node, courses, sections = two_course_tree()
+    return context, courses[0], sections[0]
+
+
+def sciebo_listing_session(root_listing: str, *, include_slides: bool) -> FakeSession:
+    session = FakeSession()
+    session.add("PROPFIND", SCIEBO_PUBLIC_ROOT, FakeResponse(text=root_listing))
+    if include_slides:
+        session.add(
+            "PROPFIND",
+            SCIEBO_PUBLIC_SLIDES,
+            FakeResponse(text=load_fixture("sciebo", "propfind_slides.xml")),
+        )
+    return session
+
+
+def dav_listing(entries) -> str:
+    responses = "".join(
+        f"""
+        <d:response>
+          <d:href>{href}</d:href>
+          <d:propstat>
+            <d:prop>
+              <d:getetag>{etag}</d:getetag>
+              <d:getcontentlength>123</d:getcontentlength>
+            </d:prop>
+            <d:status>{status}</d:status>
+          </d:propstat>
+        </d:response>"""
+        for href, etag, status in entries
+    )
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<d:multistatus xmlns:d="DAV:">'
+        f"{responses}</d:multistatus>"
+    )
+
+
+def seed_sciebo_course_cache(sync_directory) -> None:
+    context, _, section = cached_sciebo_context(sync_directory)
+    context.session = sciebo_listing_session(
+        load_fixture("sciebo", "propfind_root.xml"),
+        include_slides=True,
+    )
+    sciebo.scan_public_shares(context, SCIEBO_SHARE_LINK, section, course_id=101)
+    deck = section.children[0].children[1].children[0]
+    deck.content_hash = "a" * 64
+    deck.mark_handled()
+    course_cache.cache_root_node(context)
 
 
 def run_h5p_handler(monkeypatch, response, package_metadata=None, config=None):
@@ -1023,6 +1116,7 @@ def test_nested_moodle_folder_paths_are_preserved(monkeypatch, update_snapshots)
         monkeypatch,
         courses,
         {101: load_json_fixture("moodle", "nested_folder_course.json")},
+        folders={101: [{"coursemodule": 301}]},
     )
     syncer.session = FakeSession()
 
@@ -1156,11 +1250,20 @@ def test_sciebo_public_share_is_cached_per_sync_run(caplog):
     links.scan_for_links(syncer, SCIEBO_SHARE_LINK, first_parent, 101)
     links.scan_for_links(syncer, SCIEBO_SHARE_LINK, second_parent, 101)
 
-    assert session.count("GET", SCIEBO_SHARE_LINK) == 1
+    assert session.count("GET", SCIEBO_SHARE_LINK) == 0
     assert session.count("PROPFIND", SCIEBO_PUBLIC_ROOT) == 1
     assert session.count("PROPFIND", SCIEBO_PUBLIC_SLIDES) == 1
+    assert syncer.sciebo_direct_webdav_supported is True
     sciebo_root = first_parent.children[0]
     assert sciebo_root.children[0].remote_size == 123
+    assert sciebo_root.children[0].download_headers is not None
+    assert sciebo_root.children[0].download_headers["X-Requested-With"] == (
+        "XMLHttpRequest"
+    )
+    assert (
+        sciebo_root.children[0].download_headers["Authorization"].startswith("Basic ")
+    )
+    assert "requesttoken" not in sciebo_root.children[0].download_headers
     assert sciebo_root.children[1].children[0].remote_size == 456
     assert [
         row.replace("First occurrence/", "") for row in node_rows(first_parent)
@@ -1180,8 +1283,236 @@ def test_sciebo_public_share_is_cached_per_sync_run(caplog):
     assert "Sciebo sharingToken:" not in caplog.text
 
 
+def test_sciebo_unchanged_folder_restores_pending_cache_without_propfind(tmp_path):
+    seed_sciebo_course_cache(tmp_path)
+    context, course, section = cached_sciebo_context(tmp_path)
+    assert course_cache.get_course_cache_root(context, course) is not None
+    context.session = sciebo_listing_session(
+        load_fixture("sciebo", "propfind_root.xml"),
+        include_slides=False,
+    )
+
+    sciebo.scan_public_shares(context, SCIEBO_SHARE_LINK, section, course_id=101)
+
+    assert context.session.calls == [("PROPFIND", SCIEBO_PUBLIC_ROOT)]
+    deck = section.children[0].children[1].children[0]
+    assert not deck.is_handled
+    assert deck.content_hash is None
+    assert deck.remote_size == 456
+    assert deck.download_headers is not None
+    assert deck.download_headers["X-Requested-With"] == "XMLHttpRequest"
+    assert deck.download_headers["Authorization"].startswith("Basic ")
+
+
+def test_sciebo_changed_folder_etag_is_scanned_again(tmp_path):
+    seed_sciebo_course_cache(tmp_path)
+    context, course, section = cached_sciebo_context(tmp_path)
+    assert course_cache.get_course_cache_root(context, course) is not None
+    changed_root = load_fixture("sciebo", "propfind_root.xml").replace(
+        '"folder-slides"',
+        '"folder-slides-v2"',
+    )
+    context.session = sciebo_listing_session(changed_root, include_slides=True)
+
+    sciebo.scan_public_shares(context, SCIEBO_SHARE_LINK, section, course_id=101)
+
+    assert context.session.calls == [
+        ("PROPFIND", SCIEBO_PUBLIC_ROOT),
+        ("PROPFIND", SCIEBO_PUBLIC_SLIDES),
+    ]
+
+
+@pytest.mark.parametrize("malformation", ["cross-origin", "duplicate"])
+def test_sciebo_malformed_cached_subtree_is_scanned_again(tmp_path, malformation):
+    seed_sciebo_course_cache(tmp_path)
+    context, course, section = cached_sciebo_context(tmp_path)
+    cached_course = course_cache.get_course_cache_root(context, course)
+    assert cached_course is not None
+    cached_slides = node_at_path(
+        cached_course,
+        ["General", "sciebo-share-token-123", "slides"],
+    )
+    cached_deck = cached_slides.children[0]
+    if malformation == "cross-origin":
+        cached_deck.url = "https://evil.test/deck.pdf"
+    else:
+        cached_slides.children.append(cached_deck.clone(cached_slides))
+    context.session = sciebo_listing_session(
+        load_fixture("sciebo", "propfind_root.xml"),
+        include_slides=True,
+    )
+
+    sciebo.scan_public_shares(context, SCIEBO_SHARE_LINK, section, course_id=101)
+
+    assert context.session.calls == [
+        ("PROPFIND", SCIEBO_PUBLIC_ROOT),
+        ("PROPFIND", SCIEBO_PUBLIC_SLIDES),
+    ]
+    deck = section.children[0].children[1].children[0]
+    assert deck.url == f"{SCIEBO_PUBLIC_SLIDES}deck.pdf"
+
+
+def test_sciebo_encoded_names_remain_safe_and_restore_from_folder_cache(tmp_path):
+    folder_name = "Földér #1%?"
+    file_names = [
+        "space name.pdf",
+        "ünicode.pdf",
+        "hash#.pdf",
+        "query?.pdf",
+        "percent%.pdf",
+    ]
+    folder_href = (
+        SCIEBO_PUBLIC_ROOT.removeprefix(sciebo.SCIEBO_URL)
+        + urllib.parse.quote(
+            folder_name,
+            safe="",
+        )
+        + "/"
+    )
+    root_href = SCIEBO_PUBLIC_ROOT.removeprefix(sciebo.SCIEBO_URL)
+    root_listing = dav_listing(
+        [
+            (root_href, '"folder-root"', "HTTP/1.1 200 OK"),
+            (folder_href, '"folder-special"', "HTTP/1.1 200 OK"),
+        ]
+    )
+    folder_listing = dav_listing(
+        [
+            (folder_href, '"folder-special"', "HTTP/1.1 200 OK"),
+            *[
+                (
+                    folder_href + urllib.parse.quote(name, safe=""),
+                    f'"file-{index}"',
+                    "HTTP/1.1 200 OK",
+                )
+                for index, name in enumerate(file_names)
+            ],
+        ]
+    )
+
+    seeded, _, seeded_section = cached_sciebo_context(tmp_path)
+    seeded.session = FakeSession()
+    seeded.session.add("PROPFIND", SCIEBO_PUBLIC_ROOT, FakeResponse(text=root_listing))
+    seeded.session.add(
+        "PROPFIND",
+        sciebo.SCIEBO_URL + folder_href,
+        FakeResponse(text=folder_listing),
+    )
+    sciebo.scan_public_shares(
+        seeded,
+        SCIEBO_SHARE_LINK,
+        seeded_section,
+        course_id=101,
+    )
+    course_cache.cache_root_node(seeded)
+
+    context, course, section = cached_sciebo_context(tmp_path)
+    assert course_cache.get_course_cache_root(context, course) is not None
+    context.session = FakeSession()
+    context.session.add("PROPFIND", SCIEBO_PUBLIC_ROOT, FakeResponse(text=root_listing))
+    sciebo.scan_public_shares(context, SCIEBO_SHARE_LINK, section, course_id=101)
+
+    assert context.session.calls == [("PROPFIND", SCIEBO_PUBLIC_ROOT)]
+    folder = section.children[0].children[0]
+    assert folder.name == folder_name
+    assert [child.name for child in folder.children] == file_names
+    assert [child.url for child in folder.children] == [
+        sciebo.SCIEBO_URL + folder_href + urllib.parse.quote(name, safe="")
+        for name in file_names
+    ]
+
+
+def test_sciebo_keeps_a_child_named_webdav():
+    root_href = SCIEBO_PUBLIC_ROOT.removeprefix(sciebo.SCIEBO_URL)
+    listing = dav_listing(
+        [
+            (root_href, '"folder-root"', "HTTP/1.1 200 OK"),
+            (root_href + "webdav", '"file-webdav"', "HTTP/1.1 200 OK"),
+        ]
+    )
+    syncer = make_context({"links.sciebo": True})
+    syncer.session = FakeSession()
+    syncer.session.add("PROPFIND", SCIEBO_PUBLIC_ROOT, FakeResponse(text=listing))
+    parent = Node("Section", 1, "Section", None)
+
+    sciebo.scan_public_shares(syncer, SCIEBO_SHARE_LINK, parent)
+
+    file_node = parent.children[0].children[0]
+    assert file_node.name == "webdav"
+    assert file_node.url == SCIEBO_PUBLIC_ROOT + "webdav"
+    assert file_node.etag == '"file-webdav"'
+    assert file_node.remote_size == 123
+
+
+def test_sciebo_truncated_nested_listing_is_rejected(caplog):
+    syncer = make_context({"links.sciebo": True})
+    session = FakeSession()
+    session.add(
+        "PROPFIND",
+        SCIEBO_PUBLIC_ROOT,
+        FakeResponse(text=load_fixture("sciebo", "propfind_root.xml")),
+    )
+    truncated = load_fixture("sciebo", "propfind_slides.xml").rsplit(
+        "</d:multistatus>",
+        1,
+    )[0]
+    session.add("PROPFIND", SCIEBO_PUBLIC_SLIDES, FakeResponse(text=truncated))
+    syncer.session = session
+    parent = Node("Section", 1, "Section", None)
+    caplog.set_level(logging.WARNING, logger="syncmymoodle.sciebo")
+
+    sciebo.scan_public_shares(syncer, SCIEBO_SHARE_LINK, parent)
+
+    assert parent.children == []
+    assert syncer.sciebo_link_cache[SCIEBO_SHARE_LINK] is None
+    assert syncer.sciebo_direct_webdav_supported is None
+    assert "unexpected response instead of a DAV listing" in caplog.text
+
+
+def test_sciebo_ignores_properties_from_failed_propstat():
+    root_href = SCIEBO_PUBLIC_ROOT.removeprefix(sciebo.SCIEBO_URL)
+    listing = dav_listing(
+        [
+            (root_href, '"folder-root"', "HTTP/1.1 200 OK"),
+            (
+                root_href + "unavailable.pdf",
+                '"must-not-be-trusted"',
+                "HTTP/1.1 404 Not Found",
+            ),
+        ]
+    )
+    syncer = make_context({"links.sciebo": True})
+    syncer.session = FakeSession()
+    syncer.session.add("PROPFIND", SCIEBO_PUBLIC_ROOT, FakeResponse(text=listing))
+    parent = Node("Section", 1, "Section", None)
+
+    sciebo.scan_public_shares(syncer, SCIEBO_SHARE_LINK, parent)
+
+    file_node = parent.children[0].children[0]
+    assert file_node.etag is None
+    assert file_node.etag_kind is None
+    assert file_node.remote_size is None
+
+
+def test_sciebo_direct_webdav_transient_failure_does_not_fall_back(caplog):
+    syncer = make_context({"links.sciebo": True})
+    session = FakeSession()
+    session.add("PROPFIND", SCIEBO_PUBLIC_ROOT, FakeResponse(status_code=503))
+    syncer.session = session
+    parent = Node("Section", 1, "Section", None)
+    caplog.set_level(logging.WARNING, logger="syncmymoodle.sciebo")
+
+    sciebo.scan_public_shares(syncer, SCIEBO_SHARE_LINK, parent)
+
+    assert session.calls == [("PROPFIND", SCIEBO_PUBLIC_ROOT)]
+    assert parent.children == []
+    assert syncer.stats.failed == 1
+    assert "Sciebo transient failure: WebDAV returned HTTP 503" in caplog.text
+
+
 def test_sciebo_webdav_refuses_cross_origin_redirect_with_credentials(caplog):
     syncer = make_context({"links.sciebo": True})
+    syncer.sciebo_direct_webdav_supported = False
     session = FakeSession()
     session.add(
         "GET",
@@ -1227,8 +1558,9 @@ def test_sciebo_webdav_rejects_partial_listing_before_adding_files(caplog):
     session.add(
         "PROPFIND",
         SCIEBO_PUBLIC_ROOT,
-        FakeResponse(
-            text="""<?xml version="1.0" encoding="UTF-8"?>
+        _legacy_webdav_after_probe(
+            FakeResponse(
+                text="""<?xml version="1.0" encoding="UTF-8"?>
             <d:multistatus xmlns:d="DAV:">
               <d:response><d:href>/public.php/webdav/</d:href></d:response>
               <d:response>
@@ -1236,6 +1568,7 @@ def test_sciebo_webdav_rejects_partial_listing_before_adding_files(caplog):
               </d:response>
               <d:response><d:propstat /></d:response>
             </d:multistatus>"""
+            )
         ),
     )
     syncer.session = session
@@ -1246,6 +1579,7 @@ def test_sciebo_webdav_rejects_partial_listing_before_adding_files(caplog):
 
     assert parent.children == []
     assert syncer.sciebo_link_cache[SCIEBO_SHARE_LINK] is None
+    assert syncer.sciebo_direct_webdav_supported is None
     assert "malformed href" in caplog.text
 
 
@@ -1660,13 +1994,18 @@ def test_sharing_token_from_link_extracts_url_segment():
 def test_sciebo_share_without_token_input_uses_url_token():
     # Newer share pages drop the <input name="sharingToken">; the token is then
     # derived from the /s/<token> URL segment so the share still resolves.
-    syncer, session = sciebo_share_context("public_share_no_token.html")
+    syncer, session = sciebo_share_context(
+        "public_share_no_token.html",
+        direct=False,
+    )
 
     root = Node("", -1, "Root", None)
     parent = root.add_child("Section", 1, "Section")
     links.scan_for_links(syncer, SCIEBO_SHARE_LINK, parent, 101)
 
-    assert session.count("PROPFIND", SCIEBO_PUBLIC_ROOT) == 1
+    assert session.count("GET", SCIEBO_SHARE_LINK) == 1
+    assert session.count("PROPFIND", SCIEBO_PUBLIC_ROOT) == 2
+    assert syncer.sciebo_direct_webdav_supported is False
     assert node_rows(parent) == [
         "Sciebo Folder | Section/sciebo-share-token-123 |  |  |",
         "Sciebo File | Section/sciebo-share-token-123/readme.pdf | "
@@ -1679,10 +2018,69 @@ def test_sciebo_share_without_token_input_uses_url_token():
     ]
 
 
+def test_sciebo_legacy_capability_is_reused_for_later_shares():
+    second_link = "https://rwth-aachen.sciebo.de/s/share-token-456"
+    syncer = make_context({"links.sciebo": True})
+    session = FakeSession()
+    root_requests = 0
+
+    def root_listing(url, kwargs):
+        nonlocal root_requests
+        del url
+        root_requests += 1
+        if root_requests == 1:
+            assert "requesttoken" not in kwargs["headers"]
+            return FakeResponse(status_code=404)
+        assert kwargs["headers"]["requesttoken"] == "fake-request-token"
+        return FakeResponse(text=load_fixture("sciebo", "propfind_root.xml"))
+
+    session.add("PROPFIND", SCIEBO_PUBLIC_ROOT, root_listing)
+    session.add(
+        "PROPFIND",
+        SCIEBO_PUBLIC_SLIDES,
+        FakeResponse(text=load_fixture("sciebo", "propfind_slides.xml")),
+    )
+    share_page = FakeResponse(text=load_fixture("sciebo", "public_share_no_token.html"))
+    session.add("GET", SCIEBO_SHARE_LINK, share_page)
+    session.add("GET", second_link, share_page)
+    syncer.session = session
+    first_parent = Node("First", 1, "Section", None)
+    second_parent = Node("Second", 2, "Section", None)
+
+    sciebo.scan_public_shares(syncer, SCIEBO_SHARE_LINK, first_parent)
+    sciebo.scan_public_shares(syncer, second_link, second_parent)
+
+    assert syncer.sciebo_direct_webdav_supported is False
+    assert session.count("GET") == 2
+    assert session.count("PROPFIND", SCIEBO_PUBLIC_ROOT) == 3
+    assert len(first_parent.children) == len(second_parent.children) == 1
+
+
+def test_sciebo_known_direct_mode_falls_back_for_exceptional_share_failure():
+    syncer, session = sciebo_share_context(
+        "public_share_no_token.html",
+        direct=False,
+    )
+    syncer.sciebo_direct_webdav_supported = True
+    parent = Node("Section", 1, "Section", None)
+
+    sciebo.scan_public_shares(syncer, SCIEBO_SHARE_LINK, parent)
+
+    assert session.calls == [
+        ("PROPFIND", SCIEBO_PUBLIC_ROOT),
+        ("GET", SCIEBO_SHARE_LINK),
+        ("PROPFIND", SCIEBO_PUBLIC_ROOT),
+        ("PROPFIND", SCIEBO_PUBLIC_SLIDES),
+    ]
+    assert syncer.sciebo_direct_webdav_supported is True
+    assert len(parent.children) == 1
+
+
 def _assert_sciebo_share_outage(
     caplog, response_factory, scan_share, logger_name, reason
 ):
     syncer = make_context({"links.sciebo": True})
+    syncer.sciebo_direct_webdav_supported = False
     session = FakeSession()
     for link in SCIEBO_OUTAGE_LINKS[:3]:
         session.add("GET", link, response_factory())
@@ -1708,6 +2106,7 @@ def _assert_sciebo_share_outage(
 
 def _assert_sciebo_webdav_outage(caplog, response, reason):
     syncer = make_context({"links.sciebo": True})
+    syncer.sciebo_direct_webdav_supported = False
     session = FakeSession()
     for link in SCIEBO_OUTAGE_LINKS[:3]:
         session.add(
@@ -1761,6 +2160,7 @@ def test_sciebo_failure_marks_each_course_and_preserves_both_caches(
     }
 
     syncer = make_context(config)
+    syncer.sciebo_direct_webdav_supported = False
     syncer.root_node, _, sections = two_course_tree()
     session = FakeSession()
     first_links = (
@@ -1921,8 +2321,8 @@ def test_direct_link_redirect_cannot_bypass_allowed_domains(caplog):
     }
 
 
-def test_generic_link_resource_errors_are_reported_and_not_scanned(caplog):
-    caplog.set_level(logging.WARNING, logger="syncmymoodle.links")
+def test_generic_link_resource_errors_are_informational_and_not_scanned(caplog):
+    caplog.set_level(logging.INFO, logger="syncmymoodle.links")
 
     for status_code in (403, 404):
         url = f"https://files.example.test/error-{status_code}"
@@ -1947,19 +2347,83 @@ def test_generic_link_resource_errors_are_reported_and_not_scanned(caplog):
         )
         syncer.session = session
         parent = Node("Section", 1, "Section", None)
+        second_parent = Node("Section", 2, "Section", None)
 
         links.scan_for_links(syncer, url, parent, 101, single=True)
+        links.scan_for_links(syncer, url, second_parent, 202, single=True)
 
         assert session.calls == [("HEAD", url), ("GET", url)]
         assert parent.children == []
-        assert syncer.stats.failed == 1
-        assert syncer.incomplete_course_ids == {101}
+        assert second_parent.children == []
+        assert syncer.stats.failed == 0
+        assert syncer.incomplete_course_ids == set()
+        assert syncer.inventory_filtered_course_ids == {101, 202}
 
+    assert [(record.levelno, record.message) for record in caplog.records] == [
+        (
+            logging.INFO,
+            "Skipping linked resource: GET https://files.example.test/error-403 "
+            "returned HTTP 403",
+        ),
+        (
+            logging.INFO,
+            "Skipping linked resource: GET https://files.example.test/error-404 "
+            "returned HTTP 404",
+        ),
+    ]
+
+
+def test_generic_link_head_resource_error_is_informational_when_following_is_off(
+    caplog,
+):
+    url = "https://files.example.test/forbidden"
+    syncer = make_context(
+        {
+            "links.follow_links": False,
+            "filters.allowed_domains": ["files.example.test"],
+        }
+    )
+    session = FakeSession()
+    session.add("HEAD", url, FakeResponse(status_code=403))
+    syncer.session = session
+    parent = Node("Section", 1, "Section", None)
+    caplog.set_level(logging.INFO, logger="syncmymoodle.links")
+
+    links.scan_for_links(syncer, url, parent, 101, single=True)
+
+    assert session.calls == [("HEAD", url)]
+    assert parent.children == []
+    assert syncer.stats.failed == 0
+    assert syncer.incomplete_course_ids == set()
+    assert syncer.inventory_filtered_course_ids == {101}
+    assert [(record.levelno, record.message) for record in caplog.records] == [
+        (
+            logging.INFO,
+            "Skipping linked resource: HEAD https://files.example.test/forbidden "
+            "returned HTTP 403",
+        )
+    ]
+
+
+def test_generic_link_non_4xx_terminal_response_remains_a_failure(caplog):
+    url = "https://files.example.test/multiple-choices"
+    syncer = make_context({"filters.allowed_domains": ["files.example.test"]})
+    session = FakeSession()
+    session.add("HEAD", url, FakeResponse(status_code=300))
+    session.add("GET", url, FakeResponse(status_code=300))
+    syncer.session = session
+    parent = Node("Section", 1, "Section", None)
+    caplog.set_level(logging.WARNING, logger="syncmymoodle.links")
+
+    links.scan_for_links(syncer, url, parent, 101, single=True)
+
+    assert session.calls == [("HEAD", url), ("GET", url)]
+    assert parent.children == []
+    assert syncer.stats.failed == 1
+    assert syncer.incomplete_course_ids == {101}
     assert caplog.messages == [
-        "Skipping linked resource: GET https://files.example.test/error-403 "
-        "returned HTTP 403",
-        "Skipping linked resource: GET https://files.example.test/error-404 "
-        "returned HTTP 404",
+        "Skipping linked resource: GET "
+        "https://files.example.test/multiple-choices returned HTTP 300"
     ]
 
 
@@ -1993,6 +2457,8 @@ def test_generic_link_error_pages_open_origin_circuit_without_being_scanned(capl
         call for url in urls[:3] for call in (("HEAD", url), ("GET", url))
     ]
     assert parent.children == []
+    assert syncer.stats.failed == 4
+    assert syncer.incomplete_course_ids == {101}
     assert caplog.messages == [
         "Link origin https://files.example.test transient failure: GET "
         "https://files.example.test/outage-0 returned HTTP 503",


### PR DESCRIPTION
 Keeps enough verified state to recognize files that are already current, even after a fresh cache or partial provider failure. Repeat syncs should no longer fetch the same content again unnecessarily.

Also does a final hash check before trying to replace local files