### PR TITLE
Add browser-assisted login

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,19 @@ syncmymoodle setup
 syncmymoodle
 ```
 
-Setup asks for:
+If you use a security key, passkey, or another MFA method handled by the RWTH
+login page, run setup through your browser instead:
+
+```shell
+syncmymoodle setup --browser
+```
+
+The command opens an RWTH/Moodle sign-in link. On the Moodle page, right-click
+the blue link offered when the app does not open automatically, copy its link
+address, and paste it back into the hidden prompt. That address contains your
+Moodle tokens, so do not share or save it.
+
+Without `--browser`, setup asks for:
 
 - Your RWTH Single Sign-On username
 - Your RWTH TOTP serial, such as `TOTP12345678`
@@ -73,8 +85,11 @@ Setup asks for:
 The TOTP serial is the identifier shown in the
 [RWTH IDM Token Manager](https://idm.rwth-aachen.de/selfservice/MFATokenManager).
 
-Setup performs one RWTH sign-in, obtains the Moodle tokens, stores them in the
-system keyring when available, and writes an example configuration.
+Browser setup asks only for the username, sync directory, and token store. It
+does not ask for an RWTH password or TOTP details. It also saves browser-assisted
+sign-in as the login method, so a later `syncmymoodle auth login` uses the browser
+again. Both setup methods perform one RWTH sign-in, obtain the Moodle tokens, store
+them in the system keyring when available, and write an example configuration.
 After this one-time login, syncMyMoodle should work without requiring re-sign-ins!
 
 Setup is only for a new installation. To change an existing setup, locate and
@@ -91,6 +106,9 @@ afterwards so the stored Moodle tokens match the new configuration:
 ```shell
 syncmymoodle auth login
 ```
+
+Use `syncmymoodle auth login --browser` for a one-off browser login when the
+saved login method is `totp`.
 
 ## Everyday use
 
@@ -241,7 +259,7 @@ There are two categories of auth data:
 
 The Moodle token record contains an API token and, when Moodle provides it, a
 browser-login token. The local record is stored either in the system keyring or
-in a protected environment file managed by syncMyMoodle.
+in an environment file managed by syncMyMoodle. The system keyring is preferred.
 
 In a desktop keyring viewer, look for service `syncmymoodle` and an entry named
 like `mobile-tokens:moodle.rwth-aachen.de:<username>`. The exact grouping and
@@ -250,9 +268,11 @@ display name depend on the operating system's keyring backend.
 A normal sync behaves as follows:
 
 - Valid stored tokens are used without contacting RWTH SSO.
+- With `auth.login.method = "browser"`, missing or invalid tokens stop the sync
+  and direct you to the browser-assisted `syncmymoodle auth login` flow.
 - With `auth.login.provider = "prompt"`, missing or invalid tokens stop the sync
   and direct you to `syncmymoodle auth login`.
-- A reusable provider such as a password manager or protected sign-in file can
+- A reusable provider such as a password manager or environment file can
   sign in again and replace missing or invalid tokens automatically.
 - Network or server failures leave token validity unknown and never trigger
   token replacement.
@@ -265,32 +285,45 @@ Automatic replacement makes at most one SSO attempt during a sync.
 |------------------------------------------|----------------------------------------------------------------------------------|
 | `syncmymoodle auth status`               | Validates local tokens and reports the cached browser session without signing in |
 | `syncmymoodle auth login`                | Performs one fresh SSO login and replaces the local token record                 |
-| `syncmymoodle auth migrate --to keyring` | Copies tokens to another secure store and updates the configuration              |
+| `syncmymoodle auth migrate --to keyring` | Copies tokens to another store and updates the configuration                     |
 | `syncmymoodle auth forget`               | Removes only this installation's tokens and cached browser session               |
 | `syncmymoodle auth reset-token`          | Revokes and replaces the shared Moodle API token                                 |
 
 `auth login` does not revoke the server token or log out another installation.
 Use `auth login --totp-manual` to ignore the configured TOTP source and enter a
-current code for that login only.
+current code for that login only. Use `auth login --browser` for a browser-based
+RWTH sign-in instead. The new tokens are accepted only after Moodle confirms
+that they belong to the same account as the existing token record. If Moodle
+does not return the private token used for browser sessions, syncMyMoodle offers
+one retry with a fresh link in a new private/incognito window. If that still
+fails, the account may have a legacy mobile-app token. Revoke the old token on
+Moodle's [Security keys page](https://moodle.rwth-aachen.de/user/managetoken.php),
+then run `syncmymoodle auth login` again.
 
-`auth migrate` leaves the previous token store untouched. To move to a protected
+`auth migrate` leaves the previous token store untouched. To move to an
 environment file, use `auth migrate --to env-file --env-file PATH`.
 
 `auth forget` leaves the configuration, RWTH sign-in secrets, and shared server
 token unchanged. If a reusable sign-in provider remains configured, a later
 sync can obtain and store the local tokens again.
 
-Use `auth reset-token` only when your account still has a legacy Moodle token
-without the ability to mint Browser sessions, or you think your tokens may have been exposed.
-Resetting the shared token logs out the Moodle app and every other
-syncMyMoodle installation that uses it.
+Use `auth reset-token` with the TOTP login method only when your account
+still has a legacy Moodle token that cannot create browser sessions, or you
+think your tokens may have been exposed. Resetting the shared token logs out the
+Moodle app and every other syncMyMoodle installation that uses it.
 
 ### Sign-in providers
 
+`auth.login.method` chooses `totp` or `browser` sign-in. With `totp`,
 `auth.login.provider` controls how RWTH SSO obtains the password and TOTP when
-new Moodle tokens are needed. Supported choices are interactive prompts, the
-system keyring, a protected environment file, 1Password, Bitwarden, pass, rbw,
+new Moodle tokens are needed. Supported providers are interactive prompts, the
+system keyring, an environment file, 1Password, Bitwarden, pass, rbw,
 gopass, and a custom command.
+
+These providers are used by the TOTP flow and by unattended recovery.
+Browser login does not read them. A setup created with `setup --browser` saves
+the browser method, so plain `auth login` opens the browser when its Moodle tokens
+eventually need replacing.
 
 During setup, installed password-manager CLIs are detected without being run.
 If selected, setup asks for provider-native password and optional TOTP

--- a/syncmymoodle/cli.py
+++ b/syncmymoodle/cli.py
@@ -4,6 +4,7 @@ import json
 import logging
 import sys
 import tomllib
+import webbrowser
 from argparse import (
     SUPPRESS,
     Action,
@@ -33,6 +34,7 @@ from syncmymoodle import (
 from syncmymoodle import moodle as moodle_api
 from syncmymoodle.config import (
     CONFIG_OPTIONS,
+    DEFAULT_LOGIN_METHOD,
     DEFAULT_LOGIN_PROVIDER,
     DEFAULT_TOKEN_STORE,
     TOKEN_STORE_OPTIONS,
@@ -63,6 +65,7 @@ from syncmymoodle.moodle_tokens import (
     KeyringTokenStore,
     MoodleTokens,
     MoodleTokenStore,
+    overwrite_tokens_verified,
     store_tokens_verified,
     token_store_transaction,
 )
@@ -216,13 +219,19 @@ def build_parser() -> ArgumentParser:
     )
 
     subparsers = parser.add_subparsers(dest="command")
-    subparsers.add_parser(
+    setup_parser = subparsers.add_parser(
         "setup",
         help="configure and verify syncMyMoodle for first use",
         description=(
-            "Interactively configure RWTH sign-in, secure Moodle token storage, "
+            "Interactively configure RWTH sign-in, Moodle token storage, "
             "and the sync destination, then verify the RWTH sign-in with one login."
         ),
+    )
+    setup_parser.add_argument(
+        "--browser",
+        dest="browser_login",
+        action="store_true",
+        help="complete RWTH sign-in in a browser to use any supported MFA method",
     )
     config_parser = subparsers.add_parser("config", help="manage configuration files")
     config_subparsers = config_parser.add_subparsers(
@@ -260,15 +269,12 @@ def build_parser() -> ArgumentParser:
         "--token-store",
         choices=TOKEN_STORE_OPTIONS,
         default=DEFAULT_TOKEN_STORE,
-        help="secure store for the migrated Moodle tokens",
+        help="store for the migrated Moodle tokens",
     )
     migrate_parser.add_argument(
         "--token-env-file",
         default=None,
-        help=(
-            "protected environment file for Moodle tokens when --token-store "
-            "is env-file"
-        ),
+        help=("environment file for Moodle tokens when --token-store is env-file"),
     )
     config_subparsers.add_parser(
         "check",
@@ -291,16 +297,23 @@ def build_parser() -> ArgumentParser:
             "stored Moodle tokens. This does not revoke the shared Moodle API token."
         ),
     )
-    auth_login_parser.add_argument(
+    auth_login_method = auth_login_parser.add_mutually_exclusive_group()
+    auth_login_method.add_argument(
+        "--browser",
+        dest="browser_login",
+        action="store_true",
+        help="complete RWTH sign-in in a browser to use any supported MFA method",
+    )
+    auth_login_method.add_argument(
         "--totp-manual",
         action="store_true",
         help="ignore the configured TOTP source and prompt for a code for this login",
     )
     auth_migrate_parser = auth_subparsers.add_parser(
         "migrate",
-        help="copy Moodle tokens to another secure store and update the configuration",
+        help="copy Moodle tokens to another store and update the configuration",
         description=(
-            "Copy the stored Moodle tokens to another secure store and update the "
+            "Copy the stored Moodle tokens to another store and update the "
             "selected configuration. The previous store is left untouched."
         ),
     )
@@ -308,12 +321,12 @@ def build_parser() -> ArgumentParser:
         "--to",
         choices=TOKEN_STORE_OPTIONS,
         required=True,
-        help="secure store to use for Moodle tokens",
+        help="store to use for Moodle tokens",
     )
     auth_migrate_parser.add_argument(
         "--env-file",
         default=None,
-        help="destination protected environment file when --to is env-file",
+        help="destination environment file when --to is env-file",
     )
     auth_subparsers.add_parser(
         "status",
@@ -736,27 +749,70 @@ def run_config_command(args: Namespace, parser: ArgumentParser) -> None:
     parser.error(f"unknown config command: {args.config_command}")
 
 
+def browser_login_selected(args: Namespace, config: Config) -> bool:
+    return bool(
+        getattr(args, "browser_login", False)
+        or (
+            config.login_method == "browser" and not getattr(args, "totp_manual", False)
+        )
+    )
+
+
 def login_auth_command(
     args: Namespace,
     parser: ArgumentParser,
     keyring_backend: Any,
 ) -> None:
     ctx = configured_auth_context(args, parser, keyring_backend)
+    browser_login = browser_login_selected(args, ctx.config)
     ctx.config = replace(ctx.config, dry_run=False)
     try:
         store = token_store_from_config(ctx.config, keyring_backend)
     except ProviderSecretError as error:
         parser.error(str(error))
     require_store_available(store, parser)
-    output.phase("Logging in to obtain the current Moodle tokens...")
-    rwth.login(ctx, logger, reuse_cached_session=False)
-    tokens = acquire_validated_moodle_tokens(ctx, parser)
+    previous: MoodleTokens | None = None
+    overwrite_unreadable_store = False
+    if browser_login:
+        try:
+            previous = store.load()
+        except ProviderSecretError as error:
+            if not isinstance(store, EnvFileTokenStore):
+                parser.error(str(error))
+            overwrite_unreadable_store = True
+            output.warning(
+                f"The existing {store.description} could not be read ({error}). "
+                "It will be replaced only after you confirm the browser account."
+            )
+    tokens = acquire_moodle_tokens_for_login(
+        ctx,
+        parser,
+        browser=browser_login,
+        previous=previous,
+    )
+    if (
+        browser_login
+        and tokens.private_token is None
+        and not output.confirm(
+            "Store the Moodle API token without browser-session support"
+        )
+    ):
+        parser.error("browser login cancelled; the stored tokens were left unchanged")
     try:
-        store_tokens_verified(store, tokens)
+        if overwrite_unreadable_store:
+            overwrite_tokens_verified(store, tokens)
+        else:
+            store_tokens_verified(store, tokens)
     except ProviderSecretError as error:
         parser.error(str(error))
     output.success(f"Stored Moodle tokens in {store.description}")
-    output.print(f"Browser session cached in {ctx.config.cookie_file}")
+    if browser_login and tokens.private_token is None:
+        output.warning(
+            "Moodle did not provide a browser login token. Moodle API downloads "
+            "will work, but downloads that need a browser session may not."
+        )
+    else:
+        output.print(f"Browser session cached in {ctx.config.cookie_file}")
 
 
 def setup_sync_directory_value(value: str) -> str:
@@ -765,24 +821,30 @@ def setup_sync_directory_value(value: str) -> str:
 
 def prompt_setup_config(
     parser: ArgumentParser,
-) -> tuple[ConfigDict, str, str]:
+    *,
+    browser_login: bool = False,
+) -> tuple[ConfigDict, str]:
     username = output.prompt("RWTH SSO username")
     if not username:
         parser.error("RWTH SSO username is required")
-    totp_serial = output.prompt("RWTH SSO TOTP serial (for example, TOTP12345678)")
-    if not totp_serial:
-        parser.error("RWTH SSO TOTP serial is required")
+    totp_serial = ""
+    if not browser_login:
+        totp_serial = output.prompt("RWTH SSO TOTP serial (for example, TOTP12345678)")
+        if not totp_serial:
+            parser.error("RWTH SSO TOTP serial is required")
     sync_directory = output.prompt(
         "Directory to sync Moodle files to",
         str(Path.cwd()),
     )
     config: ConfigDict = {
         "auth.user": username,
-        "auth.login.totp_serial": totp_serial,
+        "auth.login.method": "browser" if browser_login else DEFAULT_LOGIN_METHOD,
         "auth.login.provider": DEFAULT_LOGIN_PROVIDER,
         "paths.sync_directory": setup_sync_directory_value(sync_directory),
     }
-    return config, username, totp_serial
+    if totp_serial:
+        config["auth.login.totp_serial"] = totp_serial
+    return config, username
 
 
 def mutable_toml_table(
@@ -861,6 +923,177 @@ def acquire_validated_moodle_tokens(
     return tokens
 
 
+def _prompt_browser_mobile_callback(
+    launch: moodle_api.MobileLaunchRequest,
+    parser: ArgumentParser,
+    *,
+    private_window: bool = False,
+) -> str:
+    if private_window:
+        output.phase("Retry the RWTH sign-in in a new private browser window.")
+        output.print(
+            "Open a new private/incognito browser window and paste this link into it:"
+        )
+    else:
+        output.phase("Complete the RWTH sign-in in your browser.")
+    output.print(launch.url)
+    if not private_window:
+        try:
+            opened = webbrowser.open(launch.url, new=2)
+        except (OSError, webbrowser.Error):
+            opened = False
+        if opened:
+            output.print("Opened the sign-in link in the default browser.")
+        else:
+            output.caution(
+                "Could not open a browser automatically; open the link above."
+            )
+    output.print(
+        "On the Moodle page, right-click the blue link offered when the app does "
+        "not open automatically and copy its link address. The pasted value is "
+        "hidden because it contains your Moodle tokens."
+    )
+    callback = output.prompt_secret("Paste the complete app-launch link")
+    if not callback:
+        parser.error("the Moodle app-launch link is required")
+    return callback.strip()
+
+
+def _bind_browser_moodle_account(
+    tokens: MoodleTokens,
+    result: moodle_api.TokenValidation,
+    previous: MoodleTokens | None,
+    parser: ArgumentParser,
+) -> MoodleTokens:
+    assert result.site_info is not None
+    user_id = result.site_info["userid"]
+    assert isinstance(user_id, int) and not isinstance(user_id, bool)
+    tokens = replace(tokens, moodle_user_id=user_id)
+
+    if previous is not None and previous.moodle_user_id != user_id:
+        parser.error(
+            "the browser authenticated a different Moodle account; "
+            "the existing tokens were left unchanged"
+        )
+    if (
+        previous is not None
+        and tokens.private_token is None
+        and tokens.wstoken == previous.wstoken
+    ):
+        return replace(tokens, private_token=previous.private_token)
+    return tokens
+
+
+def _confirm_browser_moodle_account(
+    tokens: MoodleTokens,
+    result: moodle_api.TokenValidation,
+    expected_username: str,
+    parser: ArgumentParser,
+) -> None:
+    assert result.site_info is not None
+    fullname = result.site_info.get("fullname")
+    account = (
+        fullname.strip()
+        if isinstance(fullname, str) and fullname.strip()
+        else f"Moodle user {tokens.moodle_user_id}"
+    )
+    if not output.confirm(
+        f"Store tokens for {account} as RWTH account {expected_username}",
+        default=True,
+    ):
+        parser.error("browser login cancelled before storing Moodle tokens")
+
+
+def acquire_browser_moodle_tokens(
+    ctx: SyncContext,
+    parser: ArgumentParser,
+    previous: MoodleTokens | None = None,
+) -> MoodleTokens:
+    assert ctx.auth.user is not None
+    private_window = False
+    while True:
+        launch = moodle_api.create_browser_mobile_launch()
+        callback = _prompt_browser_mobile_callback(
+            launch,
+            parser,
+            private_window=private_window,
+        )
+        try:
+            tokens = moodle_api.parse_mobile_launch_location(
+                callback,
+                launch.passport,
+                ctx.auth.user,
+                url_scheme=launch.url_scheme,
+            )
+        except moodle_api.MobileLaunchError as error:
+            parser.error(str(error))
+
+        result = moodle_api.inspect_mobile_token(tokens.wstoken, site=tokens.site)
+        if result.kind is not moodle_api.TokenValidationKind.VALID:
+            detail = f": {result.detail}" if result.detail else ""
+            parser.error(f"could not validate Moodle tokens{detail}")
+        tokens = _bind_browser_moodle_account(
+            tokens,
+            result,
+            previous,
+            parser,
+        )
+        if tokens.private_token is not None:
+            break
+        if not private_window:
+            output.warning(
+                "Moodle did not provide the private token needed to create browser "
+                "sessions. Try a fresh login in a new private/incognito browser "
+                "window."
+            )
+            if output.confirm(
+                "Try again in a new private browser window",
+                default=True,
+            ):
+                private_window = True
+                continue
+        output.warning(
+            "If a fresh private-window login still does not provide the private "
+            "token, your account may have a legacy Moodle mobile-app token. Revoke "
+            "the old token manually on Moodle's Security keys page, then retry: "
+            f"{moodle_api.MOODLE_MANAGE_TOKEN_URL}"
+        )
+        break
+
+    if previous is None:
+        _confirm_browser_moodle_account(tokens, result, ctx.auth.user, parser)
+    elif (
+        previous.private_token is not None
+        and tokens.private_token is None
+        and tokens.wstoken != previous.wstoken
+    ):
+        parser.error(
+            "Moodle did not return the browser login token for the replacement API "
+            "token. The existing tokens were left unchanged"
+        )
+    return tokens
+
+
+def acquire_moodle_tokens_for_login(
+    ctx: SyncContext,
+    parser: ArgumentParser,
+    *,
+    browser: bool,
+    previous: MoodleTokens | None = None,
+    persist_session: bool = True,
+) -> MoodleTokens:
+    if browser:
+        return acquire_browser_moodle_tokens(ctx, parser, previous)
+    output.phase("Logging in to obtain the current Moodle tokens...")
+    rwth.login(
+        ctx,
+        logger,
+        reuse_cached_session=False,
+        persist_session=persist_session,
+    )
+    return acquire_validated_moodle_tokens(ctx, parser)
+
+
 def prompt_setup_token_store(
     config: ConfigDict,
     username: str,
@@ -881,11 +1114,11 @@ def prompt_setup_token_store(
         )
     default_path = pathing.user_config_dir() / "moodle-tokens.env"
     env_file = output.prompt(
-        "File for securely storing Moodle tokens",
+        "File for storing Moodle tokens",
         str(default_path),
     )
     if not env_file:
-        raise ProviderSecretError("a secure Moodle token store is required")
+        raise ProviderSecretError("a Moodle token store is required")
     config["auth.tokens.store"] = "env-file"
     config["auth.tokens.env_file"] = str(pathing.absolute_path(Path(env_file)))
 
@@ -944,8 +1177,12 @@ def setup_command(
     if legacy_path is not None:
         parser.error(legacy_json_migration_message(legacy_path))
 
-    config, username, _ = prompt_setup_config(parser)
-    prompt_setup_password_manager(config, parser)
+    config, username = prompt_setup_config(
+        parser,
+        browser_login=args.browser_login,
+    )
+    if not args.browser_login:
+        prompt_setup_password_manager(config, parser)
     try:
         prompt_setup_token_store(config, username, keyring_backend)
     except ProviderSecretError as error:
@@ -958,19 +1195,24 @@ def setup_command(
     store = token_store_from_config(ctx.config, keyring_backend)
     require_store_available(store, parser)
 
-    output.phase("Logging in once to obtain Moodle tokens...")
-    rwth.login(
+    tokens = acquire_moodle_tokens_for_login(
         ctx,
-        logger,
-        reuse_cached_session=False,
+        parser,
+        browser=args.browser_login,
         persist_session=False,
     )
-    tokens = acquire_validated_moodle_tokens(ctx, parser)
     limited_opencast = tokens.private_token is None
     if limited_opencast and not output.confirm(
         "Moodle did not provide the browser login token required for embedded "
         "Opencast downloads. Finish setup with limited Opencast support"
     ):
+        if args.browser_login:
+            parser.error(
+                "setup cancelled before saving the configuration or Moodle tokens. "
+                "Moodle may have returned a legacy mobile-app token; reset the "
+                "Moodle mobile web service token in Moodle before rerunning "
+                "`syncmymoodle setup --browser`."
+            )
         parser.error(
             "setup cancelled before saving the configuration or Moodle tokens. "
             "To repair the shared token, rerun setup, finish with limited Opencast "
@@ -989,11 +1231,17 @@ def setup_command(
         "RWTH password or TOTP code."
     )
     if limited_opencast:
-        output.warning(
-            "Embedded Opencast downloads may stop working after the cached browser "
-            "session expires. Run `syncmymoodle auth reset-token` to create a "
-            "complete token pair."
-        )
+        if ctx.config.login_method == "browser":
+            output.warning(
+                "Downloads that need a Moodle browser session may not work. Run "
+                "`syncmymoodle auth login` to retry in a new private browser window."
+            )
+        else:
+            output.warning(
+                "Embedded Opencast downloads may stop working after the cached "
+                "browser session expires. Run `syncmymoodle auth reset-token` to "
+                "create a complete token pair."
+            )
     output.print("Run `syncmymoodle` to start syncing.")
 
 
@@ -1052,6 +1300,11 @@ def migrate_auth_command(
         require_store_available(source, parser)
         tokens = source.load()
         if tokens is None:
+            if config.login_method == "browser":
+                parser.error(
+                    "no stored Moodle tokens found; run `syncmymoodle auth login` "
+                    "before migrating the token store"
+                )
             ctx = SyncContext(config=config)
             configure_secret_resolvers(ctx, args, keyring_backend)
             output.phase(
@@ -1096,6 +1349,8 @@ def migrate_auth_command(
 
 
 def sign_in_method_status(config: Config, keyring_backend: Any) -> tuple[str, bool]:
+    if config.login_method == "browser":
+        return "browser-assisted sign-in (interactive)", True
     source = config.auth_source
     if isinstance(source, KeyringAuthSource):
         keyring_provider = KeyringProvider(keyring_backend)
@@ -1107,7 +1362,7 @@ def sign_in_method_status(config: Config, keyring_backend: Any) -> tuple[str, bo
     if isinstance(source, EnvFileAuthSource):
         available = source.path.is_file()
         state = "available" if available else "missing"
-        return f"protected environment file {source.path} ({state})", available
+        return f"environment file {source.path} ({state})", available
     if isinstance(source, ExternalAuthSource):
         try:
             provider = build_external_secret_provider(source.provider)
@@ -1207,9 +1462,14 @@ def report_moodle_tokens(config: Config, tokens: MoodleTokens) -> bool:
     else:
         output.caution("Browser login token: missing")
         if config.link_source_enabled("opencast"):
+            repair_command = (
+                "syncmymoodle auth login"
+                if config.login_method == "browser"
+                else "syncmymoodle auth reset-token"
+            )
             output.caution(
                 "Embedded Opencast needs a browser login token; run "
-                "`syncmymoodle auth reset-token`."
+                f"`{repair_command}`."
             )
             failed = True
     return failed
@@ -1263,7 +1523,12 @@ def forget_auth_command(
         "The shared Moodle API token, configuration, and RWTH sign-in secrets "
         "will remain unchanged."
     )
-    if not isinstance(config.auth_source, PromptAuthSource):
+    if config.login_method == "browser":
+        output.caution(
+            "Browser-assisted sign-in remains configured. Run `syncmymoodle auth "
+            "login` when you want to store local Moodle tokens again."
+        )
+    elif not isinstance(config.auth_source, PromptAuthSource):
         output.caution(
             "The configured RWTH sign-in method remains available, so a later sync "
             "can sign in and store local Moodle tokens again."
@@ -1306,6 +1571,11 @@ def reset_token_auth_command(
     keyring_backend: Any,
 ) -> None:
     ctx = configured_auth_context(args, parser, keyring_backend)
+    if ctx.config.login_method == "browser":
+        parser.error(
+            "auth reset-token requires the TOTP login method. Run "
+            "`syncmymoodle auth login` to refresh browser-assisted tokens instead"
+        )
     output.caution("This resets the shared Moodle API token.")
     output.caution(
         "The Moodle app and every other syncMyMoodle installation using it "
@@ -1759,6 +2029,8 @@ def configure_secret_resolvers(
     *,
     resolve_otp: bool = True,
 ) -> None:
+    if browser_login_selected(args, ctx.config):
+        return
     source = ctx.config.auth_source
     if isinstance(source, KeyringAuthSource):
         configure_keyring_resolver(
@@ -1966,6 +2238,12 @@ def reauthenticate_moodle_tokens(
     ctx: SyncContext,
     store: MoodleTokenStore,
 ) -> tuple[MoodleTokens, moodle_api.TokenValidation]:
+    if ctx.config.login_method == "browser":
+        logger.critical(
+            "Moodle tokens are missing or invalid, and browser-assisted sign-in "
+            "requires interaction. Run `syncmymoodle auth login`."
+        )
+        raise SystemExit(1)
     if isinstance(ctx.config.auth_source, PromptAuthSource):
         logger.critical(
             "Moodle tokens are missing or invalid, and the configured RWTH sign-in "

--- a/syncmymoodle/config.py
+++ b/syncmymoodle/config.py
@@ -39,8 +39,10 @@ CliValueKind: TypeAlias = Literal["scalar", "csv", "flag"]
 
 CONFLICT_HANDLING_OPTIONS = ("rename", "keep", "overwrite")
 DEFAULT_TOKEN_STORE = "keyring"
+DEFAULT_LOGIN_METHOD = "totp"
 DEFAULT_LOGIN_PROVIDER = "prompt"
 TOKEN_STORE_OPTIONS = (DEFAULT_TOKEN_STORE, "env-file")
+LOGIN_METHOD_OPTIONS = (DEFAULT_LOGIN_METHOD, "browser")
 LOGIN_PROVIDER_OPTIONS = (
     DEFAULT_LOGIN_PROVIDER,
     *TOKEN_STORE_OPTIONS,
@@ -303,6 +305,14 @@ class Config:
         validate=string_error,
         resolve_relative_path=True,
     )
+    login_method: str = option(
+        DEFAULT_LOGIN_METHOD,
+        group="auth.login",
+        key="method",
+        falsey_uses_default=True,
+        choices=LOGIN_METHOD_OPTIONS,
+        validate=string_error,
+    )
     login_provider: str = option(
         DEFAULT_LOGIN_PROVIDER,
         group="auth.login",
@@ -341,7 +351,7 @@ class Config:
         resolve_relative_path=True,
         cli=cli_arg(
             "login-env-file",
-            "temporarily use a protected environment file for the RWTH password "
+            "temporarily use an environment file for the RWTH password "
             "and optional TOTP seed",
         ),
     )

--- a/syncmymoodle/config.toml.example
+++ b/syncmymoodle/config.toml.example
@@ -3,10 +3,11 @@ user = "" # RWTH SSO username
 
 [auth.tokens]
 store = "keyring" # keyring (recommended) or env-file
-env_file = "" # Protected environment file used only when store = "env-file"
+env_file = "" # Environment file used only when store = "env-file"
 
 [auth.login]
-# prompt, keyring, env-file, 1password, bitwarden, pass, rbw, gopass, or command.
+method = "totp" # totp or browser; setup --browser selects browser
+# With the TOTP method: prompt, keyring, env-file, 1password, bitwarden, pass, rbw, gopass, or command.
 # Reusable providers can sign in again during sync if Moodle tokens stop working.
 provider = "prompt"
 totp_serial = "" # The TOTP ID to use e.g. TOTP12345678; see https://idm.rwth-aachen.de/selfservice/MFATokenManager

--- a/syncmymoodle/moodle.py
+++ b/syncmymoodle/moodle.py
@@ -33,6 +33,7 @@ MOODLE_REST_URL = f"{MOODLE_URL}webservice/rest/server.php"
 MOODLE_MOBILE_LAUNCH_URL = f"{MOODLE_URL}admin/tool/mobile/launch.php"
 MOODLE_MANAGE_TOKEN_URL = f"{MOODLE_URL}user/managetoken.php"
 MOBILE_URL_SCHEME = "syncmymoodle"
+MOBILE_SERVICE = "moodle_mobile_app"
 MOODLE_MOBILE_USER_AGENT = "MoodleMobile syncMyMoodle"
 MOODLE_UPDATE_FUNCTION = "core_course_check_updates"
 
@@ -161,6 +162,13 @@ class TokenValidation:
 
 
 @dataclass(frozen=True)
+class MobileLaunchRequest:
+    url: str
+    passport: str
+    url_scheme: str
+
+
+@dataclass(frozen=True)
 class CourseUpdates:
     """A conservative view of Moodle's per-module update feed."""
 
@@ -185,14 +193,33 @@ def mobile_site_signature(passport: str, site: str = MOODLE_URL) -> str:
     ).hexdigest()
 
 
+def create_browser_mobile_launch() -> MobileLaunchRequest:
+    passport = secrets.token_hex(16)
+    url_scheme = f"{MOBILE_URL_SCHEME}-{secrets.token_hex(8)}"
+    query = urllib.parse.urlencode(
+        {
+            "service": MOBILE_SERVICE,
+            "passport": passport,
+            "urlscheme": url_scheme,
+            "confirmed": "1",
+        }
+    )
+    return MobileLaunchRequest(
+        url=f"{MOODLE_MOBILE_LAUNCH_URL}?{query}",
+        passport=passport,
+        url_scheme=url_scheme,
+    )
+
+
 def parse_mobile_launch_location(
     location: str,
     passport: str,
     username: str,
     site: str = MOODLE_URL,
     moodle_user_id: int | None = None,
+    url_scheme: str = MOBILE_URL_SCHEME,
 ) -> MoodleTokens:
-    prefix = f"{MOBILE_URL_SCHEME}://token="
+    prefix = f"{url_scheme}://token="
     if not location.startswith(prefix):
         raise MobileLaunchError("Moodle returned an unexpected mobile launch redirect")
     encoded = location[len(prefix) :].split("&", 1)[0]
@@ -232,7 +259,7 @@ def acquire_mobile_tokens(
         response = session.get(
             MOODLE_MOBILE_LAUNCH_URL,
             params={
-                "service": "moodle_mobile_app",
+                "service": MOBILE_SERVICE,
                 "passport": passport,
                 "urlscheme": MOBILE_URL_SCHEME,
             },
@@ -326,11 +353,13 @@ def reset_mobile_token(session: requests.Session, session_key: str) -> None:
         )
 
 
-def validate_mobile_tokens(
-    tokens: MoodleTokens,
+def inspect_mobile_token(
+    wstoken: str,
     *,
+    site: str = MOODLE_URL,
     session: requests.Session | None = None,
 ) -> TokenValidation:
+    """Validate a mobile token and return its Moodle account metadata."""
     session = requests.Session() if session is None else session
     try:
         response = _request_moodle(
@@ -342,7 +371,7 @@ def validate_mobile_tokens(
                 "wsfunction": "core_webservice_get_site_info",
             },
             data={
-                "wstoken": tokens.wstoken,
+                "wstoken": wstoken,
                 "wsfunction": "core_webservice_get_site_info",
             },
             timeout=HTTP_TIMEOUT_SECONDS,
@@ -370,16 +399,16 @@ def validate_mobile_tokens(
             TokenValidationKind.UNKNOWN,
             f"Moodle token validation returned HTTP {response.status_code}",
         )
-    return validate_mobile_token_payload(
+    return inspect_mobile_token_payload(
         payload,
-        tokens,
+        site,
         server_time=_http_date_timestamp(response.headers.get("Date")),
     )
 
 
-def validate_mobile_token_payload(
+def inspect_mobile_token_payload(
     payload: Any,
-    tokens: MoodleTokens,
+    site: str,
     *,
     server_time: int | None = None,
 ) -> TokenValidation:
@@ -404,10 +433,31 @@ def validate_mobile_token_payload(
         return TokenValidation(
             TokenValidationKind.UNKNOWN, "site info omitted the Moodle site URL"
         )
-    if normalized_site(site_url) != normalized_site(tokens.site):
+    if normalized_site(site_url) != normalized_site(site):
         return TokenValidation(
             TokenValidationKind.INVALID, "token belongs to another site"
         )
+    return TokenValidation(
+        TokenValidationKind.VALID,
+        site_info=payload,
+        server_time=server_time,
+    )
+
+
+def validate_mobile_tokens(
+    tokens: MoodleTokens,
+    *,
+    session: requests.Session | None = None,
+) -> TokenValidation:
+    result = inspect_mobile_token(
+        tokens.wstoken,
+        site=tokens.site,
+        session=session,
+    )
+    if result.kind is not TokenValidationKind.VALID:
+        return result
+    assert result.site_info is not None
+    user_id = result.site_info["userid"]
     if tokens.moodle_user_id is None:
         return TokenValidation(
             TokenValidationKind.INVALID,
@@ -418,11 +468,7 @@ def validate_mobile_token_payload(
             TokenValidationKind.INVALID,
             "token belongs to another Moodle account",
         )
-    return TokenValidation(
-        TokenValidationKind.VALID,
-        site_info=payload,
-        server_time=server_time,
-    )
+    return result
 
 
 def _open_moodle_autologin(

--- a/syncmymoodle/moodle_tokens.py
+++ b/syncmymoodle/moodle_tokens.py
@@ -189,6 +189,14 @@ def store_tokens_verified(
         pass
 
 
+def overwrite_tokens_verified(
+    store: MoodleTokenStore,
+    tokens: MoodleTokens,
+) -> None:
+    """Replace an unreadable record when its store is managed by syncMyMoodle."""
+    _replace_tokens_verified(store, tokens)
+
+
 class KeyringTokenStore:
     def __init__(
         self,
@@ -242,7 +250,7 @@ class EnvFileTokenStore:
 
     @property
     def description(self) -> str:
-        return f"protected environment file ({self.path})"
+        return f"environment file ({self.path})"
 
     def check_available(self) -> ProviderAvailability:
         if self.path.exists() and not harden_private_file(self.path, "Moodle token"):

--- a/tests/test_auth_flow.py
+++ b/tests/test_auth_flow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import logging
 import tomllib
 from pathlib import Path
@@ -62,6 +63,58 @@ def valid(tokens: MoodleTokens) -> cli.moodle_api.TokenValidation:
         },
         server_time=1_000,
     )
+
+
+def browser_callback(
+    launch: cli.moodle_api.MobileLaunchRequest,
+    *,
+    wstoken: str = "browser-ws-token",
+    private_token: str | None = "browser-private-token",
+) -> str:
+    parts = [
+        cli.moodle_api.mobile_site_signature(launch.passport),
+        wstoken,
+    ]
+    if private_token is not None:
+        parts.append(private_token)
+    encoded = base64.b64encode(":::".join(parts).encode()).decode()
+    return f"{launch.url_scheme}://token={encoded}"
+
+
+def stub_browser_handoff(
+    monkeypatch,
+    *,
+    wstoken: str = "browser-ws-token",
+    private_token: str | None = "browser-private-token",
+    user_id: int = 123,
+    fullname: str = "Ada Example",
+) -> cli.moodle_api.MobileLaunchRequest:
+    launch = cli.moodle_api.MobileLaunchRequest(
+        "https://moodle.example.test/mobile-launch",
+        "passport",
+        "syncmymoodle-one-use",
+    )
+    monkeypatch.setattr(cli.moodle_api, "create_browser_mobile_launch", lambda: launch)
+    monkeypatch.setattr(cli.webbrowser, "open", lambda *args, **kwargs: False)
+    monkeypatch.setattr(
+        cli.output,
+        "prompt_secret",
+        lambda label: browser_callback(
+            launch,
+            wstoken=wstoken,
+            private_token=private_token,
+        ),
+    )
+
+    def inspect(actual_wstoken, *, site):
+        assert actual_wstoken == wstoken
+        return cli.moodle_api.TokenValidation(
+            cli.moodle_api.TokenValidationKind.VALID,
+            site_info={"userid": user_id, "fullname": fullname, "siteurl": site},
+        )
+
+    monkeypatch.setattr(cli.moodle_api, "inspect_mobile_token", inspect)
+    return launch
 
 
 def write_env_token_config(tmp_path: Path) -> tuple[Path, Path, MoodleTokens]:
@@ -157,7 +210,7 @@ def test_setup_rolls_back_tokens_when_config_write_fails(tmp_path, monkeypatch):
     monkeypatch.setattr(
         cli,
         "prompt_setup_config",
-        lambda parser: (
+        lambda parser, **kwargs: (
             {
                 "auth.user": original.username,
                 "auth.login.totp_serial": "TOTP123",
@@ -165,7 +218,6 @@ def test_setup_rolls_back_tokens_when_config_write_fails(tmp_path, monkeypatch):
                 "paths.sync_directory": str(tmp_path / "sync"),
             },
             original.username,
-            "TOTP123",
         ),
     )
     monkeypatch.setattr(cli, "prompt_setup_password_manager", lambda *args: None)
@@ -197,6 +249,49 @@ def test_setup_rolls_back_tokens_when_config_write_fails(tmp_path, monkeypatch):
     assert not (tmp_path / "xdg" / "syncmymoodle" / "config.toml").exists()
 
 
+def test_browser_setup_skips_totp_and_password_manager_configuration(
+    tmp_path, monkeypatch, capsys
+):
+    config_home = tmp_path / "xdg"
+    fake_keyring = FakeKeyring()
+    stored = tokens()
+    answers = iter([stored.username, str(tmp_path / "sync"), ""])
+    browser_calls = []
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(config_home))
+    monkeypatch.setattr(cli, "load_keyring_backend", lambda: fake_keyring)
+    monkeypatch.setattr("builtins.input", lambda: next(answers))
+    monkeypatch.setattr(
+        cli,
+        "detect_password_manager_clis",
+        lambda: pytest.fail("browser setup must not configure TOTP-login secrets"),
+    )
+    monkeypatch.setattr(
+        cli.rwth,
+        "login",
+        lambda *args, **kwargs: pytest.fail("browser setup performed direct SSO"),
+    )
+
+    def acquire(ctx, parser, previous=None):
+        browser_calls.append((ctx.auth.user, previous))
+        return stored
+
+    monkeypatch.setattr(cli, "acquire_browser_moodle_tokens", acquire)
+
+    cli.main(["setup", "--browser"])
+
+    parsed = tomllib.loads(
+        (config_home / "syncmymoodle" / "config.toml").read_text(encoding="utf-8")
+    )
+    assert parsed["auth"]["user"] == stored.username
+    assert parsed["auth"]["login"]["method"] == "browser"
+    assert parsed["auth"]["login"]["provider"] == "prompt"
+    assert parsed["auth"]["login"]["totp_serial"] == ""
+    assert browser_calls == [(stored.username, None)]
+    assert MoodleTokens.from_json(next(iter(fake_keyring.values.values()))) == stored
+    assert "RWTH SSO TOTP serial" not in capsys.readouterr().out
+
+
 def test_setup_token_file_fallback_prompt_is_clear(tmp_path, monkeypatch, capsys):
     token_path = tmp_path / "tokens.env"
     config = {}
@@ -210,7 +305,7 @@ def test_setup_token_file_fallback_prompt_is_clear(tmp_path, monkeypatch, capsys
     cli.prompt_setup_token_store(config, "ab123456", None)
 
     assert (
-        "File for securely storing Moodle tokens "
+        "File for storing Moodle tokens "
         f"[{cli.pathing.user_config_dir() / 'moodle-tokens.env'}]:"
         in capsys.readouterr().out
     )
@@ -218,6 +313,203 @@ def test_setup_token_file_fallback_prompt_is_clear(tmp_path, monkeypatch, capsys
         "auth.tokens.store": "env-file",
         "auth.tokens.env_file": str(token_path),
     }
+
+
+def test_browser_login_opens_handoff_and_binds_confirmed_moodle_account(
+    monkeypatch, capsys
+):
+    launch = stub_browser_handoff(monkeypatch)
+    callback = browser_callback(launch)
+    ctx = SyncContext(Config.from_dict({"auth": {"user": "ab123456"}}))
+    opened = []
+    confirmations = []
+
+    monkeypatch.setattr(
+        cli.webbrowser,
+        "open",
+        lambda url, *, new: opened.append((url, new)) or True,
+    )
+    monkeypatch.setattr(
+        cli.output,
+        "confirm",
+        lambda label, default=False: confirmations.append((label, default)) or True,
+    )
+
+    result = cli.acquire_browser_moodle_tokens(ctx, cli.build_parser())
+
+    assert result == MoodleTokens(
+        "ab123456",
+        "browser-ws-token",
+        "browser-private-token",
+        moodle_user_id=123,
+    )
+    assert opened == [(launch.url, 2)]
+    assert confirmations == [
+        ("Store tokens for Ada Example as RWTH account ab123456", True)
+    ]
+    output = capsys.readouterr().out
+    assert launch.url in output
+    assert callback not in output
+    assert "browser-ws-token" not in output
+    assert "browser-private-token" not in output
+    assert "right-click the blue link" in output
+    assert "private browser window" not in output
+
+
+def test_browser_login_keeps_existing_private_token_when_moodle_omits_it(
+    monkeypatch,
+):
+    stored = tokens()
+    ctx = SyncContext(Config.from_dict({"auth": {"user": stored.username}}))
+    stub_browser_handoff(
+        monkeypatch,
+        wstoken=stored.wstoken,
+        private_token=None,
+    )
+    monkeypatch.setattr(
+        cli.output,
+        "confirm",
+        lambda *args, **kwargs: pytest.fail(
+            "an already-bound account must not need confirmation"
+        ),
+    )
+
+    result = cli.acquire_browser_moodle_tokens(
+        ctx,
+        cli.build_parser(),
+        stored,
+    )
+
+    assert result == stored
+
+
+def test_browser_login_retries_a_missing_private_token_in_a_private_window(
+    monkeypatch, capsys
+):
+    launches = [
+        cli.moodle_api.MobileLaunchRequest(
+            "https://moodle.example.test/first-launch",
+            "first-passport",
+            "syncmymoodle-first",
+        ),
+        cli.moodle_api.MobileLaunchRequest(
+            "https://moodle.example.test/second-launch",
+            "second-passport",
+            "syncmymoodle-second",
+        ),
+    ]
+    created = []
+    opened = []
+    confirmations = []
+
+    def create_launch():
+        launch = launches[len(created)]
+        created.append(launch)
+        return launch
+
+    def callback(label):
+        del label
+        launch = created[-1]
+        return browser_callback(
+            launch,
+            wstoken=f"browser-ws-token-{len(created)}",
+            private_token=None if len(created) == 1 else "browser-private-token",
+        )
+
+    def inspect(wstoken, *, site):
+        assert site == "https://moodle.rwth-aachen.de/"
+        assert wstoken == f"browser-ws-token-{len(created)}"
+        return cli.moodle_api.TokenValidation(
+            cli.moodle_api.TokenValidationKind.VALID,
+            site_info={"userid": 123, "fullname": "Ada Example"},
+        )
+
+    def confirm(label, default=False):
+        confirmations.append((label, default))
+        return True
+
+    monkeypatch.setattr(cli.moodle_api, "create_browser_mobile_launch", create_launch)
+    monkeypatch.setattr(cli.output, "prompt_secret", callback)
+    monkeypatch.setattr(cli.moodle_api, "inspect_mobile_token", inspect)
+    monkeypatch.setattr(
+        cli.webbrowser,
+        "open",
+        lambda url, *, new: opened.append((url, new)) or True,
+    )
+    monkeypatch.setattr(cli.output, "confirm", confirm)
+    ctx = SyncContext(Config.from_dict({"auth": {"user": "ab123456"}}))
+
+    result = cli.acquire_browser_moodle_tokens(ctx, cli.build_parser())
+
+    assert result == MoodleTokens(
+        "ab123456",
+        "browser-ws-token-2",
+        "browser-private-token",
+        moodle_user_id=123,
+    )
+    assert created == launches
+    assert opened == [(launches[0].url, 2)]
+    assert confirmations == [
+        ("Try again in a new private browser window", True),
+        ("Store tokens for Ada Example as RWTH account ab123456", True),
+    ]
+    captured = capsys.readouterr()
+    assert "fresh login in a new private/incognito browser window" in captured.err
+    assert cli.moodle_api.MOODLE_MANAGE_TOKEN_URL not in captured.err
+    assert "new private/incognito browser window" in captured.out
+    assert launches[1].url in captured.out
+
+
+def test_browser_login_explains_legacy_token_recovery_when_retry_is_declined(
+    monkeypatch, capsys
+):
+    ctx = SyncContext(Config.from_dict({"auth": {"user": "ab123456"}}))
+    stub_browser_handoff(monkeypatch, private_token=None)
+    confirmations = iter((False, True))
+    monkeypatch.setattr(
+        cli.output,
+        "confirm",
+        lambda *args, **kwargs: next(confirmations),
+    )
+
+    result = cli.acquire_browser_moodle_tokens(ctx, cli.build_parser())
+
+    assert result.private_token is None
+    error = capsys.readouterr().err
+    assert "fresh login in a new private/incognito browser window" in error
+    assert "legacy Moodle mobile-app token" in error
+    assert cli.moodle_api.MOODLE_MANAGE_TOKEN_URL in error
+
+
+def test_browser_login_rejects_incomplete_replacement_token_pair(monkeypatch, capsys):
+    stored = tokens()
+    ctx = SyncContext(Config.from_dict({"auth": {"user": stored.username}}))
+    stub_browser_handoff(
+        monkeypatch,
+        wstoken="replacement-ws-token",
+        private_token=None,
+    )
+    monkeypatch.setattr(cli.output, "confirm", lambda *args, **kwargs: False)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.acquire_browser_moodle_tokens(ctx, cli.build_parser(), stored)
+
+    assert exc_info.value.code == 2
+    error = capsys.readouterr().err
+    assert "replacement API token" in error
+    assert "existing tokens were left unchanged" in error
+
+
+def test_browser_login_rejects_a_different_moodle_account(monkeypatch, capsys):
+    stored = tokens()
+    ctx = SyncContext(Config.from_dict({"auth": {"user": stored.username}}))
+    stub_browser_handoff(monkeypatch, user_id=456, fullname="Another User")
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.acquire_browser_moodle_tokens(ctx, cli.build_parser(), stored)
+
+    assert exc_info.value.code == 2
+    assert "different Moodle account" in capsys.readouterr().err
 
 
 def test_setup_configures_detected_password_manager_and_uses_it_for_login(
@@ -539,6 +831,32 @@ def test_sign_in_method_checks_configured_otp_command(monkeypatch):
     assert available is False
 
 
+def test_sign_in_method_reports_persisted_browser_method_without_checking_provider(
+    monkeypatch,
+):
+    config = Config.from_dict(
+        {
+            "auth": {
+                "login": {
+                    "method": "browser",
+                    "provider": "command",
+                    "password_command": ["missing-password-helper"],
+                }
+            }
+        }
+    )
+    monkeypatch.setattr(
+        cli,
+        "CommandSecretProvider",
+        lambda *args: pytest.fail("browser method checked a TOTP provider"),
+    )
+
+    description, available = cli.sign_in_method_status(config, None)
+
+    assert description == "browser-assisted sign-in (interactive)"
+    assert available is True
+
+
 @pytest.mark.parametrize(
     ("command", "expected"),
     [
@@ -593,8 +911,8 @@ def test_auth_login_replaces_local_pair_without_resetting_shared_token(
     monkeypatch.setattr(
         cli.rwth,
         "login",
-        lambda ctx, log, *, reuse_cached_session: login_calls.append(
-            reuse_cached_session
+        lambda ctx, log, *, reuse_cached_session, persist_session: login_calls.append(
+            (reuse_cached_session, persist_session)
         ),
     )
     monkeypatch.setattr(
@@ -608,8 +926,120 @@ def test_auth_login_replaces_local_pair_without_resetting_shared_token(
 
     cli.main(["--config", str(config_path), "auth", "login"])
 
-    assert login_calls == [False]
+    assert login_calls == [(False, True)]
     assert EnvFileTokenStore(token_path, replacement.username).load() == (replacement)
+
+
+def test_auth_login_uses_persisted_browser_method_without_totp_sso(
+    tmp_path, monkeypatch, capsys
+):
+    config_path, token_path, stored = write_env_token_config(tmp_path)
+    config_path.write_text(
+        config_path.read_text(encoding="utf-8").replace(
+            '[auth.login]\nprovider = "prompt"',
+            '[auth.login]\nmethod = "browser"\nprovider = "command"\n'
+            'password_command = ["missing-password-helper"]',
+        ),
+        encoding="utf-8",
+    )
+    replacement = MoodleTokens(
+        stored.username,
+        "browser-ws-token",
+        "browser-private-token",
+        moodle_user_id=stored.moodle_user_id,
+    )
+    browser_calls = []
+    monkeypatch.setattr(
+        cli.rwth,
+        "login",
+        lambda *args, **kwargs: pytest.fail("browser login performed direct SSO"),
+    )
+    monkeypatch.setattr(
+        cli,
+        "configure_command_secret_provider_resolvers",
+        lambda *args, **kwargs: pytest.fail(
+            "browser login configured TOTP-login secrets"
+        ),
+    )
+
+    def acquire(ctx, parser, previous=None):
+        browser_calls.append((ctx.auth.user, previous))
+        return replacement
+
+    monkeypatch.setattr(cli, "acquire_browser_moodle_tokens", acquire)
+
+    cli.main(["--config", str(config_path), "auth", "login"])
+
+    assert browser_calls == [(stored.username, stored)]
+    assert EnvFileTokenStore(token_path, replacement.username).load() == replacement
+    assert "A Moodle browser session will be created" not in capsys.readouterr().out
+
+
+def test_browser_login_rewrites_a_managed_token_file_after_account_change(
+    tmp_path, monkeypatch, capsys
+):
+    config_path, token_path, stored = write_env_token_config(tmp_path)
+    replacement = MoodleTokens(
+        "xy123456",
+        "replacement-ws-token",
+        "replacement-private-token",
+        moodle_user_id=456,
+    )
+    config_path.write_text(
+        config_path.read_text(encoding="utf-8")
+        .replace(stored.username, replacement.username)
+        .replace(
+            '[auth.login]\nprovider = "prompt"',
+            '[auth.login]\nmethod = "browser"\nprovider = "prompt"',
+        ),
+        encoding="utf-8",
+    )
+    browser_calls = []
+
+    def acquire(ctx, parser, previous=None):
+        browser_calls.append((ctx.auth.user, previous))
+        return replacement
+
+    monkeypatch.setattr(cli, "acquire_browser_moodle_tokens", acquire)
+
+    cli.main(["--config", str(config_path), "auth", "login"])
+
+    assert browser_calls == [(replacement.username, None)]
+    assert EnvFileTokenStore(token_path, replacement.username).load() == replacement
+    error = capsys.readouterr().err
+    assert "could not be read" in error
+    assert "will be replaced only after you confirm the browser account" in error
+
+
+def test_browser_login_does_not_claim_session_support_without_private_token(
+    tmp_path, monkeypatch, capsys
+):
+    config_path, token_path, stored = write_env_token_config(tmp_path)
+    limited = MoodleTokens(
+        stored.username,
+        stored.wstoken,
+        None,
+        moodle_user_id=stored.moodle_user_id,
+    )
+    EnvFileTokenStore(token_path, stored.username).store(limited)
+    config_path.write_text(
+        config_path.read_text(encoding="utf-8").replace(
+            '[auth.login]\nprovider = "prompt"',
+            '[auth.login]\nmethod = "browser"\nprovider = "prompt"',
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        cli, "acquire_browser_moodle_tokens", lambda *args, **kwargs: limited
+    )
+    monkeypatch.setattr(cli.output, "confirm", lambda *args, **kwargs: True)
+
+    cli.main(["--config", str(config_path), "auth", "login"])
+
+    captured = capsys.readouterr()
+    assert EnvFileTokenStore(token_path, stored.username).load() == limited
+    assert "A Moodle browser session will be created" not in captured.out
+    assert "downloads that need a browser session may not" in captured.err
 
 
 def test_auth_migrate_to_keyring_validates_destination_and_leaves_source(
@@ -1000,6 +1430,40 @@ def test_prompt_provider_requires_explicit_auth_login_for_invalid_tokens(
 
     assert exc_info.value.code == 1
     assert "requires interaction" in caplog.text
+    assert "syncmymoodle auth login" in caplog.text
+    assert store.writes == []
+
+
+def test_browser_method_requires_interactive_login_for_invalid_tokens(
+    monkeypatch, caplog
+):
+    stored = tokens()
+    store = MemoryStore(stored)
+    ctx = SyncContext(
+        Config.from_dict(
+            {
+                "auth": {
+                    "user": stored.username,
+                    "login": {"method": "browser"},
+                }
+            }
+        )
+    )
+    invalid = cli.moodle_api.TokenValidation(cli.moodle_api.TokenValidationKind.INVALID)
+    monkeypatch.setattr(cli, "token_store_from_config", lambda config, keyring: store)
+    monkeypatch.setattr(
+        cli.moodle_api, "validate_mobile_tokens", lambda *args, **kwargs: invalid
+    )
+    monkeypatch.setattr(
+        cli.rwth, "login", lambda *args: pytest.fail("browser method performed SSO")
+    )
+    caplog.set_level(logging.CRITICAL, logger="syncmymoodle.cli")
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.run(ctx)
+
+    assert exc_info.value.code == 1
+    assert "browser-assisted sign-in requires interaction" in caplog.text
     assert "syncmymoodle auth login" in caplog.text
     assert store.writes == []
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,9 +13,11 @@ import syncmymoodle.cli as cli
 import syncmymoodle.secret_providers as secret_providers
 from syncmymoodle.config import (
     CONFIG_OPTIONS,
+    DEFAULT_LOGIN_METHOD,
     DEFAULT_LOGIN_PROVIDER,
     DEFAULT_TOKEN_STORE,
     LEGACY_KEY_MAP,
+    LOGIN_METHOD_OPTIONS,
     LOGIN_PROVIDER_OPTIONS,
     TOKEN_STORE_OPTIONS,
     Config,
@@ -251,7 +253,7 @@ def test_setup_help_explains_what_will_be_configured(capsys):
     assert exc_info.value.code == 0
     output = capsys.readouterr().out
     assert "usage: syncmymoodle setup" in output
-    assert "configure RWTH sign-in, secure Moodle token storage" in output
+    assert "configure RWTH sign-in, Moodle token storage" in output
     assert "verify the RWTH sign-in with one login" in output
 
 
@@ -274,17 +276,30 @@ def test_management_commands_reject_sync_options(argv, option, capsys):
     assert option in error
 
 
-def test_totp_manual_is_scoped_to_auth_login(capsys):
+def test_browser_login_and_totp_manual_are_scoped_auth_modes(capsys):
     parser = cli.build_parser()
 
     args = parser.parse_args(["auth", "login", "--totp-manual"])
 
     assert args.totp_manual is True
+    assert args.browser_login is False
     assert "--totp-manual" not in parser.format_help()
     with pytest.raises(SystemExit) as exc_info:
         parser.parse_args(["auth", "status", "--totp-manual"])
     assert exc_info.value.code == 2
     assert "unrecognized arguments: --totp-manual" in capsys.readouterr().err
+
+    browser_args = parser.parse_args(["auth", "login", "--browser"])
+    assert browser_args.browser_login is True
+    assert browser_args.browser is None
+    setup_args = parser.parse_args(["setup", "--browser"])
+    assert setup_args.browser_login is True
+    assert setup_args.browser is None
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["auth", "login", "--browser", "--totp-manual"])
+    assert exc_info.value.code == 2
+    assert "not allowed with argument --browser" in capsys.readouterr().err
 
 
 def test_config_selection_is_rejected_when_command_does_not_read_it(capsys):
@@ -525,6 +540,7 @@ def test_config_validation_rejects_invalid_choices():
     with pytest.raises(ConfigValidationError) as exc_info:
         validate_config(
             {
+                "auth": {"login": {"method": "direct"}},
                 "courses": {"prefix_handling": "later"},
                 "downloads": {"conflict_handling": "delete"},
                 "modules": {"quiz": "screenshots"},
@@ -532,6 +548,7 @@ def test_config_validation_rejects_invalid_choices():
         )
 
     message = str(exc_info.value)
+    assert "auth.login.method must be one of" in message
     assert "courses.prefix_handling must be one of" in message
     assert "downloads.conflict_handling must be one of" in message
     assert "modules.quiz must be one of" in message
@@ -552,9 +569,12 @@ def test_config_validation_rejects_non_boolean_toggles():
     assert "links.youtube must be true or false" in message
 
 
-@pytest.mark.parametrize("key", ["auto_reauthenticate", "totp_manual"])
-def test_removed_login_policy_settings_are_rejected(key):
-    with pytest.raises(ConfigValidationError, match=f"auth.login.{key}"):
+@pytest.mark.parametrize("key", ["auto_reauthenticate", "totp_manual", "mode"])
+def test_removed_login_settings_are_rejected(key):
+    with pytest.raises(
+        ConfigValidationError,
+        match=f"unknown config key 'auth.login.{key}'",
+    ):
         validate_config({"auth": {"login": {key: True}}})
 
 
@@ -618,6 +638,7 @@ def test_defaults_applied_for_empty_config(tmp_path, monkeypatch):
     assert cfg.course_prefix_handling == "keep"
     assert cfg.conflict_handling == "rename"
     assert cfg.token_store == DEFAULT_TOKEN_STORE
+    assert cfg.login_method == DEFAULT_LOGIN_METHOD
     assert cfg.login_provider == DEFAULT_LOGIN_PROVIDER
     assert cfg.follow_links is True
     assert cfg.update_files is False
@@ -640,6 +661,7 @@ def test_auth_defaults_and_choices_have_one_source_of_truth():
     options = {option.canonical_key: option for option in CONFIG_OPTIONS}
 
     assert options["auth.tokens.store"].choices == TOKEN_STORE_OPTIONS
+    assert options["auth.login.method"].choices == LOGIN_METHOD_OPTIONS
     assert options["auth.login.provider"].choices == LOGIN_PROVIDER_OPTIONS
     args = cli.build_parser().parse_args(["config", "migrate"])
     assert args.token_store == DEFAULT_TOKEN_STORE

--- a/tests/test_moodle_auth.py
+++ b/tests/test_moodle_auth.py
@@ -1,5 +1,6 @@
 import base64
 import hashlib
+import urllib.parse
 from datetime import UTC, datetime
 
 import pytest
@@ -13,7 +14,12 @@ from syncmymoodle.moodle_tokens import MoodleTokens
 from .helpers import FakeResponse, FakeSession
 
 
-def launch_location(passport, wstoken="ws-token", private_token="private-token"):
+def launch_location(
+    passport,
+    wstoken="ws-token",
+    private_token="private-token",
+    url_scheme="syncmymoodle",
+):
     server_site = MOODLE_URL.rstrip("/")
     signature = hashlib.md5(
         f"{server_site}{passport}".encode(), usedforsecurity=False
@@ -22,7 +28,28 @@ def launch_location(passport, wstoken="ws-token", private_token="private-token")
     if private_token is not None:
         parts.append(private_token)
     encoded = base64.b64encode(":::".join(parts).encode()).decode()
-    return f"syncmymoodle://token={encoded}"
+    return f"{url_scheme}://token={encoded}"
+
+
+def test_browser_mobile_launch_uses_a_correlated_one_use_scheme(monkeypatch):
+    values = iter(["passport", "nonce"])
+    monkeypatch.setattr(moodle.secrets, "token_hex", lambda size: next(values))
+
+    launch = moodle.create_browser_mobile_launch()
+
+    parsed = urllib.parse.urlsplit(launch.url)
+    query = urllib.parse.parse_qs(parsed.query)
+    assert urllib.parse.urlunsplit((*parsed[:3], "", "")) == (
+        moodle.MOODLE_MOBILE_LAUNCH_URL
+    )
+    assert query == {
+        "service": [moodle.MOBILE_SERVICE],
+        "passport": ["passport"],
+        "urlscheme": ["syncmymoodle-nonce"],
+        "confirmed": ["1"],
+    }
+    assert launch.passport == "passport"
+    assert launch.url_scheme == "syncmymoodle-nonce"
 
 
 def test_mobile_launch_parser_returns_paired_tokens():
@@ -47,6 +74,29 @@ def test_mobile_launch_parser_accepts_legacy_missing_private_token():
     )
 
     assert tokens.private_token is None
+
+
+def test_mobile_launch_parser_accepts_only_the_requested_url_scheme():
+    location = launch_location(
+        "passport",
+        url_scheme="syncmymoodle-one-use-scheme",
+    )
+
+    tokens = moodle.parse_mobile_launch_location(
+        location,
+        "passport",
+        "ab123456",
+        url_scheme="syncmymoodle-one-use-scheme",
+    )
+
+    assert tokens.wstoken == "ws-token"
+    with pytest.raises(moodle.MobileLaunchError, match="unexpected"):
+        moodle.parse_mobile_launch_location(
+            location,
+            "passport",
+            "ab123456",
+            url_scheme="syncmymoodle-another-scheme",
+        )
 
 
 def test_mobile_launch_parser_rejects_response_for_another_passport():
@@ -127,6 +177,22 @@ def test_token_validation_returns_site_info_for_matching_account():
 
     result = moodle.validate_mobile_tokens(
         bound_tokens(),
+        session=validation_session(payload),
+    )
+
+    assert result.kind is moodle.TokenValidationKind.VALID
+    assert result.site_info == payload
+
+
+def test_token_inspection_returns_identity_before_account_binding():
+    payload = {
+        "userid": 123,
+        "username": "https://sso.example.test/idp!opaque-persistent-id",
+        "siteurl": MOODLE_URL.rstrip("/"),
+    }
+
+    result = moodle.inspect_mobile_token(
+        "ws-token",
         session=validation_session(payload),
     )
 

--- a/tests/test_moodle_tokens.py
+++ b/tests/test_moodle_tokens.py
@@ -13,6 +13,7 @@ from syncmymoodle.moodle_tokens import (
     EnvFileTokenStore,
     KeyringTokenStore,
     MoodleTokens,
+    overwrite_tokens_verified,
     store_tokens_verified,
 )
 from syncmymoodle.secret_providers import (
@@ -185,6 +186,25 @@ def test_env_file_token_store_rejects_record_for_another_sso_account(tmp_path):
 
     with pytest.raises(ProviderSecretError, match="different Moodle account"):
         EnvFileTokenStore(path, "xy123456").load()
+
+
+def test_unreadable_managed_token_file_can_be_replaced_and_verified(tmp_path):
+    path = tmp_path / "mobile-token.env"
+    EnvFileTokenStore(path, "ab123456").store(tokens())
+    replacement = MoodleTokens(
+        "xy123456",
+        "replacement-webservice-token",
+        "replacement-private-token",
+        moodle_user_id=456,
+    )
+    store = EnvFileTokenStore(path, replacement.username)
+
+    with pytest.raises(ProviderSecretError, match="different Moodle account"):
+        store.load()
+
+    overwrite_tokens_verified(store, replacement)
+
+    assert store.load() == replacement
 
 
 def test_env_file_token_store_fails_closed_when_permissions_cannot_be_hardened(


### PR DESCRIPTION
Adds browser-assisted setup and login for accounts using security keys, passkeys, or other MFA methods that the existing TOTP flow cannot handle. The chosen login method is saved so future authentication uses the same flow.

Closes #122 